### PR TITLE
fix: add runAsUser to resolve non-numeric user securityContext error

### DIFF
--- a/deploy/helm/digarr/templates/deployment.yaml
+++ b/deploy/helm/digarr/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         {{- include "digarr.selectorLabels" . | nindent 8 }}
     spec:
       securityContext:
-        runAsNonRoot: true
+        {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -31,6 +31,10 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+
 env:
   PORT: "3000"
   LOG_LEVEL: info

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsUser: 1000
       containers:
         - name: digarr
           securityContext:


### PR DESCRIPTION
Kubernetes cannot verify runAsNonRoot when the image user is a named string.
  Adding runAsUser: 1000 provides a numeric UID to satisfy the check.

  ## Summary

  - The `digarr` image defines its user as the string `"digarr"` rather than a numeric UID, causing Kubernetes to reject the container with `CreateContainerConfigError` when `runAsNonRoot: true` is set
  - Added `runAsUser: 1000` to the pod `securityContext` and made it configurable via `values.yaml` so it can be overridden per deployment

  ## Test plan

  - [ ] `bun run lint` passes
  - [ ] `bun run typecheck` passes
  - [ ] `bun run test` passes
  - [x] Tested manually — pod previously stuck in `CreateContainerConfigError`; starts successfully after the change

  ## Notes

  The default `runAsUser: 1000` matches the UID typically assigned to named users in Node.js base images. If a custom image uses a different UID, override via `securityContext.runAsUser` in `values.yaml`.

