### PR TITLE
fix: full review findings -- image gaps, GCM auth tag, settings write order

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Bun](https://img.shields.io/badge/runtime-Bun-f9f1e1?logo=bun)](https://bun.sh)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](deploy/docker/)
-[![Tests](https://img.shields.io/badge/tests-1081_passing-brightgreen)]()
+[![Tests](https://img.shields.io/badge/tests-1110_passing-brightgreen)]()
 [![Release](https://img.shields.io/github/v/tag/iuliandita/digarr?label=release)](https://github.com/iuliandita/digarr/releases)
 
 **AI-powered music discovery for your *arr stack.** Digarr analyzes your listening history from ListenBrainz, Last.fm, Spotify, Plex, Jellyfin, or Discogs, finds similar artists using MusicBrainz and AI, scores and ranks them, and lets you approve recommendations -- optionally adding them straight to Lidarr, pushing them to a Spotify playlist, or generating weekly discovery playlists for your media server.
@@ -52,7 +52,6 @@ Editor classics (Tokyo Night, Catppuccin, Dracula, One Dark, Nord, Gruvbox, Sola
 - **Auto-approve** -- automatically add high-scoring recommendations to your targets after each scan
 - **Artist logos** -- fanart.tv clearlogo support via Lidarr, displayed on the dashboard hero and expanded recommendation cards
 - **Subscriptions** -- pluggable adapter system for scheduled discovery from Spotify playlists/charts, Last.fm tags/charts, ListenBrainz feeds, genre searches, and similar-artist seeds
-- **Temporary similar-artist caveat** -- `similar` subscriptions currently need Last.fm as a provider; ListenBrainz-only similar lookups are blocked until that upstream endpoint is available again
 - **Cross-platform search** -- search for artists across Spotify, Deezer, MusicBrainz, TIDAL, and Bandcamp simultaneously with merged, deduplicated results
 
 ### Playlists & Targets

--- a/src/core/crypto.ts
+++ b/src/core/crypto.ts
@@ -29,7 +29,8 @@ function decryptWithKey(ivStr: string, encStr: string, tagStr: string, key: Buff
   const encrypted = Buffer.from(encStr, 'base64')
   const tag = Buffer.from(tagStr, 'base64')
 
-  const decipher = createDecipheriv(ALGORITHM, key, iv)
+  if (tag.byteLength !== 16) throw new Error('Invalid auth tag length')
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: 16 })
   decipher.setAuthTag(tag)
   return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8')
 }

--- a/src/core/library/health.ts
+++ b/src/core/library/health.ts
@@ -422,17 +422,16 @@ function extractImageUrl(results: unknown[]): string | null {
     if (typeof result !== 'object' || result === null) continue
     const r = result as Record<string, unknown>
 
-    // Look for images array (Lidarr lookup format)
+    // Look for images array (Lidarr lookup format -- remoteUrl is the CDN URL)
     if (Array.isArray(r.images)) {
       for (const img of r.images as Array<Record<string, unknown>>) {
-        if (img.coverType === 'poster' && typeof img.url === 'string') return img.url
+        if (img.coverType === 'poster' && typeof img.remoteUrl === 'string') return img.remoteUrl
       }
       for (const img of r.images as Array<Record<string, unknown>>) {
-        if (img.coverType === 'fanart' && typeof img.url === 'string') return img.url
+        if (img.coverType === 'fanart' && typeof img.remoteUrl === 'string') return img.remoteUrl
       }
-      // Fall back to any image URL
       for (const img of r.images as Array<Record<string, unknown>>) {
-        if (typeof img.url === 'string') return img.url
+        if (img.coverType !== 'clearlogo' && typeof img.remoteUrl === 'string') return img.remoteUrl
       }
     }
 

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -67,12 +67,7 @@ export function pipelineRoutes(deps: AppDependencies) {
         userId ? deps.getEnabledTargetsForUser(userId) : Promise.resolve([]),
       updateRecommendationStatus: (id, status, extra) =>
         deps.updateRecommendationStatus(id, status, extra),
-      warmArtist: deps.skyhookWarmer
-        ? (
-            (warmer) => (mbid: string) =>
-              warmer.warm(mbid)
-          )(deps.skyhookWarmer)
-        : undefined,
+      warmArtist: deps.skyhookWarmer ? (mbid: string) => deps.skyhookWarmer!.warm(mbid) : undefined,
     }
 
     // Fire-and-forget

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -203,12 +203,12 @@ export function settingsRoutes(deps: AppDependencies) {
       }
     }
 
-    if (userId && Object.keys(userUpdate).length > 0) {
-      await updateUserConnections(deps.db, userId, userUpdate)
-    }
-
     if (!isAdmin && Object.keys(globalFields).length > 0) {
       return c.json({ error: 'Admin access required to modify global settings' }, 403)
+    }
+
+    if (userId && Object.keys(userUpdate).length > 0) {
+      await updateUserConnections(deps.db, userId, userUpdate)
     }
 
     if (Object.keys(globalFields).length > 0) {

--- a/tests/core/library/health.test.ts
+++ b/tests/core/library/health.test.ts
@@ -565,7 +565,9 @@ describe('LibraryHealthService', () => {
       await service.runChecks()
 
       const imageUrl = 'https://fanart.tv/img/bjork-poster.jpg'
-      mocks.lookupArtist.mockResolvedValue([{ images: [{ coverType: 'poster', url: imageUrl }] }])
+      mocks.lookupArtist.mockResolvedValue([
+        { images: [{ coverType: 'poster', remoteUrl: imageUrl }] },
+      ])
       mocks.cacheUpdateImageUrl.mockResolvedValue(undefined)
 
       const progress = await service.fixCheck('image-gaps')


### PR DESCRIPTION
## Summary

Fixes from a full codebase review (code review + security audit + slop check + docs sweep).

- **`extractImageUrl` wrong field** (critical bug): used `img.url` (Lidarr proxy URL) instead of `img.remoteUrl` (fanart.tv CDN URL). The "Fix image gaps" action in library health silently did nothing for every artist.
- **GCM auth tag validation** (security): added explicit 16-byte auth tag length check and `authTagLength` option to `createDecipheriv`, preventing acceptance of truncated tags on crafted ciphertext.
- **Settings partial-write** (logic): moved admin check before user connection DB writes in `PATCH /api/settings`, preventing partial-write side effects when non-admin sends mixed user+global fields.
- **IIFE removal** (slop): replaced unnecessary IIFE wrapper for skyhook warmer binding with direct arrow function.
- **README cleanup**: deleted stale "LB similar-artist caveat" and updated test count badge (1081 -> 1110).

## Test plan

- [x] All 1110 tests pass
- [x] Lint clean
- [x] Typecheck clean
- [ ] CI green