### PR TITLE
fix: rank mixed search results and repair playlist scheduling

### DIFF
--- a/src/core/clients/bandcamp.ts
+++ b/src/core/clients/bandcamp.ts
@@ -21,16 +21,34 @@ export type BandcampSearchResult = {
 }
 
 // Regexes for HTML scraping. These are fragile by nature.
-// Targeting .result-info .heading a (artist name + URL) and .result-info .genre
+// Targeting .result-info .heading a (artist name + URL), .itemurl for clean URLs,
+// and both legacy and current result-type markers.
 const RE_RESULT_BLOCK = /<li class="searchresult[^"]*"[^>]*>([\s\S]*?)<\/li>/g
 const RE_HEADING_LINK =
   /<div class="heading"[^>]*>[\s\S]*?<a[^>]+href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/
+const RE_ITEMURL_LINK =
+  /<div class="itemurl"[^>]*>[\s\S]*?<a[^>]+href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/
 const RE_GENRE = /<div class="genre"[^>]*>([\s\S]*?)<\/div>/
+const RE_ITEM_TYPE = /<div class="itemtype"[^>]*>([\s\S]*?)<\/div>/
 const RE_IMAGE = /<img[^>]+src="([^"]+)"[^>]*>/
 const RE_HTML_TAG = /<[^>]+>/g
+const RE_BAND_TYPE_MARKER =
+  /itemtype=(?:"|')b(?:"|')|data-search=(?:"|')[\s\S]*?(?:"|&quot;)type(?:"|&quot;)\s*:\s*(?:"|&quot;)b(?:"|&quot;)[\s\S]*?(?:"|')/i
 
 function stripHtml(s: string): string {
   return s.replace(RE_HTML_TAG, '').trim()
+}
+
+function normalizeBandcampUrl(rawUrl: string): string {
+  const trimmed = stripHtml(rawUrl)
+  if (!trimmed) return ''
+
+  try {
+    const parsed = new URL(trimmed)
+    return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, '')
+  } catch {
+    return trimmed.replace(/\?.*$/, '').replace(/\/+$/, '')
+  }
 }
 
 function parseSearchResults(html: string, limit: number): BandcampSearchResult[] {
@@ -46,27 +64,33 @@ function parseSearchResults(html: string, limit: number): BandcampSearchResult[]
     const block = match[1] ?? ''
     const full = match[0]
 
-    // Only pick up band/artist results (itemtype=b)
-    if (!full.includes('itemtype="b"') && !full.includes("itemtype='b'")) {
+    const itemTypeMatch = RE_ITEM_TYPE.exec(block)
+    const itemType = itemTypeMatch ? stripHtml(itemTypeMatch[1] ?? '').toLowerCase() : ''
+    const isArtistResult = itemType === 'artist'
+
+    // Only pick up artist/band results.
+    if (!isArtistResult && !RE_BAND_TYPE_MARKER.test(full)) {
       continue
     }
 
     const headingMatch = RE_HEADING_LINK.exec(block)
     if (!headingMatch) continue
 
-    const rawUrl = (headingMatch[1] ?? '').trim()
+    const itemUrlMatch = RE_ITEMURL_LINK.exec(block)
+    const rawUrl = (itemUrlMatch?.[1] ?? itemUrlMatch?.[2] ?? headingMatch[1] ?? '').trim()
     const rawName = stripHtml(headingMatch[2] ?? '')
-    if (!rawName || !rawUrl) continue
+    const normalizedUrl = normalizeBandcampUrl(rawUrl)
+    if (!rawName || !normalizedUrl) continue
 
     const genreMatch = RE_GENRE.exec(block)
-    const genre = genreMatch ? stripHtml(genreMatch[1] ?? '') : undefined
+    const genre = genreMatch ? stripHtml(genreMatch[1] ?? '').replace(/^genre:\s*/i, '') : undefined
 
     const imageMatch = RE_IMAGE.exec(block)
     const imageUrl = imageMatch ? (imageMatch[1] ?? '').trim() : undefined
 
     results.push({
       name: rawName,
-      url: rawUrl,
+      url: normalizedUrl,
       genre: genre || undefined,
       imageUrl: imageUrl || undefined,
     })

--- a/src/core/clients/musicbrainz.ts
+++ b/src/core/clients/musicbrainz.ts
@@ -34,6 +34,12 @@ export type MBReleaseGroup = {
   firstReleaseDate?: string
 }
 
+export type MBRecording = {
+  id: string
+  title: string
+  isrcs?: string[]
+}
+
 export type StreamingUrls = {
   spotify?: string
   youtube?: string
@@ -107,6 +113,27 @@ export function createMusicBrainzClient() {
     }))
   }
 
+  async function getRecordings(artistMbid: string, limit = 25): Promise<MBRecording[]> {
+    const params = new URLSearchParams({
+      artist: artistMbid,
+      fmt: 'json',
+      limit: String(limit),
+    })
+    const data = await request<{
+      recordings?: Array<{
+        id: string
+        title: string
+        isrcs?: string[]
+      }>
+    }>(`/recording?${params}`)
+
+    return (data.recordings ?? []).map((recording) => ({
+      id: recording.id,
+      title: recording.title,
+      isrcs: recording.isrcs,
+    }))
+  }
+
   function extractStreamingUrls(relations: MBRelation[]): StreamingUrls {
     const result: StreamingUrls = {}
 
@@ -131,6 +158,7 @@ export function createMusicBrainzClient() {
     lookupArtist,
     searchArtist,
     getReleaseGroups,
+    getRecordings,
     extractStreamingUrls,
   }
 }

--- a/src/core/clients/spotify.ts
+++ b/src/core/clients/spotify.ts
@@ -20,6 +20,13 @@ export type SpotifyRecentTrack = {
   playedAt: string
 }
 
+export type SpotifySearchTrack = {
+  name: string
+  artists: string[]
+  uri: string
+  popularity: number
+}
+
 // Raw Spotify API response shapes
 type SpotifyTopArtistsResponse = {
   items: Array<{
@@ -43,6 +50,17 @@ type SpotifyRecentlyPlayedResponse = {
 type SpotifyProfileResponse = {
   display_name: string
   id: string
+}
+
+type SpotifySearchTracksResponse = {
+  tracks: {
+    items: Array<{
+      name: string
+      uri: string
+      popularity: number
+      artists: Array<{ name: string }>
+    }>
+  }
 }
 
 export function createSpotifyClient(accessToken: string, options?: { baseUrl?: string }) {
@@ -84,6 +102,21 @@ export function createSpotifyClient(accessToken: string, options?: { baseUrl?: s
     }))
   }
 
+  async function searchTracks(query: string, limit = 10): Promise<SpotifySearchTrack[]> {
+    const params = new URLSearchParams({
+      q: query,
+      type: 'track',
+      limit: String(limit),
+    })
+    const res = await get<SpotifySearchTracksResponse>(`/search?${params}`)
+    return res.tracks.items.map((item) => ({
+      name: item.name,
+      artists: item.artists.map((artist) => artist.name),
+      uri: item.uri,
+      popularity: item.popularity,
+    }))
+  }
+
   async function testConnection(): Promise<ServiceTestResult> {
     try {
       const profile = await get<SpotifyProfileResponse>('/me')
@@ -100,6 +133,7 @@ export function createSpotifyClient(accessToken: string, options?: { baseUrl?: s
   return {
     getTopArtists,
     getRecentlyPlayed,
+    searchTracks,
     testConnection,
   }
 }

--- a/src/core/playlists/scheduler.ts
+++ b/src/core/playlists/scheduler.ts
@@ -1,28 +1,61 @@
 import { Cron } from 'croner'
 
-export class PlaylistScheduler {
-  private job: Cron | null = null
+type ScheduledJob = { name: string; cron: Cron; expression: string }
 
-  start(cronExpression: string, runFn: () => Promise<void>): void {
-    this.stop()
-    this.job = new Cron(cronExpression, async () => {
+export class PlaylistScheduler {
+  private jobs = new Map<string, ScheduledJob>()
+
+  schedule(name: string, cronExpression: string, fn: () => Promise<void>): void {
+    this.remove(name)
+    const cron = new Cron(cronExpression, async () => {
       try {
-        await runFn()
-      } catch (e: unknown) {
-        console.error('[playlist-scheduler] error:', e)
+        await fn()
+      } catch (err: unknown) {
+        console.error(`[playlist-scheduler] Job '${name}' (${cronExpression}) failed:`, err)
       }
     })
-    console.log(`[playlist-scheduler] started, next run: ${this.job.nextRun()?.toISOString()}`)
+    this.jobs.set(name, { name, cron, expression: cronExpression })
   }
 
-  stop(): void {
-    if (this.job) {
-      this.job.stop()
-      this.job = null
+  remove(name: string): void {
+    const job = this.jobs.get(name)
+    if (job) {
+      job.cron.stop()
+      this.jobs.delete(name)
     }
   }
 
-  nextRun(): Date | null {
-    return this.job?.nextRun() ?? null
+  has(name: string): boolean {
+    return this.jobs.has(name)
+  }
+
+  listJobs(): Array<{ name: string; expression: string; nextRun: Date | null }> {
+    return [...this.jobs.values()].map((job) => ({
+      name: job.name,
+      expression: job.expression,
+      nextRun: job.cron.nextRun() ?? null,
+    }))
+  }
+
+  nextRun(name?: string): Date | null {
+    if (name) return this.jobs.get(name)?.cron.nextRun() ?? null
+
+    return (
+      this.listJobs()
+        .map((job) => job.nextRun)
+        .filter((run): run is Date => run instanceof Date)
+        .sort((a, b) => a.getTime() - b.getTime())[0] ?? null
+    )
+  }
+
+  stop(): void {
+    this.stopAll()
+  }
+
+  stopAll(): void {
+    for (const job of this.jobs.values()) {
+      job.cron.stop()
+    }
+    this.jobs.clear()
   }
 }

--- a/src/core/playlists/strategies/mood-mix.ts
+++ b/src/core/playlists/strategies/mood-mix.ts
@@ -1,11 +1,63 @@
 import type { PlaylistStrategyImpl, StrategyArtist, StrategyDeps } from './types'
 import { TRACKS_PER_ARTIST } from './types'
 
-// Simple keyword match: does any genre tag on the artist contain the mood word?
+const MOOD_ALIASES: Record<string, string[]> = {
+  'd and d': [
+    'fantasy',
+    'dungeon synth',
+    'dungeon',
+    'medieval',
+    'dark ambient',
+    'ambient',
+    'folk',
+    'soundtrack',
+    'epic',
+  ],
+  dnd: [
+    'fantasy',
+    'dungeon synth',
+    'dungeon',
+    'medieval',
+    'dark ambient',
+    'ambient',
+    'folk',
+    'soundtrack',
+    'epic',
+  ],
+  'dungeons and dragons': [
+    'fantasy',
+    'dungeon synth',
+    'dungeon',
+    'medieval',
+    'dark ambient',
+    'ambient',
+    'folk',
+    'soundtrack',
+    'epic',
+  ],
+}
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .replaceAll('&', ' and ')
+    .replaceAll(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function getMoodKeywords(mood: string): string[] {
+  const normalizedMood = normalize(mood)
+  const aliases = MOOD_ALIASES[normalizedMood] ?? []
+  return [normalizedMood, ...aliases].filter(Boolean)
+}
+
 function artistMatchesMood(artist: StrategyArtist, mood: string): boolean {
   if (!artist.genres || artist.genres.length === 0) return false
-  const keyword = mood.toLowerCase()
-  return artist.genres.some((g) => g.toLowerCase().includes(keyword))
+  const keywords = getMoodKeywords(mood)
+  return artist.genres.some((genre) => {
+    const normalizedGenre = normalize(genre)
+    return keywords.some((keyword) => normalizedGenre.includes(keyword))
+  })
 }
 
 export const moodMixStrategy: PlaylistStrategyImpl = {

--- a/src/core/search/enrich.ts
+++ b/src/core/search/enrich.ts
@@ -1,0 +1,62 @@
+import type { MergedSearchResult } from './multi-source'
+
+type SearchImageDeps = {
+  getCachedImages: (mbids: string[]) => Promise<Map<string, string>>
+  lookupLidarrImage?: (mbid: string) => Promise<string | undefined>
+  cacheImage?: (mbid: string, url: string) => Promise<void>
+}
+
+function addImage(result: MergedSearchResult, url: string, source: string): MergedSearchResult {
+  if (result.images.some((image) => image.url === url)) return result
+
+  return {
+    ...result,
+    images: [...result.images, { url, source }],
+  }
+}
+
+export async function enrichSearchResultsWithImages(
+  results: MergedSearchResult[],
+  deps: SearchImageDeps,
+): Promise<MergedSearchResult[]> {
+  const missing = results.filter((result) => result.images.length === 0 && result.mbid)
+  if (missing.length === 0) return results
+
+  const mbids = [...new Set(missing.map((result) => result.mbid).filter(Boolean))] as string[]
+  const cached = await deps.getCachedImages(mbids)
+
+  let enriched = results.map((result) => {
+    if (!result.mbid || result.images.length > 0) return result
+
+    const cachedUrl = cached.get(result.mbid)
+    return cachedUrl ? addImage(result, cachedUrl, 'cache') : result
+  })
+
+  if (!deps.lookupLidarrImage) return enriched
+
+  const stillMissing = enriched.filter((result) => result.images.length === 0 && result.mbid)
+  if (stillMissing.length === 0) return enriched
+
+  const lookedUp = await Promise.all(
+    stillMissing.map(async (result) => {
+      const url = await deps.lookupLidarrImage?.(result.mbid as string)
+      if (!url) return [result.mbid as string, undefined] as const
+
+      await deps.cacheImage?.(result.mbid as string, url)
+      return [result.mbid as string, url] as const
+    }),
+  )
+
+  const fetched = new Map(
+    lookedUp.filter((entry): entry is readonly [string, string] => Boolean(entry[1])),
+  )
+
+  enriched = enriched.map((result) => {
+    if (!result.mbid || result.images.length > 0) return result
+
+    const fetchedUrl = fetched.get(result.mbid)
+    return fetchedUrl ? addImage(result, fetchedUrl, 'lidarr') : result
+  })
+
+  return enriched
+}

--- a/src/core/search/multi-source.ts
+++ b/src/core/search/multi-source.ts
@@ -1,4 +1,5 @@
 import PQueue from 'p-queue'
+import { computeNameRelevance } from './relevance'
 
 export type SearchSource = {
   id: string
@@ -38,6 +39,15 @@ type SearchOptions = {
 }
 
 const SOURCE_TIMEOUT_MS = 5000
+
+function popularityTieBreaker(result: MergedSearchResult): number {
+  const popularity = result.popularity ?? 0
+  const listeners = result.listeners ?? 0
+  const normalizedListeners = listeners > 0 ? Math.log10(listeners + 1) : 0
+  const sourceConfidence = result.sources.length * 10
+  const imageBonus = result.images.length > 0 ? 2 : 0
+  return popularity + normalizedListeners + sourceConfidence + imageBonus
+}
 
 async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return Promise.race([
@@ -149,8 +159,18 @@ export async function multiSourceSearch(
 
   const merged = Array.from(byKey.values())
 
-  // Sort by source count descending (more sources = higher confidence)
-  merged.sort((a, b) => b.sources.length - a.sources.length)
+  merged.sort((a, b) => {
+    const relevanceDiff = computeNameRelevance(query, b.name) - computeNameRelevance(query, a.name)
+    if (relevanceDiff !== 0) return relevanceDiff
+
+    const sourceDiff = b.sources.length - a.sources.length
+    if (sourceDiff !== 0) return sourceDiff
+
+    const popularityDiff = popularityTieBreaker(b) - popularityTieBreaker(a)
+    if (popularityDiff !== 0) return popularityDiff
+
+    return a.name.length - b.name.length
+  })
 
   return merged.slice(0, limit)
 }

--- a/src/db/queries/playlists.ts
+++ b/src/db/queries/playlists.ts
@@ -57,6 +57,10 @@ export async function getPlaylistsByUser(db: Database, userId: number): Promise<
   return rows
 }
 
+export async function getEnabledPlaylists(db: Database): Promise<PlaylistRow[]> {
+  return db.select().from(playlists).where(eq(playlists.enabled, true))
+}
+
 export async function getPlaylistWithTracks(
   db: Database,
   playlistId: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { serve } from '@hono/node-server'
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 import { migrate } from 'drizzle-orm/node-postgres/migrator'
 import { canAutoSetup, envConfig } from './config/env'
 import { hashPassword } from './core/auth'
@@ -9,6 +9,7 @@ import { createDeezerClient } from './core/clients/deezer'
 import { createJellyfinClient } from './core/clients/jellyfin'
 import { createLidarrClient } from './core/clients/lidarr'
 import { createMusicBrainzClient } from './core/clients/musicbrainz'
+import { createSpotifyClient } from './core/clients/spotify'
 import { initEncryption, isEncryptionEnabled } from './core/crypto'
 import { GenreService } from './core/genre/service'
 import { LibraryHealthService } from './core/library/health'
@@ -25,6 +26,7 @@ import { createListenBrainzSource } from './core/plugins/listenbrainz'
 import { SourceRegistry } from './core/plugins/registry'
 import { createDefaultRegistry } from './core/providers/registry'
 import { buildSearchSourceCatalog } from './core/search/catalog'
+import { enrichSearchResultsWithImages } from './core/search/enrich'
 import type { SearchSource } from './core/search/multi-source'
 import { multiSourceSearch } from './core/search/multi-source'
 import { createBandcampSearchSource } from './core/search/sources/bandcamp'
@@ -66,7 +68,8 @@ import {
 } from './db/queries/genres'
 import { getOAuthToken } from './db/queries/oauth-tokens'
 import {
-  getPlaylistsDueForGeneration,
+  getEnabledPlaylists,
+  getPlaylistWithTracks,
   replacePlaylistTracks,
   updatePlaylist as updatePlaylistRow,
 } from './db/queries/playlists'
@@ -243,6 +246,21 @@ function makeLazyLidarrClient() {
 
 const lazyLidarrClient = makeLazyLidarrClient()
 
+function extractSearchImageUrl(
+  results: Array<{ images?: Array<{ coverType: string; remoteUrl?: string }> }>,
+): string | undefined {
+  const artist = results[0]
+  if (!artist?.images?.length) return undefined
+
+  for (const type of ['poster', 'fanart', 'banner']) {
+    const image = artist.images.find((entry) => entry.coverType === type && entry.remoteUrl)
+    if (image?.remoteUrl) return image.remoteUrl
+  }
+
+  return artist.images.find((entry) => entry.coverType !== 'clearlogo' && entry.remoteUrl)
+    ?.remoteUrl
+}
+
 const libraryHealth = new LibraryHealthService({
   lidarrClient: lazyLidarrClient,
   artistCache: {
@@ -396,6 +414,9 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
     scoringWeightOverrides: sub.scoringWeightOverrides,
   }
 
+  const libraryArtists = lidarrClient ? await lidarrClient.getArtists() : []
+  const libraryGenres = [...new Set(libraryArtists.flatMap((artist) => artist.genres ?? []))]
+
   await runSubscription(subscriptionConfig, adapter, {
     db: storeDb,
     queries: {
@@ -408,10 +429,8 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
     userId: sub.userId ?? undefined,
     // Populate library MBIDs from Lidarr so subscriptions don't recommend
     // artists already in the library (same dedup the main pipeline does)
-    libraryMbids: lidarrClient
-      ? new Set((await lidarrClient.getArtists()).map((a) => a.foreignArtistId))
-      : new Set<string>(),
-    libraryGenres: [],
+    libraryMbids: new Set(libraryArtists.map((artist) => artist.foreignArtistId)),
+    libraryGenres,
     rejectedMbids,
     feedbackHistory,
     cooldownDays: prefs.rejectionCooldownDays,
@@ -419,54 +438,136 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
   })
 }
 
-// Run generation for all playlists that are due (called by the playlist scheduler)
-async function runAllPlaylists(): Promise<void> {
-  const due = await getPlaylistsDueForGeneration(db)
-  if (due.length === 0) return
-  console.log(`[playlist-scheduler] ${due.length} playlist(s) due for generation`)
+async function buildPlaylistResolverDeps(userId: number | null) {
+  const mbClient = createMusicBrainzClient()
+  const resolverDeps: import('./core/playlists/types').TrackResolverDeps = {
+    musicbrainzRecordings: (artistMbid) => mbClient.getRecordings(artistMbid),
+  }
 
-  for (const playlist of due) {
-    try {
-      const strategyDeps = buildStrategyDeps(db, playlist.userId ?? null)
-      const cfg = playlist.config ?? { size: 25, trackSourcePriority: ['spotify' as const] }
-      const result = await generatePlaylist(
-        playlist.strategy as import('./db/schema').PlaylistStrategy,
-        {
-          size: cfg.size,
-          genre: cfg.genre,
-          mood: cfg.mood,
-          trackSourcePriority: cfg.trackSourcePriority,
-        },
-        strategyDeps,
-        {},
-      )
-
-      const trackInserts = result.tracks.map((t, i) => ({
-        playlistId: playlist.id,
-        artistName: t.artistName,
-        trackName: t.trackName ?? null,
-        mbid: t.mbid ?? null,
-        spotifyUri: t.spotifyUri ?? null,
-        deezerId: t.deezerId ?? null,
-        localPath: t.localPath ?? null,
-        position: i,
-      }))
-
-      await replacePlaylistTracks(db, playlist.id, trackInserts)
-      await updatePlaylistRow(db, playlist.id, {
-        lastGeneratedAt: new Date(),
-        trackCount: result.tracks.length,
-      })
-
-      console.log(
-        `[playlist-scheduler] Playlist '${playlist.name}' (id=${playlist.id}): ${result.tracks.length} tracks`,
-      )
-    } catch (err: unknown) {
-      console.error(
-        `[playlist-scheduler] Failed to generate playlist '${playlist.name}' (id=${playlist.id}):`,
-        err,
-      )
+  if (userId != null) {
+    const spotifyOAuthRow = await getOAuthToken(db, userId, 'spotify')
+    if (spotifyOAuthRow) {
+      resolverDeps.spotifySearch = async (query, limit = 10) => {
+        const accessToken = await resolveSpotifyToken(db, userId)
+        const client = createSpotifyClient(accessToken)
+        return client.searchTracks(query, limit)
+      }
     }
+  }
+
+  return resolverDeps
+}
+
+async function executePlaylistGeneration(playlistId: number): Promise<void> {
+  const result = await getPlaylistWithTracks(db, playlistId)
+  if (!result) {
+    console.warn(`[playlist-scheduler] Playlist ${playlistId} not found -- skipping`)
+    return
+  }
+
+  const playlist = result.playlist
+  const strategyDeps = buildStrategyDeps(db, playlist.userId ?? null)
+  const resolverDeps = await buildPlaylistResolverDeps(playlist.userId ?? null)
+  const cfg = playlist.config ?? { size: 25, trackSourcePriority: ['spotify' as const] }
+  const generation = await generatePlaylist(
+    playlist.strategy as import('./db/schema').PlaylistStrategy,
+    {
+      size: cfg.size,
+      genre: cfg.genre,
+      mood: cfg.mood,
+      trackSourcePriority: cfg.trackSourcePriority,
+    },
+    strategyDeps,
+    resolverDeps,
+  )
+
+  const trackInserts = generation.tracks.map((track, index) => ({
+    playlistId: playlist.id,
+    artistName: track.artistName,
+    trackName: track.trackName ?? null,
+    mbid: track.mbid ?? null,
+    spotifyUri: track.spotifyUri ?? null,
+    deezerId: track.deezerId ?? null,
+    localPath: track.localPath ?? null,
+    position: index,
+  }))
+
+  await replacePlaylistTracks(db, playlist.id, trackInserts)
+  await updatePlaylistRow(db, playlist.id, {
+    lastGeneratedAt: new Date(),
+    trackCount: generation.tracks.length,
+  })
+
+  if (playlist.targetIds.length > 0 && playlist.userId != null) {
+    const targetRows = await getTargetsByUser(db, playlist.userId)
+    const enabledTargetRows = targetRows.filter(
+      (row) => row.enabled && playlist.targetIds.includes(row.id),
+    )
+    const playlistItems = generation.tracks.map((track) => ({
+      artistName: track.artistName,
+      artistMbid: '',
+      trackName: track.trackName ?? undefined,
+      trackMbid: track.mbid ?? undefined,
+    }))
+
+    for (const targetRow of enabledTargetRows) {
+      let target:
+        | ReturnType<typeof createNavidromePlaylistTarget>
+        | ReturnType<typeof createJellyfinPlaylistTarget>
+        | ReturnType<typeof createPlexPlaylistTarget>
+        | null = null
+
+      if (targetRow.type === 'navidrome-playlist') {
+        target = createNavidromePlaylistTarget(targetRow.id, {
+          url: targetRow.config.url as string,
+          username: targetRow.config.username as string,
+          password: targetRow.config.password as string,
+        })
+      } else if (targetRow.type === 'jellyfin-playlist') {
+        target = createJellyfinPlaylistTarget(targetRow.id, {
+          url: targetRow.config.url as string,
+          apiKey: targetRow.config.apiKey as string,
+          userId: targetRow.config.userId as string,
+        })
+      } else if (targetRow.type === 'plex-playlist') {
+        target = createPlexPlaylistTarget(targetRow.id, {
+          url: targetRow.config.url as string,
+          token: targetRow.config.token as string,
+        })
+      }
+
+      if (!target?.createPlaylist) continue
+
+      try {
+        await target.createPlaylist(playlist.name, playlistItems)
+      } catch (err: unknown) {
+        console.error(
+          `[playlists] Failed to push to target ${targetRow.type}(${targetRow.id}):`,
+          err,
+        )
+      }
+    }
+  }
+
+  console.log(
+    `[playlist-scheduler] Playlist '${playlist.name}' (id=${playlist.id}): ${generation.tracks.length} tracks`,
+  )
+}
+
+async function restartPlaylistScheduler(): Promise<void> {
+  playlistScheduler.stopAll()
+
+  const settings = await getSettings(db)
+  const prefs = mergePreferences(settings?.preferences)
+  if (!prefs.playlistEnabled) return
+
+  const playlists = await getEnabledPlaylists(db)
+  for (const playlist of playlists) {
+    if (!playlist.schedule) continue
+
+    playlistScheduler.schedule(`playlist-${playlist.id}`, playlist.schedule, async () => {
+      await executePlaylistGeneration(playlist.id)
+    })
   }
 }
 
@@ -541,6 +642,7 @@ const app = createApp({
     scheduler.schedule('main-pipeline', cron, runPipeline)
     console.log(`Scheduler restarted with cron: ${cron}`)
   },
+  restartPlaylistScheduler,
   createUser: (data) => createUser(db, data),
   getUserByUsername: (username) => getUserByUsername(db, username),
   getUserById: (id) => getUserById(db, id),
@@ -636,30 +738,8 @@ const app = createApp({
   playlistDeps: {
     db,
     playlistScheduler,
-    getTargetsByUser: (userId) => getTargetsByUser(db, userId),
-    buildPlaylistTarget: (row) => {
-      if (row.type === 'navidrome-playlist') {
-        return createNavidromePlaylistTarget(row.id, {
-          url: row.config.url as string,
-          username: row.config.username as string,
-          password: row.config.password as string,
-        })
-      }
-      if (row.type === 'jellyfin-playlist') {
-        return createJellyfinPlaylistTarget(row.id, {
-          url: row.config.url as string,
-          apiKey: row.config.apiKey as string,
-          userId: row.config.userId as string,
-        })
-      }
-      if (row.type === 'plex-playlist') {
-        return createPlexPlaylistTarget(row.id, {
-          url: row.config.url as string,
-          token: row.config.token as string,
-        })
-      }
-      return null
-    },
+    runPlaylistGeneration: (playlistId) => executePlaylistGeneration(playlistId),
+    restartPlaylistScheduler,
   },
   search: {
     listSources: async (userId) => {
@@ -691,7 +771,36 @@ const app = createApp({
       // once TIDAL client ID/secret are exposed via settings (not yet implemented).
 
       const filtered = opts?.sources ? sources.filter((s) => opts.sources?.includes(s.id)) : sources
-      return multiSourceSearch(query, filtered, { limit: opts?.limit })
+      const merged = await multiSourceSearch(query, filtered, { limit: opts?.limit })
+
+      return enrichSearchResultsWithImages(merged, {
+        getCachedImages: async (mbids) => {
+          if (mbids.length === 0) return new Map<string, string>()
+
+          const rows = await db
+            .select({ mbid: artists.mbid, imageUrl: artists.imageUrl })
+            .from(artists)
+            .where(inArray(artists.mbid, mbids))
+
+          return new Map(
+            rows
+              .filter((row): row is { mbid: string; imageUrl: string } => Boolean(row.imageUrl))
+              .map((row) => [row.mbid, row.imageUrl]),
+          )
+        },
+        lookupLidarrImage: async (mbid) => {
+          const results = (await lazyLidarrClient.lookupArtist(`lidarr:${mbid}`)) as Array<{
+            images?: Array<{ coverType: string; remoteUrl?: string }>
+          }>
+          return extractSearchImageUrl(results)
+        },
+        cacheImage: async (mbid, url) => {
+          await db
+            .update(artists)
+            .set({ imageUrl: url, imageFailedAt: null })
+            .where(eq(artists.mbid, mbid))
+        },
+      })
     },
   },
 })
@@ -778,9 +887,7 @@ const server = serve({ fetch: app.fetch, port })
       console.log(`Subscription '${sub.name}' (id=${sub.id}) scheduled with cron: ${sub.cron}`)
     }
 
-    if (prefs.playlistSchedule && prefs.playlistEnabled) {
-      playlistScheduler.start(prefs.playlistSchedule, runAllPlaylists)
-    }
+    await restartPlaylistScheduler()
   } catch (err: unknown) {
     console.error('Failed to initialize:', err)
   }
@@ -825,7 +932,7 @@ for (const signal of ['SIGTERM', 'SIGINT'] as const) {
   process.on(signal, async () => {
     console.log(`${signal} received, shutting down...`)
     scheduler.stopAll()
-    playlistScheduler.stop()
+    playlistScheduler.stopAll()
     server.close()
     await new Promise((resolve) => setTimeout(resolve, 5000))
     await pool.end()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -92,6 +92,7 @@ export type AppDependencies = {
   // Artist query functions
   getArtistById: (id: number) => Promise<ArtistRow | null>
   restartScheduler: (cron: string | null) => void
+  restartPlaylistScheduler: () => Promise<void>
   // User query functions
   createUser: (data: {
     username: string

--- a/src/server/routes/playlists.ts
+++ b/src/server/routes/playlists.ts
@@ -1,34 +1,24 @@
+import { Cron } from 'croner'
 import { Hono } from 'hono'
-import type { GenerationResult } from '@/core/playlists/generator'
-import { generatePlaylist } from '@/core/playlists/generator'
 import type { PlaylistScheduler } from '@/core/playlists/scheduler'
-import { buildStrategyDeps } from '@/core/playlists/strategy-deps'
-import type { PlaylistItem } from '@/core/targets/types'
 import type { Database } from '@/db'
-import type {
-  PlaylistInsert,
-  PlaylistRow,
-  PlaylistTrackInsert,
-  PlaylistTrackRow,
-} from '@/db/queries/playlists'
+import type { PlaylistInsert, PlaylistRow, PlaylistTrackRow } from '@/db/queries/playlists'
 import {
   createPlaylist,
   deletePlaylist,
   getPlaylistsByUser,
   getPlaylistWithTracks,
-  replacePlaylistTracks,
   updatePlaylist,
 } from '@/db/queries/playlists'
 import { getSettings } from '@/db/queries/settings'
-import type { TargetRow } from '@/db/queries/targets'
 import { mergePreferences, type PlaylistConfig, type PlaylistStrategy } from '@/db/schema'
 import type { HonoEnv } from '@/server/types'
 
 export type PlaylistDeps = {
   db: Database
   playlistScheduler: PlaylistScheduler
-  getTargetsByUser: (userId: number) => Promise<TargetRow[]>
-  buildPlaylistTarget: (row: TargetRow) => import('@/core/targets/types').DestinationTarget | null
+  runPlaylistGeneration: (playlistId: number) => Promise<void>
+  restartPlaylistScheduler: () => Promise<void>
 }
 
 const ALLOWED_UPDATE_FIELDS = new Set<string>([
@@ -40,79 +30,6 @@ const ALLOWED_UPDATE_FIELDS = new Set<string>([
   'enabled',
 ])
 
-async function runGeneration(
-  db: Database,
-  playlist: PlaylistRow,
-  deps: PlaylistDeps,
-): Promise<void> {
-  const userId = playlist.userId
-  const strategyDeps = buildStrategyDeps(db, userId ?? null)
-
-  const cfg = playlist.config ?? {
-    size: 25,
-    trackSourcePriority: ['spotify' as const],
-  }
-
-  const generationConfig = {
-    size: cfg.size,
-    genre: cfg.genre,
-    mood: cfg.mood,
-    trackSourcePriority: cfg.trackSourcePriority,
-  }
-
-  const result: GenerationResult = await generatePlaylist(
-    playlist.strategy as PlaylistStrategy,
-    generationConfig,
-    strategyDeps,
-    {}, // no track resolver deps -- tracks come from strategy
-  )
-
-  const trackInserts: PlaylistTrackInsert[] = result.tracks.map((t, i) => ({
-    playlistId: playlist.id,
-    artistName: t.artistName,
-    trackName: t.trackName ?? null,
-    mbid: t.mbid ?? null,
-    spotifyUri: t.spotifyUri ?? null,
-    deezerId: t.deezerId ?? null,
-    localPath: t.localPath ?? null,
-    position: i,
-  }))
-
-  await replacePlaylistTracks(db, playlist.id, trackInserts)
-  await updatePlaylist(db, playlist.id, {
-    lastGeneratedAt: new Date(),
-    trackCount: result.tracks.length,
-  })
-
-  // Push to configured targets if any
-  if (playlist.targetIds.length > 0 && userId != null) {
-    const targetRows = await deps.getTargetsByUser(userId)
-    const enabledTargetRows = targetRows.filter(
-      (r) => r.enabled && playlist.targetIds.includes(r.id),
-    )
-
-    const playlistItems: PlaylistItem[] = result.tracks.map((t) => ({
-      artistName: t.artistName,
-      artistMbid: t.mbid ?? '',
-      trackName: t.trackName ?? undefined,
-      trackMbid: t.mbid ?? undefined,
-    }))
-
-    for (const targetRow of enabledTargetRows) {
-      const target = deps.buildPlaylistTarget(targetRow)
-      if (!target?.createPlaylist) continue
-      try {
-        await target.createPlaylist(playlist.name, playlistItems)
-      } catch (err: unknown) {
-        console.error(
-          `[playlists] Failed to push to target ${targetRow.type}(${targetRow.id}):`,
-          err,
-        )
-      }
-    }
-  }
-}
-
 export function playlistRoutes(deps: PlaylistDeps) {
   const router = new Hono<HonoEnv>()
   const { db } = deps
@@ -122,12 +39,25 @@ export function playlistRoutes(deps: PlaylistDeps) {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    const next = deps.playlistScheduler.nextRun()
     const settings = await getSettings(db)
     const prefs = mergePreferences(settings?.preferences as Record<string, unknown> | null)
+    const playlists = await getPlaylistsByUser(db, userId)
+    const jobsByName = new Map(deps.playlistScheduler.listJobs().map((job) => [job.name, job]))
+    const nextRuns = playlists
+      .map((playlist) => jobsByName.get(`playlist-${playlist.id}`)?.nextRun ?? null)
+      .filter((run): run is Date => run instanceof Date)
+      .sort((a, b) => a.getTime() - b.getTime())
+    const scheduledCrons = [
+      ...new Set(
+        playlists
+          .map((playlist) => playlist.schedule)
+          .filter((cron): cron is string => Boolean(cron)),
+      ),
+    ]
+
     return c.json({
-      nextRun: next ? next.toISOString() : null,
-      cron: prefs.playlistSchedule ?? null,
+      nextRun: nextRuns[0]?.toISOString() ?? null,
+      cron: scheduledCrons.length === 1 ? scheduledCrons[0] : null,
       enabled: prefs.playlistEnabled ?? false,
     })
   })
@@ -160,6 +90,13 @@ export function playlistRoutes(deps: PlaylistDeps) {
     if (!validStrategies.includes(strategy)) {
       return c.json({ error: `strategy must be one of: ${validStrategies.join(', ')}` }, 400)
     }
+    if (body.schedule != null && typeof body.schedule === 'string') {
+      try {
+        new Cron(body.schedule, { maxRuns: 0 })
+      } catch {
+        return c.json({ error: 'Invalid schedule cron expression' }, 400)
+      }
+    }
 
     const data: PlaylistInsert = {
       name,
@@ -172,6 +109,7 @@ export function playlistRoutes(deps: PlaylistDeps) {
     }
 
     const row = await createPlaylist(db, data)
+    await deps.restartPlaylistScheduler()
     return c.json(row, 201)
   })
 
@@ -210,7 +148,16 @@ export function playlistRoutes(deps: PlaylistDeps) {
       }
     }
 
+    if (Object.hasOwn(update, 'schedule') && update.schedule != null) {
+      try {
+        new Cron(String(update.schedule), { maxRuns: 0 })
+      } catch {
+        return c.json({ error: 'Invalid schedule cron expression' }, 400)
+      }
+    }
+
     await updatePlaylist(db, id, update)
+    await deps.restartPlaylistScheduler()
     return c.json({ updated: true })
   })
 
@@ -227,6 +174,7 @@ export function playlistRoutes(deps: PlaylistDeps) {
     if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
 
     await deletePlaylist(db, id)
+    await deps.restartPlaylistScheduler()
     return c.json({ deleted: true })
   })
 
@@ -242,11 +190,9 @@ export function playlistRoutes(deps: PlaylistDeps) {
     if (!result) return c.json({ error: 'Not found' }, 404)
     if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
 
-    const playlist = result.playlist
-
     // Fire-and-forget
     Promise.resolve()
-      .then(() => runGeneration(db, playlist, deps))
+      .then(() => deps.runPlaylistGeneration(id))
       .catch((err: unknown) => {
         console.error(`[playlists] Generation failed for playlist ${id}:`, err)
       })

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -229,6 +229,10 @@ export function settingsRoutes(deps: AppDependencies) {
       }
     }
 
+    if (prefs?.playlistEnabled !== undefined || prefs?.playlistSchedule !== undefined) {
+      await deps.restartPlaylistScheduler()
+    }
+
     const response = await buildSettingsResponse(deps, userId, isAdmin)
     if (!response) {
       return c.json({ error: 'Settings not found' }, 404)

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -10,7 +10,6 @@ const ALLOWED_UPDATE_FIELDS = new Set([
   'maxArtistsPerRun',
   'listenerRange',
   'cron',
-  'action',
   'scoreThreshold',
   'scoringWeightPreset',
   'scoringWeightOverrides',
@@ -193,8 +192,8 @@ export function subscriptionRoutes(deps: AppDependencies) {
       enabled: typeof body.enabled === 'boolean' ? body.enabled : true,
       maxArtistsPerRun:
         typeof body.maxArtistsPerRun === 'number' ? body.maxArtistsPerRun : undefined,
-      action: typeof body.action === 'string' ? body.action : undefined,
-      scoreThreshold: typeof body.scoreThreshold === 'number' ? body.scoreThreshold : undefined,
+      action: 'add_to_recommendations',
+      scoreThreshold: undefined,
       listenerRange:
         body.listenerRange && typeof body.listenerRange === 'object'
           ? (body.listenerRange as { min?: number; max?: number })
@@ -273,6 +272,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
         update[key] = (body as Record<string, unknown>)[key]
       }
     }
+    update.action = 'add_to_recommendations'
 
     if (Object.hasOwn(update, 'cron') && update.cron !== undefined) {
       try {

--- a/src/web/components/subscription-form.tsx
+++ b/src/web/components/subscription-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { CronPicker } from './cron-picker'
 
 export type SubscriptionFormData = {
@@ -37,13 +37,6 @@ const SOURCE_PROVIDERS: ReadonlyArray<{
   { value: 'discogs', label: 'Discogs', capabilities: ['genreArtists'] },
 ]
 
-const ACTIONS = [
-  { value: 'add_to_recommendations', label: 'Add to recommendations' },
-  { value: 'auto_approve', label: 'Auto-approve (above threshold)' },
-  { value: 'auto_add_to_target', label: 'Auto-add to target' },
-  { value: 'notify_only', label: 'Notify only (webhook)' },
-] as const
-
 const WEIGHT_PRESETS = [
   { value: 'default', label: 'Default' },
   { value: 'genre', label: 'Genre-optimized' },
@@ -71,8 +64,6 @@ export function SubscriptionForm({
   const [cron, setCron] = useState(initial?.cron ?? '0 8 * * 0')
   const [enabled, setEnabled] = useState(initial?.enabled ?? true)
   const [maxArtists, setMaxArtists] = useState(initial?.maxArtistsPerRun ?? 20)
-  const [action, setAction] = useState(initial?.action ?? 'add_to_recommendations')
-  const [scoreThreshold, setScoreThreshold] = useState(initial?.scoreThreshold ?? null)
   const [weightPreset, setWeightPreset] = useState(
     initial?.scoringWeightPreset ??
       ((initial?.sourceType ?? 'genre') === 'similar' ? 'default' : 'genre'),
@@ -80,13 +71,19 @@ export function SubscriptionForm({
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  // Reset providers when source type changes (only show relevant ones)
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reset providers on source type change
-  useEffect(() => {
-    const cap = sourceType === 'similar' ? 'similarArtists' : 'genreArtists'
-    const relevant = SOURCE_PROVIDERS.filter((p) => p.capabilities.includes(cap))
-    setProviders(configuredSources.filter((id) => relevant.some((p) => p.value === id)))
-  }, [sourceType])
+  function handleSourceTypeChange(nextType: string) {
+    setSourceType(nextType)
+    const capability = nextType === 'similar' ? 'similarArtists' : 'genreArtists'
+    const relevant = configuredSources.filter((id) =>
+      SOURCE_PROVIDERS.some(
+        (provider) => provider.value === id && provider.capabilities.includes(capability),
+      ),
+    )
+    setProviders((prev) => {
+      const kept = prev.filter((id) => relevant.includes(id))
+      return kept.length > 0 ? kept : relevant
+    })
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -127,8 +124,8 @@ export function SubscriptionForm({
         cron,
         enabled,
         maxArtistsPerRun: maxArtists,
-        action,
-        scoreThreshold: action === 'auto_approve' ? (scoreThreshold ?? 0.7) : null,
+        action: 'add_to_recommendations',
+        scoreThreshold: null,
         scoringWeightPreset: weightPreset,
       })
     } catch (err: unknown) {
@@ -187,7 +184,7 @@ export function SubscriptionForm({
             <select
               id="sub-source-type"
               value={sourceType}
-              onChange={(e) => setSourceType(e.target.value)}
+              onChange={(e) => handleSourceTypeChange(e.target.value)}
               className="w-full px-3 py-2 bg-surface border border-border rounded text-sm text-text focus:border-accent focus:outline-none"
             >
               {SOURCE_TYPES.map((t) => (
@@ -294,44 +291,6 @@ export function SubscriptionForm({
               className="w-24 px-3 py-2 bg-surface border border-border rounded text-sm text-text focus:border-accent focus:outline-none"
             />
           </div>
-
-          {/* Action */}
-          <div>
-            <label htmlFor="sub-action" className="block text-sm font-medium text-text mb-1">
-              Action
-            </label>
-            <select
-              id="sub-action"
-              value={action}
-              onChange={(e) => setAction(e.target.value)}
-              className="w-full px-3 py-2 bg-surface border border-border rounded text-sm text-text focus:border-accent focus:outline-none"
-            >
-              {ACTIONS.map((a) => (
-                <option key={a.value} value={a.value}>
-                  {a.label}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {/* Score threshold (for auto-approve action) */}
-          {action === 'auto_approve' && (
-            <div>
-              <label htmlFor="sub-threshold" className="block text-sm font-medium text-text mb-1">
-                Score threshold (0-1)
-              </label>
-              <input
-                id="sub-threshold"
-                type="number"
-                min={0}
-                max={1}
-                step={0.05}
-                value={scoreThreshold ?? 0.7}
-                onChange={(e) => setScoreThreshold(Number(e.target.value))}
-                className="w-24 px-3 py-2 bg-surface border border-border rounded text-sm text-text focus:border-accent focus:outline-none"
-              />
-            </div>
-          )}
 
           {/* Weight preset */}
           <div>

--- a/src/web/pages/playlists.tsx
+++ b/src/web/pages/playlists.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Plus } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { Hint } from '../components/hint'
 import { PlaylistCard } from '../components/playlist-card'
@@ -95,6 +96,8 @@ function SkeletonGrid() {
 
 export function PlaylistsPage() {
   const queryClient = useQueryClient()
+  const location = useLocation()
+  const navigate = useNavigate()
   const [formMode, setFormMode] = useState<'create' | 'edit' | null>(null)
   const [editingPlaylist, setEditingPlaylist] = useState<PlaylistRow | null>(null)
 
@@ -111,6 +114,18 @@ export function PlaylistsPage() {
     queryKey: ['playlists', 'scheduler'],
     queryFn: getPlaylistScheduler,
   })
+
+  useEffect(() => {
+    const editId = (location.state as { editId?: number } | null)?.editId
+    if (!editId || playlists.length === 0) return
+
+    const playlist = playlists.find((row) => row.id === editId)
+    if (!playlist) return
+
+    setEditingPlaylist(playlist)
+    setFormMode('edit')
+    navigate(location.pathname, { replace: true, state: null })
+  }, [location.pathname, location.state, navigate, playlists])
 
   function openCreate() {
     setEditingPlaylist(null)

--- a/src/web/pages/subscriptions.tsx
+++ b/src/web/pages/subscriptions.tsx
@@ -175,14 +175,7 @@ function SubscriptionCard({
     return sub.sourceType
   })()
 
-  const actionLabel =
-    sub.action === 'auto_approve'
-      ? 'Auto-approve'
-      : sub.action === 'auto_add_to_target'
-        ? 'Auto-add'
-        : sub.action === 'notify_only'
-          ? 'Notify only'
-          : 'Add to queue'
+  const actionLabel = 'Add to recommendations'
 
   return (
     <div className="bg-surface border border-border rounded-lg">

--- a/tests/core/clients/bandcamp.test.ts
+++ b/tests/core/clients/bandcamp.test.ts
@@ -7,25 +7,32 @@ import { createBandcampClient } from '@/core/clients/bandcamp'
 let server: http.Server
 let baseUrl: string
 
-// Sample Bandcamp-like HTML with band result items
+// Sample current Bandcamp-like HTML with artist result items
 const SAMPLE_HTML_TWO_BANDS = `
 <!DOCTYPE html>
 <html>
 <body>
 <ul class="result-items">
-  <li class="searchresult band" itemtype="b">
+  <li class="searchresult data-search" data-search='{"type":"b","id":1}'>
     <div class="result-info">
       <div class="heading">
-        <a href="https://portishead.bandcamp.com">Portishead</a>
+        <a href="https://portishead.bandcamp.com/album/live-at-roseland?from=search">Portishead</a>
       </div>
-      <div class="genre">trip-hop</div>
+      <div class="itemurl">
+        <a href="https://portishead.bandcamp.com/?from=search">https://portishead.bandcamp.com/?from=search</a>
+      </div>
+      <div class="itemtype">ARTIST</div>
+      <div class="genre">genre: trip-hop</div>
       <img src="https://f4.bcbits.com/portishead_thumb.jpg" />
     </div>
   </li>
-  <li class="searchresult band" itemtype="b">
+  <li class="searchresult data-search" data-search='{"type":"b","id":2}'>
     <div class="result-info">
       <div class="heading">
         <a href="https://massiveattack.bandcamp.com">Massive Attack</a>
+      </div>
+      <div class="itemurl">
+        <a href="https://massiveattack.bandcamp.com/">https://massiveattack.bandcamp.com/</a>
       </div>
       <div class="genre">electronic</div>
     </div>
@@ -38,9 +45,10 @@ const SAMPLE_HTML_TWO_BANDS = `
 // HTML with a non-band result (album, itemtype=a) mixed in
 const SAMPLE_HTML_MIXED = `
 <ul>
-  <li class="searchresult album" itemtype="a">
+  <li class="searchresult album" data-search='{"type":"a","id":10}'>
     <div class="result-info">
       <div class="heading"><a href="https://portishead.bandcamp.com/album/dummy">Dummy</a></div>
+      <div class="itemtype">ALBUM</div>
     </div>
   </li>
   <li class="searchresult band" itemtype="b">
@@ -110,7 +118,7 @@ afterAll(() => {
 
 describe('createBandcampClient', () => {
   describe('searchArtists(query, limit)', () => {
-    it('parses band results from HTML', async () => {
+    it('parses artist results from current Bandcamp HTML', async () => {
       const client = createBandcampClient({ baseUrl })
       const results = await client.searchArtists('portishead')
       expect(results).toHaveLength(2)
@@ -122,12 +130,12 @@ describe('createBandcampClient', () => {
       })
     })
 
-    it('returns genre and imageUrl as optional fields', async () => {
+    it('normalizes item URLs and keeps genre and imageUrl optional', async () => {
       const client = createBandcampClient({ baseUrl })
       const results = await client.searchArtists('portishead')
-      // Second result has genre but no image
       expect(results[1]).toMatchObject({
         name: 'Massive Attack',
+        url: 'https://massiveattack.bandcamp.com',
         genre: 'electronic',
       })
       expect(results[1]?.imageUrl).toBeUndefined()

--- a/tests/core/playlists/generator.test.ts
+++ b/tests/core/playlists/generator.test.ts
@@ -203,6 +203,15 @@ describe('mood_mix strategy', () => {
     expect(lower.map((a) => a.name)).toEqual(upper.map((a) => a.name))
   })
 
+  it('matches alias moods like d&d against adjacent genre tags', async () => {
+    const deps = makeStrategyDeps()
+    const impl = getStrategy('mood_mix')
+
+    const artists = await impl.selectArtists(deps, { size: 9, mood: 'd&d' })
+
+    expect(artists.map((artist) => artist.name)).toContain('Boards of Canada')
+  })
+
   it('returns all artists sorted by score when mood is not provided', async () => {
     const deps = makeStrategyDeps()
     const impl = getStrategy('mood_mix')

--- a/tests/core/playlists/scheduler.test.ts
+++ b/tests/core/playlists/scheduler.test.ts
@@ -3,36 +3,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PlaylistScheduler } from '@/core/playlists/scheduler'
 
-// Mock croner so tests don't run real timers
-vi.mock('croner', () => {
-  class MockCron {
-    private _nextRun: Date | null
-
-    constructor(
-      _expression: string,
-      private fn: () => Promise<void>,
-    ) {
-      // Schedule a next run 1 minute from now
-      this._nextRun = new Date(Date.now() + 60_000)
-    }
-
-    stop() {
-      this._nextRun = null
-    }
-
-    nextRun(): Date | null {
-      return this._nextRun
-    }
-
-    // Test helper: manually trigger the cron callback
-    async trigger() {
-      await this.fn()
-    }
-  }
-
-  return { Cron: MockCron }
-})
-
 describe('PlaylistScheduler', () => {
   let scheduler: PlaylistScheduler
 
@@ -41,55 +11,75 @@ describe('PlaylistScheduler', () => {
   })
 
   afterEach(() => {
-    scheduler.stop()
+    scheduler.stopAll()
   })
 
-  it('starts and reports a next run time', () => {
-    const runFn = vi.fn(async () => {})
-    scheduler.start('0 6 * * 1', runFn)
+  it('adds named jobs and exposes them via has()', () => {
+    scheduler.schedule('playlist-1', '0 6 * * 1', async () => {})
 
-    const next = scheduler.nextRun()
+    expect(scheduler.has('playlist-1')).toBe(true)
+  })
+
+  it('replaces an existing job with the same name', () => {
+    scheduler.schedule('playlist-1', '0 6 * * 1', async () => {})
+    scheduler.schedule('playlist-1', '0 8 * * 0', async () => {})
+
+    expect(scheduler.listJobs()).toHaveLength(1)
+    expect(scheduler.listJobs()[0]?.expression).toBe('0 8 * * 0')
+  })
+
+  it('returns the next run for a named job', () => {
+    scheduler.schedule('playlist-1', '0 6 * * 1', async () => {})
+
+    const next = scheduler.nextRun('playlist-1')
+
     expect(next).toBeInstanceOf(Date)
-    expect(next?.getTime()).toBeGreaterThan(Date.now())
   })
 
-  it('nextRun returns null before start', () => {
-    expect(scheduler.nextRun()).toBeNull()
+  it('returns the earliest next run when called without a name', () => {
+    scheduler.schedule('playlist-1', '0 6 * * 1', async () => {})
+    scheduler.schedule('playlist-2', '0 8 * * 0', async () => {})
+
+    const earliest = scheduler.nextRun()
+    const allRuns = scheduler
+      .listJobs()
+      .map((job) => job.nextRun)
+      .filter((run): run is Date => run instanceof Date)
+      .sort((a, b) => a.getTime() - b.getTime())
+
+    expect(earliest?.toISOString()).toBe(allRuns[0]?.toISOString())
   })
 
-  it('stop clears the job', () => {
-    const runFn = vi.fn(async () => {})
-    scheduler.start('0 6 * * 1', runFn)
-    expect(scheduler.nextRun()).not.toBeNull()
+  it('removes a job cleanly', () => {
+    scheduler.schedule('playlist-1', '0 6 * * 1', async () => {})
 
-    scheduler.stop()
-    expect(scheduler.nextRun()).toBeNull()
+    scheduler.remove('playlist-1')
+
+    expect(scheduler.has('playlist-1')).toBe(false)
+    expect(scheduler.nextRun('playlist-1')).toBeNull()
   })
 
-  it('start replaces an existing job', () => {
-    const fn1 = vi.fn(async () => {})
-    const fn2 = vi.fn(async () => {})
+  it('stopAll clears every scheduled playlist job', () => {
+    scheduler.schedule('playlist-1', '0 6 * * 1', async () => {})
+    scheduler.schedule('playlist-2', '0 8 * * 0', async () => {})
 
-    scheduler.start('0 6 * * 1', fn1)
-    const first = scheduler.nextRun()
+    scheduler.stopAll()
 
-    scheduler.start('0 7 * * 2', fn2)
-    const second = scheduler.nextRun()
-
-    // Both return a Date -- the job was replaced
-    expect(first).toBeInstanceOf(Date)
-    expect(second).toBeInstanceOf(Date)
+    expect(scheduler.listJobs()).toEqual([])
   })
 
-  it('swallows errors thrown by the run function', async () => {
-    const errorFn = vi.fn(async () => {
+  it('swallows callback errors when the job is triggered', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    scheduler.schedule('playlist-1', '* * * * * *', async () => {
       throw new Error('boom')
     })
 
-    scheduler.start('0 6 * * 1', errorFn)
+    const internalJob = (
+      scheduler as unknown as { jobs: Map<string, { cron: { trigger: () => Promise<void> } }> }
+    ).jobs.get('playlist-1')
 
-    // Trigger the cron via the mock helper -- should not throw
-    const job = (scheduler as unknown as { job: { trigger: () => Promise<void> } }).job
-    await expect(job.trigger()).resolves.toBeUndefined()
+    await expect(internalJob?.cron.trigger()).resolves.toBeUndefined()
+
+    consoleSpy.mockRestore()
   })
 })

--- a/tests/core/plugins/spotify.test.ts
+++ b/tests/core/plugins/spotify.test.ts
@@ -27,6 +27,7 @@ describe('createSpotifySource()', () => {
           playedAt: '2025-01-15T10:25:00Z',
         },
       ]),
+      searchTracks: vi.fn().mockResolvedValue([]),
       testConnection: vi.fn().mockResolvedValue({
         success: true,
         message: 'Connected to Spotify as testuser',

--- a/tests/core/search/enrich.test.ts
+++ b/tests/core/search/enrich.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest'
+import { enrichSearchResultsWithImages } from '@/core/search/enrich'
+import type { MergedSearchResult } from '@/core/search/multi-source'
+
+function makeResult(overrides: Partial<MergedSearchResult> = {}): MergedSearchResult {
+  return {
+    name: 'Scorpions',
+    mbid: 'mbid-1',
+    images: [],
+    genres: [],
+    sources: [{ id: 'musicbrainz' }],
+    inLibrary: false,
+    inRecommendations: false,
+    ...overrides,
+  }
+}
+
+describe('enrichSearchResultsWithImages', () => {
+  it('uses cached images before falling back to Lidarr', async () => {
+    const lookupLidarrImage = vi.fn().mockResolvedValue(undefined)
+
+    const results = await enrichSearchResultsWithImages([makeResult()], {
+      getCachedImages: async () => new Map([['mbid-1', 'https://img.example/cache.jpg']]),
+      lookupLidarrImage,
+    })
+
+    expect(results[0]?.images).toEqual([{ url: 'https://img.example/cache.jpg', source: 'cache' }])
+    expect(lookupLidarrImage).not.toHaveBeenCalled()
+  })
+
+  it('uses Lidarr when the cache is empty and stores the result', async () => {
+    const cacheImage = vi.fn().mockResolvedValue(undefined)
+
+    const results = await enrichSearchResultsWithImages([makeResult()], {
+      getCachedImages: async () => new Map(),
+      lookupLidarrImage: async () => 'https://img.example/lidarr.jpg',
+      cacheImage,
+    })
+
+    expect(results[0]?.images).toEqual([
+      { url: 'https://img.example/lidarr.jpg', source: 'lidarr' },
+    ])
+    expect(cacheImage).toHaveBeenCalledWith('mbid-1', 'https://img.example/lidarr.jpg')
+  })
+
+  it('leaves existing images untouched', async () => {
+    const existing = makeResult({
+      images: [{ url: 'https://img.example/existing.jpg', source: 'deezer' }],
+    })
+
+    const results = await enrichSearchResultsWithImages([existing], {
+      getCachedImages: async () => new Map(),
+      lookupLidarrImage: async () => 'https://img.example/lidarr.jpg',
+    })
+
+    expect(results[0]?.images).toEqual([
+      { url: 'https://img.example/existing.jpg', source: 'deezer' },
+    ])
+  })
+})

--- a/tests/core/search/multi-source.test.ts
+++ b/tests/core/search/multi-source.test.ts
@@ -172,6 +172,41 @@ describe('multiSourceSearch', () => {
     expect(results[1]?.name).toBe('Artist B')
   })
 
+  it('keeps the most probable exact match ahead of noisier multi-source matches', async () => {
+    const exact: SearchResult = {
+      name: 'Scorpions',
+      mbid: mbid1,
+      images: [],
+      genres: ['rock'],
+      sourceId: 'musicbrainz',
+    }
+    const noisyA: SearchResult = {
+      name: 'Scorpions Tribute Band',
+      mbid: mbid2,
+      images: [{ url: 'https://img.example/noisy.jpg', source: 'deezer' }],
+      genres: ['rock'],
+      listeners: 500_000,
+      sourceId: 'deezer',
+    }
+    const noisyB: SearchResult = {
+      name: 'Scorpions Tribute Band',
+      mbid: mbid2,
+      images: [],
+      genres: ['hard rock'],
+      sourceId: 'bandcamp',
+    }
+
+    const results = await multiSourceSearch('scorpions', [
+      makeSource('musicbrainz', [exact]),
+      makeSource('deezer', [noisyA]),
+      makeSource('bandcamp', [noisyB]),
+    ])
+
+    expect(results[0]?.name).toBe('Scorpions')
+    expect(results[1]?.name).toBe('Scorpions Tribute Band')
+    expect(results[1]?.sources).toHaveLength(2)
+  })
+
   it('respects limit', async () => {
     const manyResults: SearchResult[] = Array.from({ length: 30 }, (_, i) => ({
       name: `Artist ${i}`,

--- a/tests/server/middleware/auth.test.ts
+++ b/tests/server/middleware/auth.test.ts
@@ -34,6 +34,7 @@ function makeDeps() {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',

--- a/tests/server/routes/analytics.test.ts
+++ b/tests/server/routes/analytics.test.ts
@@ -36,6 +36,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',

--- a/tests/server/routes/auth.test.ts
+++ b/tests/server/routes/auth.test.ts
@@ -47,6 +47,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async (data) => ({
       id: 1,
       username: data.username,

--- a/tests/server/routes/dashboard.test.ts
+++ b/tests/server/routes/dashboard.test.ts
@@ -44,6 +44,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',

--- a/tests/server/routes/genres.test.ts
+++ b/tests/server/routes/genres.test.ts
@@ -118,6 +118,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',

--- a/tests/server/routes/health.test.ts
+++ b/tests/server/routes/health.test.ts
@@ -32,6 +32,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',

--- a/tests/server/routes/library.test.ts
+++ b/tests/server/routes/library.test.ts
@@ -89,6 +89,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',

--- a/tests/server/routes/pipeline.test.ts
+++ b/tests/server/routes/pipeline.test.ts
@@ -48,6 +48,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',

--- a/tests/server/routes/playlists.test.ts
+++ b/tests/server/routes/playlists.test.ts
@@ -34,8 +34,11 @@ const mockTrack = {
 }
 
 const mockPlaylistScheduler = {
-  start: vi.fn(),
-  stop: vi.fn(),
+  schedule: vi.fn(),
+  remove: vi.fn(),
+  has: vi.fn(() => false),
+  listJobs: vi.fn(() => [] as Array<{ name: string; expression: string; nextRun: Date | null }>),
+  stopAll: vi.fn(),
   nextRun: vi.fn(() => null as Date | null),
 }
 
@@ -50,8 +53,8 @@ function makeDeps(overrides: Partial<PlaylistDeps> = {}): PlaylistDeps {
   return {
     db: mockDb as unknown as PlaylistDeps['db'],
     playlistScheduler: mockPlaylistScheduler as unknown as PlaylistDeps['playlistScheduler'],
-    getTargetsByUser: vi.fn().mockResolvedValue([]),
-    buildPlaylistTarget: vi.fn().mockReturnValue(null),
+    runPlaylistGeneration: vi.fn().mockResolvedValue(undefined),
+    restartPlaylistScheduler: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   }
 }
@@ -95,6 +98,7 @@ vi.mock('@/db/queries/settings', () => ({
 beforeEach(async () => {
   vi.clearAllMocks()
   mockPlaylistScheduler.nextRun.mockReturnValue(null)
+  mockPlaylistScheduler.listJobs.mockReturnValue([])
 
   const {
     createPlaylist,
@@ -137,7 +141,13 @@ describe('GET /api/playlists/scheduler', () => {
       makeDeps({
         playlistScheduler: {
           ...mockPlaylistScheduler,
-          nextRun: () => nextDate,
+          listJobs: () => [
+            {
+              name: 'playlist-1',
+              expression: '0 6 * * 1',
+              nextRun: nextDate,
+            },
+          ],
         } as unknown as PlaylistDeps['playlistScheduler'],
       }),
       USER_ID,
@@ -173,7 +183,8 @@ describe('GET /api/playlists', () => {
 
 describe('POST /api/playlists', () => {
   it('creates a playlist with valid body', async () => {
-    const app = createTestApp(makeDeps(), USER_ID)
+    const deps = makeDeps()
+    const app = createTestApp(deps, USER_ID)
     const res = await app.request('/api/playlists', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -182,6 +193,7 @@ describe('POST /api/playlists', () => {
     expect(res.status).toBe(201)
     const body = (await res.json()) as { id: number }
     expect(typeof body.id).toBe('number')
+    expect(deps.restartPlaylistScheduler).toHaveBeenCalledOnce()
   })
 
   it('returns 400 when name is missing', async () => {
@@ -200,6 +212,16 @@ describe('POST /api/playlists', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'My Mix', strategy: 'not_a_strategy' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for invalid schedule cron', async () => {
+    const app = createTestApp(makeDeps(), USER_ID)
+    const res = await app.request('/api/playlists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'My Mix', strategy: 'weekly_digest', schedule: 'not a cron' }),
     })
     expect(res.status).toBe(400)
   })
@@ -240,7 +262,8 @@ describe('GET /api/playlists/:id', () => {
 
 describe('PATCH /api/playlists/:id', () => {
   it('updates allowed fields for owner', async () => {
-    const app = createTestApp(makeDeps(), USER_ID)
+    const deps = makeDeps()
+    const app = createTestApp(deps, USER_ID)
     const res = await app.request('/api/playlists/1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -249,6 +272,7 @@ describe('PATCH /api/playlists/:id', () => {
     expect(res.status).toBe(200)
     const body = (await res.json()) as { updated: boolean }
     expect(body.updated).toBe(true)
+    expect(deps.restartPlaylistScheduler).toHaveBeenCalledOnce()
   })
 
   it('returns 403 for non-owner', async () => {
@@ -264,11 +288,13 @@ describe('PATCH /api/playlists/:id', () => {
 
 describe('DELETE /api/playlists/:id', () => {
   it('deletes playlist for owner', async () => {
-    const app = createTestApp(makeDeps(), USER_ID)
+    const deps = makeDeps()
+    const app = createTestApp(deps, USER_ID)
     const res = await app.request('/api/playlists/1', { method: 'DELETE' })
     expect(res.status).toBe(200)
     const body = (await res.json()) as { deleted: boolean }
     expect(body.deleted).toBe(true)
+    expect(deps.restartPlaylistScheduler).toHaveBeenCalledOnce()
   })
 
   it('returns 403 for non-owner', async () => {
@@ -280,11 +306,13 @@ describe('DELETE /api/playlists/:id', () => {
 
 describe('POST /api/playlists/:id/generate', () => {
   it('returns 202 and fires generation for owner', async () => {
-    const app = createTestApp(makeDeps(), USER_ID)
+    const deps = makeDeps()
+    const app = createTestApp(deps, USER_ID)
     const res = await app.request('/api/playlists/1/generate', { method: 'POST' })
     expect(res.status).toBe(202)
     const body = (await res.json()) as { status: string }
     expect(body.status).toBe('generating')
+    expect(deps.runPlaylistGeneration).toHaveBeenCalledWith(1)
   })
 
   it('returns 403 for non-owner', async () => {

--- a/tests/server/routes/recommendations.test.ts
+++ b/tests/server/routes/recommendations.test.ts
@@ -94,6 +94,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -53,6 +53,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',
@@ -238,6 +239,18 @@ describe('PATCH /api/settings', () => {
     })
     expect(res.status).toBe(200)
     expect(restartScheduler).not.toHaveBeenCalled()
+  })
+
+  it('restarts playlist scheduling when playlist preferences change', async () => {
+    const restartPlaylistScheduler = vi.fn(async () => {})
+    const app = createApp(makeDeps({ restartPlaylistScheduler }))
+    const res = await app.request('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ preferences: { playlistEnabled: true } }),
+    })
+    expect(res.status).toBe(200)
+    expect(restartPlaylistScheduler).toHaveBeenCalledOnce()
   })
 
   it('does not restart scheduler when no preferences in body', async () => {

--- a/tests/server/routes/setup.test.ts
+++ b/tests/server/routes/setup.test.ts
@@ -34,6 +34,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',

--- a/tests/server/routes/subscriptions.test.ts
+++ b/tests/server/routes/subscriptions.test.ts
@@ -95,6 +95,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async () => ({
       id: 1,
       username: 'test',
@@ -255,7 +256,11 @@ describe('POST /api/subscriptions', () => {
     })
     expect(res.status).toBe(201)
     expect(mockSubQueries.createSubscription).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'Test Sub', userId: USER_ID }),
+      expect.objectContaining({
+        name: 'Test Sub',
+        userId: USER_ID,
+        action: 'add_to_recommendations',
+      }),
     )
   })
 

--- a/tests/server/routes/users.test.ts
+++ b/tests/server/routes/users.test.ts
@@ -79,6 +79,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
     getBatch: vi.fn(async () => null),
     getArtistById: vi.fn(async () => null),
     restartScheduler: vi.fn(),
+    restartPlaylistScheduler: vi.fn(),
     createUser: vi.fn(async (data) => ({
       id: 1,
       username: data.username,


### PR DESCRIPTION
## Summary
- rank search results across sources so the most probable match wins instead of source-by-source ordering
- enrich MusicBrainz-backed search results with cached or Lidarr-derived artwork and repair Bandcamp artist scraping
- honor per-playlist schedules, use real track resolution during generation, and clean up misleading subscription settings

## Testing
- bun run test
- bun run typecheck
- bun run lint