### PR TITLE
fix(subscriptions): restore similar results

### DIFF
--- a/src/core/subscriptions/adapters/similar.ts
+++ b/src/core/subscriptions/adapters/similar.ts
@@ -7,6 +7,11 @@ import type {
 } from '@/core/subscriptions/types'
 
 type SeedArtist = { name: string; mbid?: string }
+type SimilarAdapterDeps = {
+  searchArtist?: (
+    query: string,
+  ) => Promise<{ artists: Array<{ id: string; name: string; score: number }> }>
+}
 
 const CONFIG_FIELDS: AdapterConfigField[] = [
   {
@@ -53,7 +58,37 @@ function parseSeeds(raw: unknown): SeedArtist[] {
   return []
 }
 
-export function createSimilarAdapter(sources: DiscoverySource[]): SubscriptionAdapter {
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+async function resolveSeedMbids(
+  seeds: SeedArtist[],
+  searchArtist: NonNullable<SimilarAdapterDeps['searchArtist']>,
+): Promise<SeedArtist[]> {
+  return Promise.all(
+    seeds.map(async (seed) => {
+      if (seed.mbid) return seed
+
+      try {
+        const searchResult = await searchArtist(seed.name)
+        const match =
+          searchResult.artists.find(
+            (artist) => normalizeName(artist.name) === normalizeName(seed.name),
+          ) ?? searchResult.artists[0]
+
+        return match ? { ...seed, mbid: match.id } : seed
+      } catch {
+        return seed
+      }
+    }),
+  )
+}
+
+export function createSimilarAdapter(
+  sources: DiscoverySource[],
+  deps: SimilarAdapterDeps = {},
+): SubscriptionAdapter {
   return {
     type: 'similar',
     label: 'Similar Artists',
@@ -82,8 +117,13 @@ export function createSimilarAdapter(sources: DiscoverySource[]): SubscriptionAd
 
       if (capable.length === 0) return { artists: [] }
 
+      const resolvedSeeds =
+        deps.searchArtist && capable.some((source) => source.id === 'listenbrainz')
+          ? await resolveSeedMbids(seeds, deps.searchArtist)
+          : seeds
+
       // Fan out: all seeds x all sources
-      const calls = seeds.flatMap((seed) =>
+      const calls = resolvedSeeds.flatMap((seed) =>
         capable.map((source) =>
           source.getSimilarArtists(seed.name, seed.mbid).then((entries) =>
             entries.map((entry) => ({

--- a/src/core/subscriptions/connections.ts
+++ b/src/core/subscriptions/connections.ts
@@ -1,0 +1,19 @@
+import type { SettingsRow } from '@/db/queries/settings'
+import type { UserConnections } from '@/db/queries/users'
+
+export function resolveSubscriptionSourceConnections(
+  settings: SettingsRow | null,
+  userConnections: UserConnections | null,
+): {
+  lbUsername: string | null
+  lbToken: string | null
+  lfUsername: string | null
+  lfApiKey: string | null
+} {
+  return {
+    lbUsername: userConnections?.listenbrainzUsername ?? settings?.listenbrainzUsername ?? null,
+    lbToken: userConnections?.listenbrainzToken ?? settings?.listenbrainzToken ?? null,
+    lfUsername: userConnections?.lastfmUsername ?? settings?.lastfmUsername ?? null,
+    lfApiKey: userConnections?.lastfmApiKey ?? settings?.lastfmApiKey ?? null,
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import { createListenBrainzAdapter } from './core/subscriptions/adapters/listenb
 import { createSimilarAdapter } from './core/subscriptions/adapters/similar'
 import { createSpotifyChartsAdapter } from './core/subscriptions/adapters/spotify-charts'
 import { createSpotifyPlaylistAdapter } from './core/subscriptions/adapters/spotify-playlist'
+import { resolveSubscriptionSourceConnections } from './core/subscriptions/connections'
 import { AdapterRegistry } from './core/subscriptions/registry'
 import { runSubscription } from './core/subscriptions/runner'
 import type {
@@ -316,13 +317,11 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
   const rejectedMbids = await storeDb.getRejectedMbids(prefs.rejectionCooldownDays)
   const feedbackHistory = await storeDb.getFeedbackHistory()
 
-  // Source connections are per-user only (no global fallback)
   const userConns = sub.userId ? await getUserConnections(db, sub.userId) : null
-
-  const lbUsername = userConns?.listenbrainzUsername ?? null
-  const lbToken = userConns?.listenbrainzToken ?? null
-  const lfUsername = userConns?.lastfmUsername ?? null
-  const lfApiKey = userConns?.lastfmApiKey ?? null
+  const { lbUsername, lbToken, lfUsername, lfApiKey } = resolveSubscriptionSourceConnections(
+    settings,
+    userConns,
+  )
   const dcToken = userConns?.discogsToken ?? null
   const dcUsername = userConns?.discogsUsername ?? null
 
@@ -348,7 +347,11 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
   if (!adapterRegistry) {
     adapterRegistry = new AdapterRegistry()
     adapterRegistry.register(createGenreAdapter(sourceRegistry.withCapability('genreArtists')))
-    adapterRegistry.register(createSimilarAdapter(sourceRegistry.withCapability('similarArtists')))
+    adapterRegistry.register(
+      createSimilarAdapter(sourceRegistry.withCapability('similarArtists'), {
+        searchArtist: createMusicBrainzClient().searchArtist,
+      }),
+    )
 
     // Last.fm adapters -- only if the user has a Last.fm API key
     if (lfApiKey) {

--- a/src/web/pages/subscriptions.tsx
+++ b/src/web/pages/subscriptions.tsx
@@ -336,11 +336,9 @@ export default function SubscriptionsPage() {
   const configuredSources = (() => {
     if (!settings) return []
     const sources: string[] = []
-    // Only check per-user connections (global last.fm/discogs fields are legacy leftovers).
-    // The _*Scope markers indicate user-level data was loaded by the settings endpoint.
-    if (settings._lastfmScope && settings.lastfmUsername) sources.push('lastfm')
-    if (settings._listenbrainzScope && settings.listenbrainzUsername) sources.push('listenbrainz')
-    if (settings._discogsScope && settings.discogsUsername) sources.push('discogs')
+    if (settings.lastfmUsername && settings.lastfmApiKey) sources.push('lastfm')
+    if (settings.listenbrainzUsername && settings.listenbrainzToken) sources.push('listenbrainz')
+    if (settings.discogsUsername && settings.discogsToken) sources.push('discogs')
     if (spotifyStatus?.connected) sources.push('spotify')
     return sources
   })()
@@ -490,37 +488,36 @@ export default function SubscriptionsPage() {
       )}
 
       {/* Empty state */}
-      {!isLoading && subscriptions && subscriptions.length === 0 && (
-        <>
-          {subscriptionMode === 'ai-only' ? (
-            <div className="bg-surface border border-border rounded-lg px-4 py-12 text-center space-y-3">
-              <p className="text-sm font-medium text-text">AI-only mode</p>
-              <p className="text-xs text-muted">
-                Discovery runs on the pipeline schedule with no external feed subscriptions.
-              </p>
-              <button
-                type="button"
-                onClick={() => setShowPresets(true)}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-muted border border-border rounded-md hover:text-text hover:border-accent/40 transition-colors"
-              >
-                <LayoutGrid size={14} />
-                Switch to a preset
-              </button>
-            </div>
-          ) : (
-            <div className="bg-surface border border-border rounded-lg p-6 space-y-6">
-              <SubscriptionPresets
-                connectedServices={configuredSources}
-                onComplete={() => {
-                  invalidate()
-                  setShowPresets(false)
-                }}
-                onCustom={() => setShowForm({ mode: 'create' })}
-              />
-            </div>
-          )}
-        </>
-      )}
+      {!isLoading &&
+        subscriptions &&
+        subscriptions.length === 0 &&
+        (subscriptionMode === 'ai-only' ? (
+          <div className="bg-surface border border-border rounded-lg px-4 py-12 text-center space-y-3">
+            <p className="text-sm font-medium text-text">AI-only mode</p>
+            <p className="text-xs text-muted">
+              Discovery runs on the pipeline schedule with no external feed subscriptions.
+            </p>
+            <button
+              type="button"
+              onClick={() => setShowPresets(true)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-muted border border-border rounded-md hover:text-text hover:border-accent/40 transition-colors"
+            >
+              <LayoutGrid size={14} />
+              Switch to a preset
+            </button>
+          </div>
+        ) : (
+          <div className="bg-surface border border-border rounded-lg p-6 space-y-6">
+            <SubscriptionPresets
+              connectedServices={configuredSources}
+              onComplete={() => {
+                invalidate()
+                setShowPresets(false)
+              }}
+              onCustom={() => setShowForm({ mode: 'create' })}
+            />
+          </div>
+        ))}
 
       {/* Inline presets panel (shown when list is non-empty and user clicked Presets) */}
       {!isLoading && subscriptions && subscriptions.length > 0 && showPresets && (

--- a/tests/core/subscriptions/adapters/similar.test.ts
+++ b/tests/core/subscriptions/adapters/similar.test.ts
@@ -74,6 +74,24 @@ describe('createSimilarAdapter', () => {
     expect(getSimilarArtists).toHaveBeenCalledWith('Radiohead', 'mbid-rh')
   })
 
+  it('resolves missing MBIDs before calling ListenBrainz', async () => {
+    const listenbrainz = makeSource('listenbrainz', [
+      { name: 'Artist B', similarityScore: 0.8, source: 'listenbrainz' },
+    ])
+    const searchArtist = vi.fn().mockResolvedValue({
+      artists: [{ id: 'mbid-seed', name: 'Artist A', score: 100 }],
+    })
+    const adapter = createSimilarAdapter([listenbrainz], { searchArtist })
+
+    await adapter.fetch({
+      seedArtists: [{ name: 'Artist A' }],
+      providers: ['listenbrainz'],
+    })
+
+    expect(searchArtist).toHaveBeenCalledWith('Artist A')
+    expect(listenbrainz.getSimilarArtists).toHaveBeenCalledWith('Artist A', 'mbid-seed')
+  })
+
   it('deduplicates artists across seeds by lowercase name', async () => {
     const source = makeSource('lastfm', [])
     const getSimilarFn = vi.mocked(source.getSimilarArtists)

--- a/tests/core/subscriptions/connections.test.ts
+++ b/tests/core/subscriptions/connections.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { resolveSubscriptionSourceConnections } from '@/core/subscriptions/connections'
+import type { SettingsRow } from '@/db/queries/settings'
+import type { UserConnections } from '@/db/queries/users'
+
+function makeSettings(overrides: Partial<SettingsRow> = {}): SettingsRow {
+  return {
+    id: 1,
+    setupComplete: true,
+    lidarrUrl: null,
+    lidarrApiKey: null,
+    skipTlsVerify: false,
+    listenbrainzUsername: 'global-lb-user',
+    listenbrainzToken: 'global-lb-token',
+    lastfmUsername: 'global-lastfm-user',
+    lastfmApiKey: 'global-lastfm-key',
+    aiProvider: null,
+    aiApiKey: null,
+    aiModel: null,
+    aiBaseUrl: null,
+    oidcIssuerUrl: null,
+    oidcClientId: null,
+    oidcClientSecret: null,
+    oidcScopes: null,
+    preferences: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function makeUserConnections(overrides: Partial<UserConnections> = {}): UserConnections {
+  return {
+    listenbrainzUsername: null,
+    listenbrainzToken: null,
+    lastfmUsername: null,
+    lastfmApiKey: null,
+    plexUrl: null,
+    plexToken: null,
+    jellyfinUrl: null,
+    jellyfinApiKey: null,
+    jellyfinUserId: null,
+    discogsToken: null,
+    discogsUsername: null,
+    ...overrides,
+  }
+}
+
+describe('resolveSubscriptionSourceConnections', () => {
+  it('falls back to global settings when the user has no source credentials', () => {
+    const resolved = resolveSubscriptionSourceConnections(makeSettings(), makeUserConnections())
+
+    expect(resolved).toEqual({
+      lbUsername: 'global-lb-user',
+      lbToken: 'global-lb-token',
+      lfUsername: 'global-lastfm-user',
+      lfApiKey: 'global-lastfm-key',
+    })
+  })
+
+  it('prefers user credentials over global settings', () => {
+    const resolved = resolveSubscriptionSourceConnections(
+      makeSettings(),
+      makeUserConnections({
+        listenbrainzUsername: 'user-lb',
+        listenbrainzToken: 'user-lb-token',
+        lastfmUsername: 'user-lastfm',
+        lastfmApiKey: 'user-lastfm-key',
+      }),
+    )
+
+    expect(resolved).toEqual({
+      lbUsername: 'user-lb',
+      lbToken: 'user-lb-token',
+      lfUsername: 'user-lastfm',
+      lfApiKey: 'user-lastfm-key',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- resolve missing MBIDs before ListenBrainz similar lookups so name-only seed artists can return results
- restore global Last.fm and ListenBrainz fallback for subscription runs
- treat globally configured services as available on the subscriptions page

## Verification
- bun run test tests/core/subscriptions/adapters/similar.test.ts
- bun run test tests/core/subscriptions/connections.test.ts
- bun run test tests/core/subscriptions/runner.test.ts
- bun run test tests/server/routes/subscriptions.test.ts
- bun run typecheck
- bun run lint