### PR TITLE
fix(search): disable dead filters and trim noisy matches

### DIFF
--- a/src/core/search/catalog.ts
+++ b/src/core/search/catalog.ts
@@ -1,0 +1,33 @@
+export type SearchSourceDescriptor = {
+  id: string
+  label: string
+  available: boolean
+  reason?: string
+}
+
+type SearchSourceCatalogOptions = {
+  hasSpotifyOAuth: boolean
+  hasTidalSearch: boolean
+}
+
+export function buildSearchSourceCatalog(
+  options: SearchSourceCatalogOptions,
+): SearchSourceDescriptor[] {
+  return [
+    {
+      id: 'spotify',
+      label: 'Spotify',
+      available: options.hasSpotifyOAuth,
+      reason: options.hasSpotifyOAuth ? undefined : 'Connect Spotify in Settings to enable search.',
+    },
+    { id: 'deezer', label: 'Deezer', available: true },
+    { id: 'musicbrainz', label: 'MusicBrainz', available: true },
+    {
+      id: 'tidal',
+      label: 'TIDAL',
+      available: options.hasTidalSearch,
+      reason: options.hasTidalSearch ? undefined : 'TIDAL search is not configured yet.',
+    },
+    { id: 'bandcamp', label: 'Bandcamp', available: true },
+  ]
+}

--- a/src/core/search/relevance.ts
+++ b/src/core/search/relevance.ts
@@ -1,0 +1,105 @@
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function toCompact(value: string): string {
+  return value.replace(/\s+/g, '')
+}
+
+function tokenize(value: string): string[] {
+  return value.split(/\s+/).filter(Boolean)
+}
+
+export function computeNameRelevance(query: string, candidate: string): number {
+  const normalizedQuery = normalizeSearchText(query)
+  const normalizedCandidate = normalizeSearchText(candidate)
+  if (!normalizedQuery || !normalizedCandidate) return 0
+
+  const compactQuery = toCompact(normalizedQuery)
+  const compactCandidate = toCompact(normalizedCandidate)
+  const queryTokens = tokenize(normalizedQuery)
+  const candidateTokens = tokenize(normalizedCandidate)
+
+  if (normalizedCandidate === normalizedQuery || compactCandidate === compactQuery) {
+    return 1
+  }
+
+  let score = 0
+
+  if (normalizedCandidate.startsWith(normalizedQuery)) {
+    score = Math.max(score, 0.92)
+  }
+
+  if (normalizedCandidate.includes(` ${normalizedQuery}`)) {
+    score = Math.max(score, 0.82)
+  }
+
+  if (compactCandidate.includes(compactQuery)) {
+    score = Math.max(score, 0.76)
+  }
+
+  let exactTokenMatches = 0
+  let prefixTokenMatches = 0
+
+  for (const token of queryTokens) {
+    if (candidateTokens.includes(token)) {
+      exactTokenMatches += 1
+      continue
+    }
+    if (candidateTokens.some((candidateToken) => candidateToken.startsWith(token))) {
+      prefixTokenMatches += 1
+    }
+  }
+
+  const tokenCoverage =
+    (exactTokenMatches + prefixTokenMatches * 0.6) / Math.max(queryTokens.length, 1)
+  score = Math.max(score, tokenCoverage * 0.78)
+
+  const extraTokenPenalty = Math.max(candidateTokens.length - queryTokens.length, 0) * 0.035
+
+  return Math.max(0, Math.min(1, score - Math.min(extraTokenPenalty, 0.18)))
+}
+
+type RankOptions<T> = {
+  limit: number
+  maxResults?: number
+  minScore?: number
+  fallbackResults?: number
+  getName: (item: T) => string
+  getTieBreaker?: (item: T) => number
+  getBaseScore?: (item: T) => number
+  baseScoreWeight?: number
+}
+
+export function rankSearchMatches<T>(items: T[], query: string, options: RankOptions<T>): T[] {
+  const weightedBase = options.baseScoreWeight ?? 0
+  const scored = items
+    .map((item) => {
+      const relevance = computeNameRelevance(query, options.getName(item))
+      const baseScore = options.getBaseScore ? options.getBaseScore(item) : 0
+      return {
+        item,
+        score: relevance * (1 - weightedBase) + baseScore * weightedBase,
+        relevance,
+      }
+    })
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score
+      const tieA = options.getTieBreaker ? options.getTieBreaker(a.item) : 0
+      const tieB = options.getTieBreaker ? options.getTieBreaker(b.item) : 0
+      return tieB - tieA
+    })
+
+  const threshold = options.minScore ?? 0
+  const filtered = scored.filter((entry) => entry.relevance >= threshold)
+  const effective = filtered.length > 0 ? filtered : scored.slice(0, options.fallbackResults ?? 3)
+  const cap = Math.min(options.maxResults ?? options.limit, options.limit)
+
+  return effective.slice(0, cap).map((entry) => entry.item)
+}

--- a/src/core/search/sources/deezer.ts
+++ b/src/core/search/sources/deezer.ts
@@ -1,5 +1,6 @@
 import type { createDeezerClient } from '@/core/clients/deezer'
 import type { SearchResult, SearchSource } from '@/core/search/multi-source'
+import { rankSearchMatches } from '@/core/search/relevance'
 
 export function createDeezerSearchSource(
   client: ReturnType<typeof createDeezerClient>,
@@ -10,8 +11,16 @@ export function createDeezerSearchSource(
     available: true,
 
     async search(query: string, limit: number): Promise<SearchResult[]> {
-      const results = await client.searchArtists(query, limit)
-      return results.map((item) => ({
+      const results = await client.searchArtists(query, Math.min(limit, 25))
+      const ranked = rankSearchMatches(results, query, {
+        limit,
+        maxResults: Math.min(limit, 8),
+        minScore: query.trim().length >= 4 ? 0.58 : 0.46,
+        fallbackResults: 4,
+        getName: (item) => item.name,
+        getTieBreaker: (item) => item.fans,
+      })
+      return ranked.map((item) => ({
         name: item.name,
         images: item.imageUrl ? [{ url: item.imageUrl, source: 'deezer' }] : [],
         genres: [],

--- a/src/core/search/sources/musicbrainz.ts
+++ b/src/core/search/sources/musicbrainz.ts
@@ -1,4 +1,5 @@
 import type { SearchResult, SearchSource } from '@/core/search/multi-source'
+import { rankSearchMatches } from '@/core/search/relevance'
 
 type MBSearchResult = {
   artists: Array<{
@@ -21,8 +22,17 @@ export function createMusicBrainzSearchSource(mbClient: {
     async search(query: string, limit: number): Promise<SearchResult[]> {
       const raw = await mbClient.searchArtist(query)
       const data = raw as MBSearchResult
-      const artists = data.artists ?? []
-      return artists.slice(0, limit).map((artist) => ({
+      const artists = rankSearchMatches(data.artists ?? [], query, {
+        limit,
+        maxResults: Math.min(limit, 8),
+        minScore: query.trim().length >= 4 ? 0.55 : 0.42,
+        fallbackResults: 4,
+        getName: (artist) => artist.name,
+        getTieBreaker: (artist) => artist.score,
+        getBaseScore: (artist) => artist.score / 100,
+        baseScoreWeight: 0.2,
+      })
+      return artists.map((artist) => ({
         name: artist.name,
         mbid: artist.id,
         images: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { createLastFmSource } from './core/plugins/lastfm'
 import { createListenBrainzSource } from './core/plugins/listenbrainz'
 import { SourceRegistry } from './core/plugins/registry'
 import { createDefaultRegistry } from './core/providers/registry'
+import { buildSearchSourceCatalog } from './core/search/catalog'
 import type { SearchSource } from './core/search/multi-source'
 import { multiSourceSearch } from './core/search/multi-source'
 import { createBandcampSearchSource } from './core/search/sources/bandcamp'
@@ -658,6 +659,13 @@ const app = createApp({
     },
   },
   search: {
+    listSources: async (userId) => {
+      const spotifyOAuth = userId ? await getOAuthToken(db, userId, 'spotify') : null
+      return buildSearchSourceCatalog({
+        hasSpotifyOAuth: Boolean(spotifyOAuth),
+        hasTidalSearch: false,
+      })
+    },
     search: async (query, opts) => {
       const sources: SearchSource[] = [...staticSearchSources]
 

--- a/src/server/routes/search.ts
+++ b/src/server/routes/search.ts
@@ -1,8 +1,10 @@
 import { Hono } from 'hono'
+import type { SearchSourceDescriptor } from '@/core/search/catalog'
 import type { MergedSearchResult } from '@/core/search/multi-source'
 import type { HonoEnv } from '@/server/types'
 
 export type SearchDeps = {
+  listSources: (userId?: number) => Promise<SearchSourceDescriptor[]>
   search: (
     query: string,
     opts?: { limit?: number; sources?: string[]; userId?: number },
@@ -11,6 +13,12 @@ export type SearchDeps = {
 
 export function searchRoutes(deps: SearchDeps) {
   const router = new Hono<HonoEnv>()
+
+  router.get('/api/search/sources', async (c) => {
+    const userId = c.get('userId')
+    const sources = await deps.listSources(userId)
+    return c.json({ sources })
+  })
 
   router.get('/api/search', async (c) => {
     const query = c.req.query('q')

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -433,6 +433,15 @@ export type SearchResult = {
   inRecommendations: boolean
 }
 
+export type SearchSourceOption = {
+  id: string
+  label: string
+  available: boolean
+  reason?: string
+}
+
+export const getSearchSources = () => fetchApi<{ sources: SearchSourceOption[] }>('/search/sources')
+
 export async function searchArtists(
   query: string,
   sources?: string[],

--- a/src/web/pages/search.tsx
+++ b/src/web/pages/search.tsx
@@ -2,28 +2,43 @@ import { useQuery } from '@tanstack/react-query'
 import { SearchIcon } from 'lucide-react'
 import { useDeferredValue, useState } from 'react'
 import { SearchResultCard } from '../components/search-result-card'
-import { searchArtists } from '../lib/api'
+import { getSearchSources, searchArtists } from '../lib/api'
 import { cn } from '../lib/utils'
 
 // ---------------------------------------------------------------------------
 // Source filter config
 // ---------------------------------------------------------------------------
 
-const SOURCES = [
-  { id: 'spotify', label: 'Spotify', active: 'bg-green-500/20 text-green-400 border-green-500/40' },
-  { id: 'deezer', label: 'Deezer', active: 'bg-pink-500/20 text-pink-400 border-pink-500/40' },
-  {
-    id: 'musicbrainz',
+const SOURCE_ORDER = ['spotify', 'deezer', 'musicbrainz', 'tidal', 'bandcamp'] as const
+type SourceId = (typeof SOURCE_ORDER)[number]
+
+const SOURCE_STYLES = {
+  spotify: {
+    label: 'Spotify',
+    active: 'bg-green-500/20 text-green-400 border-green-500/40',
+    defaultAvailable: false,
+  },
+  deezer: {
+    label: 'Deezer',
+    active: 'bg-pink-500/20 text-pink-400 border-pink-500/40',
+    defaultAvailable: true,
+  },
+  musicbrainz: {
     label: 'MusicBrainz',
     active: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/40',
+    defaultAvailable: true,
   },
-  { id: 'tidal', label: 'TIDAL', active: 'bg-blue-500/20 text-blue-400 border-blue-500/40' },
-  {
-    id: 'bandcamp',
+  tidal: {
+    label: 'TIDAL',
+    active: 'bg-blue-500/20 text-blue-400 border-blue-500/40',
+    defaultAvailable: false,
+  },
+  bandcamp: {
     label: 'Bandcamp',
     active: 'bg-teal-500/20 text-teal-400 border-teal-500/40',
+    defaultAvailable: true,
   },
-]
+} as const
 
 // ---------------------------------------------------------------------------
 // SearchPage
@@ -32,15 +47,44 @@ const SOURCES = [
 export function SearchPage() {
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
-  const [activeSources, setActiveSources] = useState<string[]>([])
+  const [activeSources, setActiveSources] = useState<SourceId[]>([])
+  const { data: sourceData } = useQuery({
+    queryKey: ['search-sources'],
+    queryFn: getSearchSources,
+    staleTime: 300_000,
+  })
 
-  function toggleSource(id: string) {
+  const sourceState = new Map(sourceData?.sources.map((source) => [source.id, source]))
+  const renderedSources = SOURCE_ORDER.map((id) => {
+    const known = sourceState.get(id)
+    const style = SOURCE_STYLES[id]
+    return {
+      id,
+      label: known?.label ?? style.label,
+      active: style.active,
+      available: known?.available ?? style.defaultAvailable,
+      reason: known?.reason,
+    }
+  })
+  const availableSourceIds = renderedSources
+    .filter((source) => source.available)
+    .map((source) => source.id)
+  const availableSourceSet = new Set(availableSourceIds)
+  const disabledSources = renderedSources.filter((source) => !source.available && source.reason)
+  const effectiveActiveSources = activeSources.filter((id) => availableSourceSet.has(id))
+
+  function toggleSource(id: SourceId) {
+    if (!availableSourceSet.has(id)) return
     setActiveSources((prev) => (prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]))
   }
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['search', deferredQuery, activeSources],
-    queryFn: () => searchArtists(deferredQuery, activeSources.length ? activeSources : undefined),
+    queryKey: ['search', deferredQuery, effectiveActiveSources],
+    queryFn: () =>
+      searchArtists(
+        deferredQuery,
+        effectiveActiveSources.length ? effectiveActiveSources : undefined,
+      ),
     enabled: deferredQuery.length >= 2,
     staleTime: 30_000,
   })
@@ -68,24 +112,27 @@ export function SearchPage() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           className="w-full pl-9 pr-4 py-2.5 bg-surface border border-border rounded-lg text-text placeholder:text-muted text-sm focus:outline-none focus:border-accent transition-colors"
-          autoFocus
         />
       </div>
 
       {/* Source filter toggles */}
       <div className="flex flex-wrap gap-2">
-        {SOURCES.map((s) => {
-          const isActive = activeSources.includes(s.id)
+        {renderedSources.map((s) => {
+          const isActive = effectiveActiveSources.includes(s.id)
           return (
             <button
               key={s.id}
               type="button"
+              disabled={!s.available}
               onClick={() => toggleSource(s.id)}
+              title={!s.available ? s.reason : undefined}
               className={cn(
                 'text-xs px-2.5 py-1 rounded-full border font-medium transition-colors',
                 isActive
                   ? s.active
-                  : 'bg-surface border-border text-muted hover:text-text hover:border-accent/40',
+                  : s.available
+                    ? 'bg-surface border-border text-muted hover:text-text hover:border-accent/40'
+                    : 'bg-surface border-border text-muted/60 opacity-50 cursor-not-allowed',
               )}
             >
               {s.label}
@@ -103,6 +150,12 @@ export function SearchPage() {
         )}
       </div>
 
+      {disabledSources.length > 0 && (
+        <p className="text-xs text-muted">
+          {disabledSources.map((source) => `${source.label}: ${source.reason}`).join(' ')}
+        </p>
+      )}
+
       {/* Results area */}
       {!showResults && (
         <p className="text-sm text-muted text-center pt-8">Type at least 2 characters to search</p>
@@ -110,10 +163,9 @@ export function SearchPage() {
 
       {showResults && isPending && (
         <div className="grid gap-2">
-          {Array.from({ length: 3 }).map((_, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+          {['search-skeleton-1', 'search-skeleton-2', 'search-skeleton-3'].map((key) => (
             <div
-              key={i}
+              key={key}
               className="bg-surface border border-border rounded-lg p-3 h-20 animate-pulse"
             />
           ))}

--- a/tests/core/search.test.ts
+++ b/tests/core/search.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { buildSearchSourceCatalog } from '@/core/search/catalog'
+import { createDeezerSearchSource } from '@/core/search/sources/deezer'
+import { createMusicBrainzSearchSource } from '@/core/search/sources/musicbrainz'
+
+describe('search source catalog', () => {
+  it('marks Spotify and TIDAL unavailable when not configured', () => {
+    const sources = buildSearchSourceCatalog({
+      hasSpotifyOAuth: false,
+      hasTidalSearch: false,
+    })
+
+    expect(sources).toEqual([
+      {
+        id: 'spotify',
+        label: 'Spotify',
+        available: false,
+        reason: 'Connect Spotify in Settings to enable search.',
+      },
+      { id: 'deezer', label: 'Deezer', available: true },
+      { id: 'musicbrainz', label: 'MusicBrainz', available: true },
+      {
+        id: 'tidal',
+        label: 'TIDAL',
+        available: false,
+        reason: 'TIDAL search is not configured yet.',
+      },
+      { id: 'bandcamp', label: 'Bandcamp', available: true },
+    ])
+  })
+})
+
+describe('Deezer search source', () => {
+  it('prioritizes close name matches and trims noisy results', async () => {
+    const source = createDeezerSearchSource({
+      searchArtists: async () => [
+        { id: 1, name: 'Head Radio', fans: 999_999, url: 'https://deezer.example/head-radio' },
+        { id: 2, name: 'Radiohead', fans: 500_000, url: 'https://deezer.example/radiohead' },
+        {
+          id: 3,
+          name: 'Radiohead Tribute Orchestra',
+          fans: 800_000,
+          url: 'https://deezer.example/tribute',
+        },
+        { id: 4, name: 'Radioheater', fans: 750_000, url: 'https://deezer.example/radioheater' },
+      ],
+      testConnection: async () => ({ success: true, message: 'ok' }),
+    })
+
+    const results = await source.search('radiohead', 20)
+
+    expect(results.map((result) => result.name)).toEqual([
+      'Radiohead',
+      'Radiohead Tribute Orchestra',
+    ])
+  })
+})
+
+describe('MusicBrainz search source', () => {
+  it('keeps the exact artist first and drops low-relevance matches', async () => {
+    const source = createMusicBrainzSearchSource({
+      searchArtist: async () => ({
+        artists: [
+          { id: '1', name: 'Head Radio', score: 100 },
+          { id: '2', name: 'Radiohead', score: 95, tags: [{ name: 'alternative', count: 9 }] },
+          { id: '3', name: 'The Radiohead Project', score: 88 },
+          { id: '4', name: 'Radioheater', score: 94 },
+        ],
+      }),
+    })
+
+    const results = await source.search('radiohead', 20)
+
+    expect(results.map((result) => result.name)).toEqual(['Radiohead', 'The Radiohead Project'])
+    expect(results[0]?.genres).toEqual(['alternative'])
+  })
+
+  it('caps broad MusicBrainz result sets to eight items', async () => {
+    const source = createMusicBrainzSearchSource({
+      searchArtist: async () => ({
+        artists: Array.from({ length: 12 }, (_, index) => ({
+          id: String(index + 1),
+          name: `Muse Tribute ${index + 1}`,
+          score: 95 - index,
+        })).concat([{ id: 'exact', name: 'Muse', score: 100 }]),
+      }),
+    })
+
+    const results = await source.search('muse', 20)
+
+    expect(results).toHaveLength(8)
+    expect(results[0]?.name).toBe('Muse')
+  })
+})

--- a/tests/server/routes/search.test.ts
+++ b/tests/server/routes/search.test.ts
@@ -2,6 +2,7 @@
 
 import { Hono } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
+import type { SearchSourceDescriptor } from '@/core/search/catalog'
 import type { MergedSearchResult } from '@/core/search/multi-source'
 import { type SearchDeps, searchRoutes } from '@/server/routes/search'
 
@@ -18,10 +19,33 @@ function makeResult(name: string): MergedSearchResult {
 
 function makeDeps(overrides: Partial<SearchDeps> = {}): SearchDeps {
   return {
+    listSources: vi.fn().mockResolvedValue([] satisfies SearchSourceDescriptor[]),
     search: vi.fn().mockResolvedValue([makeResult('Portishead'), makeResult('Massive Attack')]),
     ...overrides,
   }
 }
+
+describe('GET /api/search/sources', () => {
+  it('returns source metadata from the deps', async () => {
+    const listSources = vi.fn().mockResolvedValue([
+      { id: 'deezer', label: 'Deezer', available: true },
+      {
+        id: 'spotify',
+        label: 'Spotify',
+        available: false,
+        reason: 'Connect Spotify in Settings to enable search.',
+      },
+    ] satisfies SearchSourceDescriptor[])
+    const app = new Hono()
+    app.route('/', searchRoutes(makeDeps({ listSources })))
+
+    const res = await app.request('/api/search/sources')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { sources: SearchSourceDescriptor[] }
+    expect(body.sources).toHaveLength(2)
+    expect(listSources).toHaveBeenCalled()
+  })
+})
 
 describe('GET /api/search', () => {
   it('returns 400 when q is missing', async () => {


### PR DESCRIPTION
## Summary
- disable search filters that are not actually available for the current user
- add source metadata endpoint so the search UI can explain unavailable providers
- rank and trim Deezer and MusicBrainz matches to reduce noisy popular-band results

## Testing
- bun run test tests/core/search.test.ts tests/server/routes/search.test.ts
- bun run typecheck
- bunx biome check src/core/search/catalog.ts src/core/search/relevance.ts src/core/search/sources/deezer.ts src/core/search/sources/musicbrainz.ts src/server/routes/search.ts src/index.ts src/web/lib/api.ts src/web/pages/search.tsx tests/core/search.test.ts tests/server/routes/search.test.ts