### PR TITLE
fix: multi-user dedup, SSRF guard, preference helper, supply chain hardening

### DIFF
--- a/.forgejo/workflows/release.yml
+++ b/.forgejo/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
   docker:
     runs-on: docker
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         env:
           GIT_SSL_NO_VERIFY: "true"
 
       - name: Log in to Forgejo registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -35,7 +35,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
           file: deploy/docker/Dockerfile

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM oven/bun:1.3.11 AS builder
+FROM oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7 AS builder
 WORKDIR /app
 COPY package.json bun.lock* ./
 RUN bun install --frozen-lockfile
@@ -8,7 +8,7 @@ ENV NODE_ENV=production
 RUN bun run build
 
 # Runtime stage -- production deps only
-FROM oven/bun:1.3.11-slim
+FROM oven/bun:1.3.11-slim@sha256:478281fdd196871c7e51ba6a820b7803a8ae97042ec86cdbc2e1c6b6626442d9
 WORKDIR /app
 
 # Non-root user

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -225,7 +225,7 @@ export class PipelineOrchestrator extends EventEmitter {
         stage: 'filter',
         message: `Filtering ${scored.length} scored artists...`,
       })
-      const existingMbids = await db.getExistingRecommendationMbids()
+      const existingMbids = await db.getExistingRecommendationMbids(deps.userId)
       for (const mbid of existingMbids) {
         libraryMbids.add(mbid)
       }

--- a/src/core/pipeline/store.ts
+++ b/src/core/pipeline/store.ts
@@ -2,7 +2,7 @@ import type { ScoredArtist } from '@/core/types'
 
 // Minimal database interface -- only what store() needs
 export interface StoreDb {
-  getExistingRecommendationMbids: () => Promise<Set<string>>
+  getExistingRecommendationMbids: (userId?: number) => Promise<Set<string>>
 
   insertBatch: (data: {
     status: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { serve } from '@hono/node-server'
-import { eq, inArray } from 'drizzle-orm'
+import { eq, inArray, isNull, or } from 'drizzle-orm'
 import { migrate } from 'drizzle-orm/node-postgres/migrator'
 import { canAutoSetup, envConfig } from './config/env'
 import { hashPassword } from './core/auth'
@@ -146,11 +146,15 @@ console.log('Database migrations applied')
 setSessionStore(sessionQueries(db))
 
 const storeDb: StoreDb = {
-  getExistingRecommendationMbids: async () => {
-    const rows = await db
+  getExistingRecommendationMbids: async (userId) => {
+    const base = db
       .select({ mbid: artists.mbid })
       .from(recommendations)
       .innerJoin(artists, eq(recommendations.artistId, artists.id))
+    const rows =
+      userId !== undefined
+        ? await base.where(or(eq(recommendations.userId, userId), isNull(recommendations.userId)))
+        : await base
     return new Set(rows.map((r) => r.mbid))
   },
   insertBatch: async (data) => {

--- a/src/server/helpers/preferences.ts
+++ b/src/server/helpers/preferences.ts
@@ -1,0 +1,26 @@
+import type { Database } from '@/db'
+import { getUserById, type UserPublic } from '@/db/queries/users'
+
+/**
+ * Resolve per-user preferences with fallback to global.
+ * Returns the user's preferences if they exist and are non-empty,
+ * otherwise returns the global preferences unchanged.
+ *
+ * Accepts either a Database instance (calls getUserById internally)
+ * or a pre-bound lookup function (for routes using AppDependencies).
+ */
+export async function resolveUserPreferences(
+  dbOrLookup: Database | ((id: number) => Promise<UserPublic | null>),
+  globalPrefs: Record<string, unknown> | null,
+  userId?: number,
+): Promise<Record<string, unknown> | null> {
+  if (!userId) return globalPrefs
+  const user =
+    typeof dbOrLookup === 'function'
+      ? await dbOrLookup(userId)
+      : await getUserById(dbOrLookup, userId)
+  if (user?.preferences && Object.keys(user.preferences as Record<string, unknown>).length > 0) {
+    return user.preferences as Record<string, unknown>
+  }
+  return globalPrefs
+}

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -11,9 +11,10 @@ import { store } from '@/core/pipeline/store'
 import { resolveSpotifyToken } from '@/core/spotify-auth'
 import { errMsg } from '@/core/validation'
 import { upsertArtist } from '@/db/queries/artists'
-import { getUserById, getUserConnections } from '@/db/queries/users'
+import { getUserConnections } from '@/db/queries/users'
 import { mergePreferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
+import { resolveUserPreferences } from '@/server/helpers/preferences'
 import { createPipelineSSEStream } from '@/server/sse'
 import type { HonoEnv } from '@/server/types'
 
@@ -44,13 +45,11 @@ export function pipelineRoutes(deps: AppDependencies) {
     }
 
     // Read per-user preferences, fallback to global
-    let userPreferences = settings.preferences as Record<string, unknown> | null
-    if (userId) {
-      const user = await getUserById(deps.db, userId)
-      if (user?.preferences && Object.keys(user.preferences).length > 0) {
-        userPreferences = user.preferences as Record<string, unknown>
-      }
-    }
+    const userPreferences = await resolveUserPreferences(
+      deps.db,
+      settings.preferences as Record<string, unknown> | null,
+      userId,
+    )
 
     // Build auto-approve deps -- closures capture userId for per-user target lookup
     const autoApproveDeps: AutoApproveDeps = {
@@ -203,20 +202,18 @@ export function pipelineRoutes(deps: AppDependencies) {
         if (discovered.length === 0) return
 
         // Read per-user preferences for quick-discover, fallback to global
-        let qdPreferences = settings.preferences as Record<string, unknown> | null
-        if (quickDiscoverUserId) {
-          const qdUser = await getUserById(deps.db, quickDiscoverUserId)
-          if (qdUser?.preferences && Object.keys(qdUser.preferences).length > 0) {
-            qdPreferences = qdUser.preferences as Record<string, unknown>
-          }
-        }
+        const qdPreferences = await resolveUserPreferences(
+          deps.db,
+          settings.preferences as Record<string, unknown> | null,
+          quickDiscoverUserId,
+        )
         const prefs = mergePreferences(qdPreferences)
 
         const resolved = await resolve(discovered, mb, undefined, lidarr ?? undefined)
         const rejectedMbids = await deps.storeDb.getRejectedMbids(prefs.rejectionCooldownDays)
         const feedbackHistory = await deps.storeDb.getFeedbackHistory()
         const scored = score(resolved, [], prefs.scoringWeights, feedbackHistory)
-        const existingMbids = await deps.storeDb.getExistingRecommendationMbids()
+        const existingMbids = await deps.storeDb.getExistingRecommendationMbids(quickDiscoverUserId)
         for (const mbid of existingMbids) libraryMbids.add(mbid)
 
         const filtered = filter(

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import type { AppDependencies } from '@/server'
+import { resolveUserPreferences } from '@/server/helpers/preferences'
 import type { HonoEnv } from '@/server/types'
 
 type TargetWithCapabilities = Awaited<
@@ -70,13 +71,8 @@ async function buildAddOptions(
   const globalPrefs = (settings?.preferences as Record<string, unknown> | null) ?? {}
 
   // Merge per-user preferences over global
-  let prefs = globalPrefs
-  if (userId) {
-    const user = await deps.getUserById(userId)
-    if (user?.preferences && Object.keys(user.preferences).length > 0) {
-      prefs = { ...globalPrefs, ...(user.preferences as Record<string, unknown>) }
-    }
-  }
+  const resolved = await resolveUserPreferences(deps.getUserById, globalPrefs, userId)
+  const prefs = resolved && resolved !== globalPrefs ? { ...globalPrefs, ...resolved } : globalPrefs
 
   return {
     ...(overrides.monitorOption != null ? { monitorOption: overrides.monitorOption } : {}),

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -5,6 +5,16 @@ import { createListenBrainzClient } from '@/core/clients/listenbrainz'
 import { sendWebhook } from '@/core/notifications'
 import { errMsg, isHttpUrl } from '@/core/validation'
 import { getUserConnections, updateUserConnections } from '@/db/queries/users'
+
+function isCloudMetadata(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname
+    return hostname === '169.254.169.254' || hostname === 'metadata.google.internal'
+  } catch {
+    return false
+  }
+}
+
 import type { AppDependencies } from '@/server'
 import { resolveAdmin } from '@/server/middleware/admin-guard'
 import type { HonoEnv } from '@/server/types'
@@ -250,6 +260,9 @@ export function settingsRoutes(deps: AppDependencies) {
       if (typeof val === 'string' && val && !isHttpUrl(val)) {
         return c.json({ success: false, message: 'URL must start with http:// or https://' }, 400)
       }
+      if (typeof val === 'string' && val && isCloudMetadata(val)) {
+        return c.json({ success: false, message: 'Cloud metadata endpoints are not allowed' }, 400)
+      }
     }
 
     // Fall back to stored credentials when the request sends empty keys
@@ -387,6 +400,12 @@ export function settingsRoutes(deps: AppDependencies) {
         if (issuerUrl && !isHttpUrl(issuerUrl)) {
           return c.json(
             { success: false, message: 'Issuer URL must start with http:// or https://' },
+            400,
+          )
+        }
+        if (issuerUrl && isCloudMetadata(issuerUrl)) {
+          return c.json(
+            { success: false, message: 'Cloud metadata endpoints are not allowed' },
             400,
           )
         }

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -28,6 +28,7 @@ import {
   useNavigate,
 } from 'react-router-dom'
 import { Toaster, toast } from 'sonner'
+import { errMsg } from '@/core/validation'
 import { VERSION } from '@/version'
 import { AuthGate } from './components/auth-gate'
 import { BottomNav } from './components/bottom-nav'
@@ -421,7 +422,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
                   triggerPipeline()
                     .then(() => toast.success('Scan started -- check Dashboard for progress'))
                     .catch((err) => {
-                      const msg = err instanceof Error ? err.message : 'Failed to start scan'
+                      const msg = errMsg(err)
                       toast.error(msg.includes('409') ? 'Scan already running' : msg)
                     })
                 }

--- a/src/web/components/auth-gate.tsx
+++ b/src/web/components/auth-gate.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { errMsg } from '@/core/validation'
 import {
   AUTH_EXPIRED_EVENT,
   clearStoredToken,
@@ -150,11 +151,7 @@ function LoginForm({
       const res = await loginUser(username.trim(), password)
       onSuccess(res.token)
     } catch (err: unknown) {
-      setError(
-        err instanceof Error && err.message.includes('401')
-          ? 'Invalid credentials'
-          : 'Login failed',
-      )
+      setError(errMsg(err).includes('401') ? 'Invalid credentials' : 'Login failed')
     } finally {
       setLoading(false)
     }
@@ -319,7 +316,7 @@ function RegisterForm({
       const res = await registerUser(username.trim(), password)
       onSuccess(res.token)
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Registration failed'
+      const msg = errMsg(err)
       if (msg.includes('409')) {
         setError('Username already taken')
       } else if (msg.includes('400')) {

--- a/src/web/components/playlist-form.tsx
+++ b/src/web/components/playlist-form.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { errMsg } from '@/core/validation'
 import type { PlaylistInsert, PlaylistRow } from '../lib/api'
 import { CronPicker } from './cron-picker'
 
@@ -80,7 +81,7 @@ export function PlaylistForm({ playlist, onSave, onCancel }: PlaylistFormProps) 
         enabled,
       })
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to save')
+      setError(errMsg(err))
     } finally {
       setSubmitting(false)
     }

--- a/src/web/components/subscription-form.tsx
+++ b/src/web/components/subscription-form.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { errMsg } from '@/core/validation'
 import { CronPicker } from './cron-picker'
 
 export type SubscriptionFormData = {
@@ -164,7 +165,7 @@ export function SubscriptionForm({
         scoringWeightPreset: weightPreset,
       })
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to save')
+      setError(errMsg(err))
     } finally {
       setSubmitting(false)
     }

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { errMsg } from '@/core/validation'
 import { AlbumPicker } from '../components/album-picker'
 import { ApproveDialog } from '../components/approve-dialog'
 import { CardStack } from '../components/card-stack'
@@ -1180,7 +1181,7 @@ export function DiscoverPage() {
             triggerPipeline()
               .then(() => toast.success('Scan started -- check Dashboard for progress'))
               .catch((err) => {
-                const msg = err instanceof Error ? err.message : 'Failed to start scan'
+                const msg = errMsg(err)
                 toast.error(msg.includes('409') ? 'Scan already running' : msg)
               })
           }

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
+import { errMsg } from '@/core/validation'
 import { DEFAULT_PREFERENCES, type Preferences } from '@/db/schema'
 import { Field } from '../components/field'
 import { Hint } from '../components/hint'
@@ -1808,7 +1809,7 @@ function AccountTab() {
       setNewPassword('')
       setConfirmPassword('')
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Failed to change password'
+      const msg = errMsg(err)
       toast.error(
         msg.includes('401') || msg.includes('403') ? 'Current password is incorrect' : msg,
       )

--- a/src/web/pages/user-management.tsx
+++ b/src/web/pages/user-management.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Plus } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
+import { errMsg } from '@/core/validation'
 import { Hint } from '../components/hint'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
@@ -28,13 +29,13 @@ export function UserManagementPage() {
   const toggleAdmin = useMutation({
     mutationFn: ({ id, isAdmin }: { id: number; isAdmin: boolean }) => updateUserAdmin(id, isAdmin),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['users'] }),
-    onError: (err) => toast.error(err instanceof Error ? err.message : 'Failed to update user'),
+    onError: (err) => toast.error(errMsg(err)),
   })
 
   const deleteUser = useMutation({
     mutationFn: (id: number) => deleteUserApi(id),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['users'] }),
-    onError: (err) => toast.error(err instanceof Error ? err.message : 'Failed to delete user'),
+    onError: (err) => toast.error(errMsg(err)),
   })
 
   const createUser = useMutation({
@@ -49,7 +50,7 @@ export function UserManagementPage() {
       setShowForm(false)
     },
     onError: (err) => {
-      const msg = err instanceof Error ? err.message : 'Failed to create user'
+      const msg = errMsg(err)
       toast.error(msg.includes('409') ? 'Username already taken' : msg)
     },
   })


### PR DESCRIPTION
## Summary

Remaining fixes from the full codebase review (#20).

### Bug fixes
- **Multi-user recommendation dedup**: `getExistingRecommendationMbids()` now scopes by `userId`, so user B can get artists already recommended to user A. Includes legacy null-user recs via `OR user_id IS NULL`.
- **Cloud metadata SSRF**: service test endpoints now block `169.254.169.254` and `metadata.google.internal` to prevent cloud metadata access via admin-supplied URLs.

### Code quality
- **Preference resolution helper**: extracted `resolveUserPreferences()` into `src/server/helpers/preferences.ts`, replacing 3 duplicated blocks across pipeline and recommendation routes.
- **Frontend `errMsg()` reuse**: replaced 9 inline `err instanceof Error ? err.message` patterns across 7 frontend files with the shared `errMsg()` helper from `@/core/validation`.

### Supply chain hardening
- **Forgejo CI SHA pinning**: actions in `.forgejo/workflows/release.yml` now pinned to commit SHAs (matching the GitHub workflows).
- **Docker digest pinning**: `oven/bun:1.3.11` and `oven/bun:1.3.11-slim` base images pinned to SHA256 digests in the Dockerfile.

## Test plan

- [x] All 1110 tests pass
- [x] Lint clean
- [x] Typecheck clean
- [ ] CI green