### PR TITLE
fix: export playlists and guard dead lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Not just "here are similar artists." Digarr collects your taste from up to 6 sou
 Type "something like Boards of Canada but darker" or "upbeat 90s pop for a road trip" and get instant AI-powered results. No menus, no filters -- just plain English.
 
 ### Auto-Playlists ("Digarr Digest")
-Generate curated playlists from your approved recommendations and push them to Navidrome, Jellyfin, Plex, or Spotify automatically. Four strategies: Weekly Digest, Genre Focus, Mood Mix, and Rediscover (forgotten gems from weeks ago).
+Generate curated playlists from your approved recommendations, download them as M3U/XSPF, or push them to Navidrome, Jellyfin, or Plex automatically. Four strategies: Weekly Digest, Genre Focus, Mood Mix, and Rediscover (forgotten gems from weeks ago).
 
 ### Genre Deep Dive
 Browse your library by genre, then explore three discovery tabs: **Recommended** (approved artists in that genre), **Trending** (recent discoveries), and **Deep Cuts** (hidden gems with low popularity). Preview tracks and queue artists directly from genre pages.
@@ -52,10 +52,11 @@ Editor classics (Tokyo Night, Catppuccin, Dracula, One Dark, Nord, Gruvbox, Sola
 - **Auto-approve** -- automatically add high-scoring recommendations to your targets after each scan
 - **Artist logos** -- fanart.tv clearlogo support via Lidarr, displayed on the dashboard hero and expanded recommendation cards
 - **Subscriptions** -- pluggable adapter system for scheduled discovery from Spotify playlists/charts, Last.fm tags/charts, ListenBrainz feeds, genre searches, and similar-artist seeds
+- **Temporary similar-artist caveat** -- `similar` subscriptions currently need Last.fm as a provider; ListenBrainz-only similar lookups are blocked until that upstream endpoint is available again
 - **Cross-platform search** -- search for artists across Spotify, Deezer, MusicBrainz, TIDAL, and Bandcamp simultaneously with merged, deduplicated results
 
 ### Playlists & Targets
-- **Auto-playlists** -- 4 strategies (Weekly Digest, Genre Focus, Mood Mix, Rediscover) pushed to Navidrome, Jellyfin, Plex, or Spotify on their own schedule
+- **Auto-playlists** -- 4 strategies (Weekly Digest, Genre Focus, Mood Mix, Rediscover) generated on their own schedule, exportable as JSON/CSV/M3U/XSPF, and pushable to Navidrome, Jellyfin, or Plex
 - **Target registry** -- pluggable approval targets: Lidarr (download + monitor with per-user quality/metadata/root folder preferences), Spotify Playlist (OAuth push), Navidrome/Jellyfin/Plex (playlist API)
 - **Export** -- JSON, CSV, M3U, XSPF (with artist images, AI reasoning, streaming links, and MusicBrainz metadata)
 - **Lidarr-optional** -- works without Lidarr in pure discovery mode

--- a/src/core/clients/listenbrainz.ts
+++ b/src/core/clients/listenbrainz.ts
@@ -82,7 +82,7 @@ export function createListenBrainzClient(username: string, token: string) {
       return res.map((a) => ({ name: a.name, score: a.score }))
     } catch (err: unknown) {
       if (err instanceof HttpError && err.status === 404) {
-        return []
+        throw new Error('ListenBrainz similar artists endpoint unavailable (404)')
       }
       throw err
     }

--- a/src/core/playlists/export.ts
+++ b/src/core/playlists/export.ts
@@ -1,0 +1,137 @@
+import type { PlaylistTrackRow } from '@/db/queries/playlists'
+
+export type PlaylistExportFormat = 'json' | 'csv' | 'm3u' | 'xspf'
+
+export type ExportablePlaylistTrack = Pick<
+  PlaylistTrackRow,
+  'artistName' | 'trackName' | 'mbid' | 'spotifyUri' | 'deezerId' | 'localPath' | 'position'
+>
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function escapeCsv(value: string): string {
+  if (!/[",\n]/.test(value)) {
+    return value
+  }
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+function spotifyTrackUrl(uri: string): string {
+  const match = /^spotify:track:(.+)$/.exec(uri)
+  return match ? `https://open.spotify.com/track/${match[1]}` : uri
+}
+
+function fallbackSearchUrl(track: ExportablePlaylistTrack): string {
+  const query = [track.artistName, track.trackName].filter(Boolean).join(' ')
+  return `https://musicbrainz.org/search?query=${encodeURIComponent(query)}&type=recording&method=indexed`
+}
+
+export function getPlaylistTrackLocation(track: ExportablePlaylistTrack): string {
+  if (track.localPath) return track.localPath
+  if (track.spotifyUri) return spotifyTrackUrl(track.spotifyUri)
+  if (track.deezerId) return `https://www.deezer.com/track/${track.deezerId}`
+  if (track.mbid) return `https://musicbrainz.org/recording/${track.mbid}`
+  return fallbackSearchUrl(track)
+}
+
+function getTrackTitle(track: ExportablePlaylistTrack): string {
+  return track.trackName?.trim() || track.artistName
+}
+
+function getTrackLabel(track: ExportablePlaylistTrack): string {
+  return `${track.artistName} - ${getTrackTitle(track)}`
+}
+
+export function exportPlaylistToJson(tracks: ExportablePlaylistTrack[]): string {
+  return JSON.stringify(
+    tracks.map((track) => ({
+      position: track.position,
+      artistName: track.artistName,
+      trackName: track.trackName,
+      mbid: track.mbid,
+      spotifyUri: track.spotifyUri,
+      deezerId: track.deezerId,
+      localPath: track.localPath,
+      location: getPlaylistTrackLocation(track),
+    })),
+    null,
+    2,
+  )
+}
+
+export function exportPlaylistToCsv(tracks: ExportablePlaylistTrack[]): string {
+  const lines = [
+    'position,artist,track,location,mbid,spotifyUri,deezerId,localPath',
+    ...tracks.map((track) =>
+      [
+        track.position,
+        escapeCsv(track.artistName),
+        escapeCsv(track.trackName ?? ''),
+        escapeCsv(getPlaylistTrackLocation(track)),
+        escapeCsv(track.mbid ?? ''),
+        escapeCsv(track.spotifyUri ?? ''),
+        escapeCsv(track.deezerId ?? ''),
+        escapeCsv(track.localPath ?? ''),
+      ].join(','),
+    ),
+  ]
+
+  return lines.join('\n')
+}
+
+export function exportPlaylistToM3u(tracks: ExportablePlaylistTrack[]): string {
+  const lines = ['#EXTM3U']
+
+  for (const track of tracks) {
+    lines.push(`#EXTINF:-1,${getTrackLabel(track)}`)
+    lines.push(getPlaylistTrackLocation(track))
+  }
+
+  return lines.join('\n')
+}
+
+export function exportPlaylistToXspf(
+  tracks: ExportablePlaylistTrack[],
+  options?: { title?: string; creator?: string },
+): string {
+  const title = options?.title ?? 'Digarr Playlist'
+  const creator = options?.creator ?? 'Digarr'
+  const sortedTracks = tracks.slice().sort((a, b) => a.position - b.position)
+
+  const trackList = sortedTracks
+    .map((track) =>
+      [
+        '    <track>',
+        `      <location>${escapeXml(getPlaylistTrackLocation(track))}</location>`,
+        `      <creator>${escapeXml(track.artistName)}</creator>`,
+        `      <title>${escapeXml(getTrackTitle(track))}</title>`,
+        track.mbid
+          ? `      <identifier>${escapeXml(`https://musicbrainz.org/recording/${track.mbid}`)}</identifier>`
+          : null,
+        '    </track>',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    )
+    .join('\n')
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<playlist version="1" xmlns="http://xspf.org/ns/0/">',
+    `  <title>${escapeXml(title)}</title>`,
+    `  <creator>${escapeXml(creator)}</creator>`,
+    tracks.length === 0 ? '  <trackList/>' : '  <trackList>',
+    trackList,
+    tracks.length === 0 ? null : '  </trackList>',
+    '</playlist>',
+  ]
+    .filter(Boolean)
+    .join('\n')
+}

--- a/src/core/search/enrich.ts
+++ b/src/core/search/enrich.ts
@@ -39,11 +39,21 @@ export async function enrichSearchResultsWithImages(
 
   const lookedUp = await Promise.all(
     stillMissing.map(async (result) => {
-      const url = await deps.lookupLidarrImage?.(result.mbid as string)
-      if (!url) return [result.mbid as string, undefined] as const
+      try {
+        const mbid = result.mbid as string
+        const url = await deps.lookupLidarrImage?.(mbid)
+        if (!url) return [mbid, undefined] as const
 
-      await deps.cacheImage?.(result.mbid as string, url)
-      return [result.mbid as string, url] as const
+        try {
+          await deps.cacheImage?.(mbid, url)
+        } catch {
+          // A cache write failure should not block search results.
+        }
+
+        return [mbid, url] as const
+      } catch {
+        return [result.mbid as string, undefined] as const
+      }
     }),
   )
 

--- a/src/server/routes/playlists.ts
+++ b/src/server/routes/playlists.ts
@@ -1,5 +1,12 @@
 import { Cron } from 'croner'
 import { Hono } from 'hono'
+import {
+  exportPlaylistToCsv,
+  exportPlaylistToJson,
+  exportPlaylistToM3u,
+  exportPlaylistToXspf,
+  type PlaylistExportFormat,
+} from '@/core/playlists/export'
 import type { PlaylistScheduler } from '@/core/playlists/scheduler'
 import type { Database } from '@/db'
 import type { PlaylistInsert, PlaylistRow, PlaylistTrackRow } from '@/db/queries/playlists'
@@ -29,6 +36,30 @@ const ALLOWED_UPDATE_FIELDS = new Set<string>([
   'config',
   'enabled',
 ])
+
+const PLAYLIST_EXPORT_CONTENT_TYPES: Record<PlaylistExportFormat, string> = {
+  json: 'application/json',
+  csv: 'text/csv',
+  m3u: 'audio/x-mpegurl',
+  xspf: 'application/xspf+xml',
+}
+
+const PLAYLIST_EXPORTERS: Record<
+  PlaylistExportFormat,
+  (args: { name: string; tracks: PlaylistTrackRow[] }) => string
+> = {
+  json: ({ tracks }) => exportPlaylistToJson(tracks),
+  csv: ({ tracks }) => exportPlaylistToCsv(tracks),
+  m3u: ({ tracks }) => exportPlaylistToM3u(tracks),
+  xspf: ({ name, tracks }) => exportPlaylistToXspf(tracks, { title: name }),
+}
+
+function sanitizeFilename(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
 
 export function playlistRoutes(deps: PlaylistDeps) {
   const router = new Hono<HonoEnv>()
@@ -126,6 +157,37 @@ export function playlistRoutes(deps: PlaylistDeps) {
     if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
 
     return c.json(result)
+  })
+
+  // GET /api/playlists/:id/export/:format
+  router.get('/api/playlists/:id/export/:format', async (c) => {
+    const userId = c.get('userId')
+    if (!userId) return c.json({ error: 'Unauthorized' }, 401)
+
+    const id = Number(c.req.param('id'))
+    if (Number.isNaN(id)) return c.json({ error: 'Invalid id' }, 400)
+
+    const format = c.req.param('format') as PlaylistExportFormat
+    const exporter = PLAYLIST_EXPORTERS[format]
+    const contentType = PLAYLIST_EXPORT_CONTENT_TYPES[format]
+    if (!exporter || !contentType) {
+      return c.json({ error: 'Unsupported format. Use json, csv, m3u, or xspf' }, 400)
+    }
+
+    const result = await getPlaylistWithTracks(db, id)
+    if (!result) return c.json({ error: 'Not found' }, 404)
+    if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
+
+    const tracks = result.tracks.slice().sort((a, b) => a.position - b.position)
+    const filename = sanitizeFilename(result.playlist.name) || `playlist-${id}`
+    const body = exporter({ name: result.playlist.name, tracks })
+
+    return new Response(body, {
+      headers: {
+        'Content-Type': contentType,
+        'Content-Disposition': `attachment; filename="${filename}.${format}"`,
+      },
+    })
   })
 
   // PATCH /api/playlists/:id

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -3,6 +3,9 @@ import { Hono } from 'hono'
 import type { AppDependencies } from '@/server'
 import type { HonoEnv } from '@/server/types'
 
+const LISTENBRAINZ_SIMILAR_ERROR =
+  'ListenBrainz similar-artist lookups are currently unavailable. Add Last.fm or choose a different subscription type.'
+
 const ALLOWED_UPDATE_FIELDS = new Set([
   'name',
   'enabled',
@@ -14,6 +17,45 @@ const ALLOWED_UPDATE_FIELDS = new Set([
   'scoringWeightPreset',
   'scoringWeightOverrides',
 ])
+
+function normalizeProviders(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+function resolveSubscriptionProviders(
+  sourceConfig: Record<string, unknown>,
+  sourceProvider?: string,
+): string[] {
+  const fromConfig = normalizeProviders(sourceConfig.providers)
+  const resolved = fromConfig.length > 0 ? fromConfig : normalizeProviders(sourceProvider)
+  return [...new Set(resolved)]
+}
+
+function getUnsupportedSimilarProviderError(
+  sourceType: string,
+  sourceConfig: Record<string, unknown>,
+  sourceProvider?: string,
+): string | null {
+  if (sourceType !== 'similar') {
+    return null
+  }
+
+  const providers = resolveSubscriptionProviders(sourceConfig, sourceProvider)
+  return providers.length === 1 && providers[0] === 'listenbrainz'
+    ? LISTENBRAINZ_SIMILAR_ERROR
+    : null
+}
 
 export function subscriptionRoutes(deps: AppDependencies) {
   const router = new Hono<HonoEnv>()
@@ -175,6 +217,14 @@ export function subscriptionRoutes(deps: AppDependencies) {
     if (!cron || typeof cron !== 'string') {
       return c.json({ error: 'cron is required' }, 400)
     }
+    const unsupportedProviderError = getUnsupportedSimilarProviderError(
+      sourceType,
+      sourceConfig as Record<string, unknown>,
+      sourceProvider,
+    )
+    if (unsupportedProviderError) {
+      return c.json({ error: unsupportedProviderError }, 400)
+    }
 
     try {
       new Cron(cron, { maxRuns: 0 })
@@ -273,6 +323,21 @@ export function subscriptionRoutes(deps: AppDependencies) {
       }
     }
     update.action = 'add_to_recommendations'
+    const nextSourceConfig =
+      Object.hasOwn(update, 'sourceConfig') &&
+      update.sourceConfig &&
+      typeof update.sourceConfig === 'object' &&
+      !Array.isArray(update.sourceConfig)
+        ? (update.sourceConfig as Record<string, unknown>)
+        : (existing.sourceConfig as Record<string, unknown>)
+    const unsupportedProviderError = getUnsupportedSimilarProviderError(
+      existing.sourceType,
+      nextSourceConfig,
+      existing.sourceProvider,
+    )
+    if (unsupportedProviderError) {
+      return c.json({ error: unsupportedProviderError }, 400)
+    }
 
     if (Object.hasOwn(update, 'cron') && update.cron !== undefined) {
       try {

--- a/src/web/components/subscription-form.tsx
+++ b/src/web/components/subscription-form.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
 import { CronPicker } from './cron-picker'
 
+const LISTENBRAINZ_SIMILAR_ERROR =
+  'ListenBrainz similar-artist lookups are currently unavailable. Add Last.fm or choose a different subscription type.'
+
 export type SubscriptionFormData = {
   name: string
   sourceType: string
@@ -41,6 +44,15 @@ const WEIGHT_PRESETS = [
   { value: 'default', label: 'Default' },
   { value: 'genre', label: 'Genre-optimized' },
 ] as const
+
+function getUnsupportedSimilarProviderError(
+  sourceType: string,
+  providers: string[],
+): string | null {
+  return sourceType === 'similar' && providers.length === 1 && providers[0] === 'listenbrainz'
+    ? LISTENBRAINZ_SIMILAR_ERROR
+    : null
+}
 
 export function SubscriptionForm({
   initial,
@@ -101,6 +113,11 @@ export function SubscriptionForm({
     }
     if (providers.length === 0) {
       setError('Select at least one source')
+      return
+    }
+    const unsupportedProviderError = getUnsupportedSimilarProviderError(sourceType, providers)
+    if (unsupportedProviderError) {
+      setError(unsupportedProviderError)
       return
     }
     setError(null)
@@ -267,6 +284,9 @@ export function SubscriptionForm({
             </div>
             {providers.length === 0 && (
               <p className="text-xs text-reject mt-1">Select at least one source</p>
+            )}
+            {providers.length > 0 && getUnsupportedSimilarProviderError(sourceType, providers) && (
+              <p className="text-xs text-reject mt-1">{LISTENBRAINZ_SIMILAR_ERROR}</p>
             )}
           </div>
 

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -411,13 +411,25 @@ export async function exportRecommendations(
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   })
   if (!response.ok) throw new Error('Export failed')
+  await downloadResponseBlob(
+    response,
+    `digarr-export-${new Date().toISOString().slice(0, 10)}.${format}`,
+  )
+}
+
+async function downloadResponseBlob(response: Response, fallbackFilename: string): Promise<void> {
   const blob = await response.blob()
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = `digarr-export-${new Date().toISOString().slice(0, 10)}.${format}`
+  a.download = getDownloadFilename(response.headers.get('content-disposition'), fallbackFilename)
   a.click()
   URL.revokeObjectURL(url)
+}
+
+function getDownloadFilename(contentDisposition: string | null, fallbackFilename: string): string {
+  const match = /filename="([^"]+)"/.exec(contentDisposition ?? '')
+  return match?.[1] ?? fallbackFilename
 }
 
 // Search
@@ -667,6 +679,18 @@ export const deletePlaylistApi = (id: number) =>
 
 export const generatePlaylistApi = (id: number) =>
   fetchApi<{ status: string }>(`/playlists/${id}/generate`, { method: 'POST' })
+
+export async function exportPlaylistApi(
+  id: number,
+  format: 'json' | 'csv' | 'm3u' | 'xspf',
+): Promise<void> {
+  const token = getStoredToken()
+  const response = await fetch(`${BASE}/playlists/${id}/export/${format}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  })
+  if (!response.ok) throw new Error('Playlist export failed')
+  await downloadResponseBlob(response, `playlist-${id}.${format}`)
+}
 
 export const getPlaylistScheduler = () =>
   fetchApi<{ nextRun: string | null; cron: string | null; enabled: boolean }>(

--- a/src/web/pages/playlist-detail.tsx
+++ b/src/web/pages/playlist-detail.tsx
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
-import { Pencil, Play } from 'lucide-react'
+import { Download, Pencil, Play } from 'lucide-react'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { Hint } from '../components/hint'
 import { Skeleton } from '../components/ui/skeleton'
 import {
+  exportPlaylistApi,
   generatePlaylistApi,
   getPlaylist,
   type PlaylistRow,
@@ -134,6 +135,7 @@ function PlaylistActions({
   onRefetch: () => void
 }) {
   const [generating, setGenerating] = useState(false)
+  const [exporting, setExporting] = useState<string | null>(null)
 
   async function handleGenerate() {
     setGenerating(true)
@@ -148,8 +150,20 @@ function PlaylistActions({
     }
   }
 
+  async function handleExport(format: 'm3u' | 'xspf') {
+    setExporting(format)
+    try {
+      await exportPlaylistApi(playlist.id, format)
+      toast.success(`${format.toUpperCase()} downloaded`)
+    } catch {
+      toast.error('Failed to download playlist')
+    } finally {
+      setExporting(null)
+    }
+  }
+
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 flex-wrap">
       <button
         type="button"
         onClick={handleGenerate}
@@ -175,6 +189,18 @@ function PlaylistActions({
         )}
         {generating ? 'Generating...' : 'Generate Now'}
       </button>
+      {(['m3u', 'xspf'] as const).map((format) => (
+        <button
+          key={format}
+          type="button"
+          onClick={() => handleExport(format)}
+          disabled={exporting !== null}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-surface border border-border rounded-md text-sm text-muted hover:text-text transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          <Download size={14} aria-hidden="true" />
+          {exporting === format ? 'Downloading...' : `Download ${format.toUpperCase()}`}
+        </button>
+      ))}
       <button
         type="button"
         onClick={onEdit}
@@ -272,7 +298,8 @@ export function PlaylistDetailPage() {
 
       <Hint id="playlist-detail-intro-tip" type="inline">
         This playlist was generated from your approved recommendations. Click Generate Now to
-        refresh it with new picks.
+        refresh it with new picks, download it as M3U or XSPF, or add a playlist target to push
+        future runs to Navidrome, Jellyfin, or Plex automatically.
       </Hint>
 
       {/* Actions */}

--- a/tests/core/clients/listenbrainz.test.ts
+++ b/tests/core/clients/listenbrainz.test.ts
@@ -154,13 +154,14 @@ describe('createListenBrainzClient', () => {
       expect(result[0]).toMatchObject({ name: 'Thom Yorke', score: 0.95 })
     })
 
-    it('returns empty array on 404 (endpoint may not exist)', async () => {
+    it('throws a clear error on 404 so callers do not treat it as empty data', async () => {
       const { HttpError } = await import('@/core/clients/http')
       const mbid = 'a74b1b7f-71a5-4011-9441-d0b5e4122711'
       mockGet.mockRejectedValueOnce(new HttpError(404, 'Not Found', `/1/artist/${mbid}/similar`))
       const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
-      const result = await client.getSimilarArtists(mbid)
-      expect(result).toEqual([])
+      await expect(client.getSimilarArtists(mbid)).rejects.toThrow(
+        'ListenBrainz similar artists endpoint unavailable (404)',
+      )
     })
 
     it('re-throws non-404 errors from getSimilarArtists', async () => {

--- a/tests/core/playlists/export.test.ts
+++ b/tests/core/playlists/export.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import {
+  type ExportablePlaylistTrack,
+  exportPlaylistToCsv,
+  exportPlaylistToJson,
+  exportPlaylistToM3u,
+  exportPlaylistToXspf,
+  getPlaylistTrackLocation,
+} from '@/core/playlists/export'
+
+const SAMPLE: ExportablePlaylistTrack[] = [
+  {
+    artistName: 'Radiohead',
+    trackName: 'Creep',
+    mbid: 'mbid-creep',
+    spotifyUri: 'spotify:track:abc123',
+    deezerId: null,
+    localPath: null,
+    position: 0,
+  },
+  {
+    artistName: 'Massive Attack',
+    trackName: 'Teardrop',
+    mbid: 'mbid-teardrop',
+    spotifyUri: null,
+    deezerId: '456',
+    localPath: null,
+    position: 1,
+  },
+  {
+    artistName: 'Biosphere',
+    trackName: null,
+    mbid: null,
+    spotifyUri: null,
+    deezerId: null,
+    localPath: '/music/Biosphere/Substrata/01 - As the Sun Kissed the Horizon.flac',
+    position: 2,
+  },
+]
+
+describe('playlist export helpers', () => {
+  it('prefers local paths, then Spotify, Deezer, and MusicBrainz locations', () => {
+    const [spotifyTrack, deezerTrack, localTrack] = SAMPLE
+    expect(spotifyTrack).toBeDefined()
+    expect(deezerTrack).toBeDefined()
+    expect(localTrack).toBeDefined()
+    expect(getPlaylistTrackLocation(spotifyTrack as ExportablePlaylistTrack)).toBe(
+      'https://open.spotify.com/track/abc123',
+    )
+    expect(getPlaylistTrackLocation(deezerTrack as ExportablePlaylistTrack)).toBe(
+      'https://www.deezer.com/track/456',
+    )
+    expect(getPlaylistTrackLocation(localTrack as ExportablePlaylistTrack)).toBe(
+      '/music/Biosphere/Substrata/01 - As the Sun Kissed the Horizon.flac',
+    )
+  })
+
+  it('exports JSON with resolved locations', () => {
+    const result = exportPlaylistToJson(SAMPLE)
+    expect(result).toContain('"artistName": "Radiohead"')
+    expect(result).toContain('"location": "https://open.spotify.com/track/abc123"')
+  })
+
+  it('exports CSV with track locations', () => {
+    const result = exportPlaylistToCsv(SAMPLE)
+    expect(result).toContain('position,artist,track,location')
+    expect(result).toContain('Massive Attack,Teardrop,https://www.deezer.com/track/456')
+  })
+
+  it('exports M3U entries with artist and track names', () => {
+    const result = exportPlaylistToM3u(SAMPLE)
+    expect(result).toContain('#EXTM3U')
+    expect(result).toContain('#EXTINF:-1,Radiohead - Creep')
+    expect(result).toContain('#EXTINF:-1,Biosphere - Biosphere')
+  })
+
+  it('exports XSPF with playlist metadata and recording identifiers', () => {
+    const result = exportPlaylistToXspf(SAMPLE, { title: 'Night Mix' })
+    expect(result).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(result).toContain('<title>Night Mix</title>')
+    expect(result).toContain('<creator>Massive Attack</creator>')
+    expect(result).toContain(
+      '<identifier>https://musicbrainz.org/recording/mbid-teardrop</identifier>',
+    )
+  })
+})

--- a/tests/core/search/enrich.test.ts
+++ b/tests/core/search/enrich.test.ts
@@ -59,4 +59,30 @@ describe('enrichSearchResultsWithImages', () => {
       { url: 'https://img.example/existing.jpg', source: 'deezer' },
     ])
   })
+
+  it('keeps search results when Lidarr lookup fails', async () => {
+    const results = await enrichSearchResultsWithImages([makeResult()], {
+      getCachedImages: async () => new Map(),
+      lookupLidarrImage: async () => {
+        throw new Error('skyhook unavailable')
+      },
+    })
+
+    expect(results[0]?.name).toBe('Scorpions')
+    expect(results[0]?.images).toEqual([])
+  })
+
+  it('keeps search results when image cache persistence fails', async () => {
+    const results = await enrichSearchResultsWithImages([makeResult()], {
+      getCachedImages: async () => new Map(),
+      lookupLidarrImage: async () => 'https://img.example/lidarr.jpg',
+      cacheImage: async () => {
+        throw new Error('db unavailable')
+      },
+    })
+
+    expect(results[0]?.images).toEqual([
+      { url: 'https://img.example/lidarr.jpg', source: 'lidarr' },
+    ])
+  })
 })

--- a/tests/server/routes/playlists.test.ts
+++ b/tests/server/routes/playlists.test.ts
@@ -260,6 +260,41 @@ describe('GET /api/playlists/:id', () => {
   })
 })
 
+describe('GET /api/playlists/:id/export/:format', () => {
+  it('exports a playlist as M3U for the owner', async () => {
+    const app = createTestApp(makeDeps(), USER_ID)
+    const res = await app.request('/api/playlists/1/export/m3u')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('audio/x-mpegurl')
+    expect(res.headers.get('content-disposition')).toContain('weekly-mix.m3u')
+    const body = await res.text()
+    expect(body).toContain('#EXTM3U')
+    expect(body).toContain('Radiohead - Creep')
+  })
+
+  it('exports a playlist as XSPF for the owner', async () => {
+    const app = createTestApp(makeDeps(), USER_ID)
+    const res = await app.request('/api/playlists/1/export/xspf')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/xspf+xml')
+    const body = await res.text()
+    expect(body).toContain('<?xml')
+    expect(body).toContain('<title>Weekly Mix</title>')
+  })
+
+  it('returns 400 for unsupported export format', async () => {
+    const app = createTestApp(makeDeps(), USER_ID)
+    const res = await app.request('/api/playlists/1/export/xml')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 403 for non-owner export access', async () => {
+    const app = createTestApp(makeDeps(), 999)
+    const res = await app.request('/api/playlists/1/export/m3u')
+    expect(res.status).toBe(403)
+  })
+})
+
 describe('PATCH /api/playlists/:id', () => {
   it('updates allowed fields for owner', async () => {
     const deps = makeDeps()

--- a/tests/server/routes/subscriptions.test.ts
+++ b/tests/server/routes/subscriptions.test.ts
@@ -22,7 +22,7 @@ const mockSub = {
   enabled: true,
   sourceType: 'genre',
   sourceProvider: 'library',
-  sourceConfig: { genreSlug: 'rock' },
+  sourceConfig: { genreSlug: 'rock' } as Record<string, unknown>,
   maxArtistsPerRun: 20,
   listenerRange: null,
   cron: '0 9 * * *',
@@ -288,6 +288,33 @@ describe('POST /api/subscriptions', () => {
     expect(res.status).toBe(400)
   })
 
+  it('rejects similar subscriptions that only use ListenBrainz', async () => {
+    const app = createTestApp(makeDeps(), USER_ID)
+    const res = await app.request('/api/subscriptions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Similar Only',
+        sourceType: 'similar',
+        sourceProvider: 'listenbrainz',
+        sourceConfig: {
+          seedArtists: [{ name: 'Massive Attack' }],
+          providers: ['listenbrainz'],
+        },
+        cron: '0 9 * * *',
+      }),
+    })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        error: expect.stringContaining(
+          'ListenBrainz similar-artist lookups are currently unavailable',
+        ),
+      }),
+    )
+    expect(mockSubQueries.createSubscription).not.toHaveBeenCalled()
+  })
+
   it('returns 401 when not authenticated', async () => {
     const app = createTestApp(makeDeps(), undefined)
     const res = await app.request('/api/subscriptions', {
@@ -359,6 +386,31 @@ describe('PATCH /api/subscriptions/:id', () => {
       body: JSON.stringify({ cron: 'bad-cron' }),
     })
     expect(res.status).toBe(400)
+  })
+
+  it('rejects updates that keep similar subscriptions on ListenBrainz only', async () => {
+    mockSubQueries.getSubscription.mockResolvedValueOnce({
+      ...mockSub,
+      sourceType: 'similar',
+      sourceProvider: 'listenbrainz',
+      sourceConfig: {
+        seedArtists: [{ name: 'Sleep Token' }],
+        providers: ['listenbrainz'],
+      } as Record<string, unknown>,
+    })
+    const app = createTestApp(makeDeps(), USER_ID)
+    const res = await app.request('/api/subscriptions/1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sourceConfig: {
+          seedArtists: [{ name: 'Massive Attack' }],
+          providers: ['listenbrainz'],
+        },
+      }),
+    })
+    expect(res.status).toBe(400)
+    expect(mockSubQueries.updateSubscription).not.toHaveBeenCalled()
   })
 
   it('reschedules in scheduler when cron changes', async () => {


### PR DESCRIPTION
## Summary
- make search image enrichment best-effort so Lidarr image lookup failures do not break `/api/search`
- surface the dead ListenBrainz similar-artists endpoint as an error and block `similar` subscriptions that only use ListenBrainz
- add authenticated playlist export/download support (JSON, CSV, M3U, XSPF) with M3U/XSPF actions on the playlist detail page
- update the README to document playlist exports and the temporary ListenBrainz similar-provider limitation

## Testing
- bun run test tests/core/playlists/export.test.ts tests/core/search/enrich.test.ts tests/core/clients/listenbrainz.test.ts tests/server/routes/playlists.test.ts tests/server/routes/subscriptions.test.ts tests/server/routes/search.test.ts
- bun run typecheck
- bun run lint