### PR TITLE
fix: mood discover dedup, cover shimmer, preview proxy

### DIFF
--- a/src/server/routes/artists.ts
+++ b/src/server/routes/artists.ts
@@ -75,6 +75,31 @@ export function artistRoutes(deps: AppDependencies) {
     return c.json({ tracks })
   })
 
+  // Proxy Deezer preview audio to avoid CORS issues in browsers
+  router.get('/api/preview/audio', async (c) => {
+    const url = c.req.query('url')
+    if (!url || !url.startsWith('https://cdns-preview-')) {
+      return c.json({ error: 'Invalid preview URL' }, 400)
+    }
+    try {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 10_000)
+      const res = await fetch(url, { signal: controller.signal })
+      clearTimeout(timer)
+      if (!res.ok || !res.body) {
+        return c.json({ error: 'Preview not available' }, 502)
+      }
+      return new Response(res.body, {
+        headers: {
+          'Content-Type': res.headers.get('Content-Type') ?? 'audio/mpeg',
+          'Cache-Control': 'public, max-age=86400',
+        },
+      })
+    } catch {
+      return c.json({ error: 'Preview fetch failed' }, 502)
+    }
+  })
+
   router.get('/api/albums/:mbid', async (c) => {
     const mbid = c.req.param('mbid')
     if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(mbid)) {

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -157,20 +157,42 @@ export function pipelineRoutes(deps: AppDependencies) {
           ? new Set((await lidarr.getArtists()).map((a) => a.foreignArtistId))
           : new Set<string>()
 
-        // Add the seed artist itself as a direct pick
+        // Add the seed artist directly (bypasses dedup filter)
+        const seedDiscovered = [
+          {
+            name: artistName,
+            similarityScore: 1.0,
+            aiReasoning: 'Directly added from mood discovery.',
+            source: 'mood' as const,
+          },
+        ]
+        const seedResolved = await resolve(seedDiscovered, mb, undefined, lidarr ?? undefined)
+        if (seedResolved.length > 0) {
+          const seedScored = score(
+            seedResolved,
+            [],
+            {
+              consensus: 0,
+              similarity: 0,
+              genreOverlap: 0,
+              aiConfidence: 0,
+              feedbackBoost: 0,
+              popularity: 0,
+            },
+            new Map(),
+          )
+          // Force score to 1.0 -- direct user pick
+          for (const s of seedScored) s.score = 1.0
+          await store(seedScored, deps.storeDb, { userId: quickDiscoverUserId })
+        }
+
+        // Find similar artists via Last.fm + AI
         const discovered: Array<{
           name: string
           similarityScore: number
           aiReasoning?: string
           source: string
-        }> = [
-          {
-            name: artistName,
-            similarityScore: 1.0,
-            aiReasoning: 'Directly added from mood discovery.',
-            source: 'mood',
-          },
-        ]
+        }> = []
 
         // Get similar from Last.fm
         if (lastfmApiKey && lastfmApiKey !== '***') {

--- a/src/web/components/recently-approved.tsx
+++ b/src/web/components/recently-approved.tsx
@@ -23,7 +23,7 @@ function Tile({ name, mbid, imageUrl }: { name: string; mbid?: string; imageUrl?
 
   // Fetch album data for cover fallback when no artist image
   const needsFallback = !imageUrl || imgError
-  const { data: albumData } = useQuery({
+  const { data: albumData, isLoading: albumLoading } = useQuery({
     queryKey: ['tile-albums', mbid],
     queryFn: () => getAlbums(mbid!),
     enabled: needsFallback && !!mbid,
@@ -36,6 +36,7 @@ function Tile({ name, mbid, imageUrl }: { name: string; mbid?: string; imageUrl?
     : null
 
   const displayUrl = (!imgError && imageUrl) || (!coverError && coverUrl)
+  const showShimmer = needsFallback && albumLoading
 
   return (
     <Link to="/discover" className="aspect-square rounded-lg overflow-hidden relative group block">
@@ -48,6 +49,11 @@ function Tile({ name, mbid, imageUrl }: { name: string; mbid?: string; imageUrl?
             if (displayUrl === imageUrl) setImgError(true)
             else setCoverError(true)
           }}
+        />
+      ) : showShimmer ? (
+        <div
+          className="w-full h-full animate-pulse"
+          style={{ background: `hsl(${hue}, 30%, 30%)` }}
         />
       ) : (
         <div className="w-full h-full" style={{ background: `hsl(${hue}, 40%, 45%)` }} />

--- a/src/web/components/recommendation-card.tsx
+++ b/src/web/components/recommendation-card.tsx
@@ -371,7 +371,9 @@ function TopTracks({ artistId }: { artistId: number }) {
       audioRef.current.onerror = null
       audioRef.current.src = ''
     }
-    const audio = new Audio(previewUrl)
+    // Proxy through backend to avoid Deezer CORS blocking
+    const proxyUrl = `/api/preview/audio?url=${encodeURIComponent(previewUrl)}`
+    const audio = new Audio(proxyUrl)
     audioRef.current = audio
     audio.onended = () => setPlayingUrl(null)
     audio.onerror = () => setPlayingUrl(null)


### PR DESCRIPTION
## Summary

- **Mood discover**: seed artist now stored separately before the dedup-filtered pipeline, so the clicked artist always gets added regardless of existing recommendations
- **Recently approved covers**: show loading shimmer (animate-pulse) while MB album queries are in flight, instead of static colored squares
- **Preview proxy**: new `GET /api/preview/audio?url=` endpoint proxies Deezer CDN preview MP3s through the backend, bypassing browser CORS blocking. Top tracks play buttons now work.

## Test plan

- [x] 1132 tests passing
- [x] 0 type errors, 0 lint errors
- [ ] Mood: clicking Discover on a mood result adds the artist to recommendations (even if similar artists already exist)
- [ ] Dashboard: recently approved tiles shimmer while covers load
- [ ] Top tracks: clicking play on a track plays the 30-sec Deezer preview
- [ ] CI green