### PR TITLE
fix: preview auth, action buttons, mood discover reliability

### DIFF
--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -152,39 +152,43 @@ export function pipelineRoutes(deps: AppDependencies) {
             : null
         const mb = createMusicBrainzClient()
 
+        // Add the seed artist directly (bypasses dedup, no Lidarr dependency)
+        try {
+          const seedDiscovered = [
+            {
+              name: artistName,
+              similarityScore: 1.0,
+              aiReasoning: 'Directly added from mood discovery.',
+              source: 'mood' as const,
+            },
+          ]
+          // Resolve via MB only (no Lidarr image lookup -- avoids SkyHook dependency)
+          const seedResolved = await resolve(seedDiscovered, mb)
+          if (seedResolved.length > 0) {
+            const seedScored = score(
+              seedResolved,
+              [],
+              {
+                consensus: 0,
+                similarity: 0,
+                genreOverlap: 0,
+                aiConfidence: 0,
+                feedbackBoost: 0,
+                popularity: 0,
+              },
+              new Map(),
+            )
+            for (const s of seedScored) s.score = 1.0
+            await store(seedScored, deps.storeDb, { userId: quickDiscoverUserId })
+          }
+        } catch (err: unknown) {
+          console.warn('Seed artist store failed:', errMsg(err))
+        }
+
         // Get library MBIDs -- intermediate array is immediately GC-eligible
         const libraryMbids = lidarr
           ? new Set((await lidarr.getArtists()).map((a) => a.foreignArtistId))
           : new Set<string>()
-
-        // Add the seed artist directly (bypasses dedup filter)
-        const seedDiscovered = [
-          {
-            name: artistName,
-            similarityScore: 1.0,
-            aiReasoning: 'Directly added from mood discovery.',
-            source: 'mood' as const,
-          },
-        ]
-        const seedResolved = await resolve(seedDiscovered, mb, undefined, lidarr ?? undefined)
-        if (seedResolved.length > 0) {
-          const seedScored = score(
-            seedResolved,
-            [],
-            {
-              consensus: 0,
-              similarity: 0,
-              genreOverlap: 0,
-              aiConfidence: 0,
-              feedbackBoost: 0,
-              popularity: 0,
-            },
-            new Map(),
-          )
-          // Force score to 1.0 -- direct user pick
-          for (const s of seedScored) s.score = 1.0
-          await store(seedScored, deps.storeDb, { userId: quickDiscoverUserId })
-        }
 
         // Find similar artists via Last.fm + AI
         const discovered: Array<{

--- a/src/web/components/recommendation-card.tsx
+++ b/src/web/components/recommendation-card.tsx
@@ -358,7 +358,7 @@ function TopTracks({ artistId }: { artistId: number }) {
   const [playingUrl, setPlayingUrl] = useState<string | null>(null)
   const audioRef = useRef<HTMLAudioElement | null>(null)
 
-  function handlePlay(previewUrl: string) {
+  async function handlePlay(previewUrl: string) {
     if (playingUrl === previewUrl) {
       audioRef.current?.pause()
       setPlayingUrl(null)
@@ -371,14 +371,30 @@ function TopTracks({ artistId }: { artistId: number }) {
       audioRef.current.onerror = null
       audioRef.current.src = ''
     }
-    // Proxy through backend to avoid Deezer CORS blocking
-    const proxyUrl = `/api/preview/audio?url=${encodeURIComponent(previewUrl)}`
-    const audio = new Audio(proxyUrl)
-    audioRef.current = audio
-    audio.onended = () => setPlayingUrl(null)
-    audio.onerror = () => setPlayingUrl(null)
-    audio.play().catch(() => setPlayingUrl(null))
     setPlayingUrl(previewUrl)
+    try {
+      // Fetch through auth'd proxy, play as blob to avoid CORS + auth issues
+      const token = localStorage.getItem('digarr-auth-token')
+      const res = await fetch(`/api/preview/audio?url=${encodeURIComponent(previewUrl)}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      })
+      if (!res.ok) throw new Error('Preview fetch failed')
+      const blob = await res.blob()
+      const blobUrl = URL.createObjectURL(blob)
+      const audio = new Audio(blobUrl)
+      audioRef.current = audio
+      audio.onended = () => {
+        setPlayingUrl(null)
+        URL.revokeObjectURL(blobUrl)
+      }
+      audio.onerror = () => {
+        setPlayingUrl(null)
+        URL.revokeObjectURL(blobUrl)
+      }
+      await audio.play()
+    } catch {
+      setPlayingUrl(null)
+    }
   }
 
   useEffect(() => {
@@ -516,14 +532,14 @@ export function RecommendationCard({
           {/* Left edge: reject */}
           <button
             type="button"
-            className="hidden md:group-hover:flex absolute left-0 top-0 bottom-0 z-10 items-center justify-center w-10 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-all duration-150 bg-transparent border-none p-0"
+            className="hidden md:group-hover:flex absolute left-1 top-0 bottom-0 z-10 items-center justify-center w-10 opacity-0 group-hover:opacity-100 transition-all duration-150 bg-transparent border-none p-0"
             onClick={(e) => {
               e.stopPropagation()
               onReject(rec.id)
             }}
             aria-label="Reject"
           >
-            <span className="w-8 h-8 rounded-full bg-reject/20 border border-reject/40 text-reject hover:bg-reject/40 transition-colors flex items-center justify-center shadow-md">
+            <span className="w-8 h-8 rounded-full bg-surface/90 backdrop-blur-sm border border-reject/40 text-reject hover:bg-reject/30 transition-colors flex items-center justify-center shadow-lg">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
@@ -543,14 +559,14 @@ export function RecommendationCard({
           {/* Right edge: approve */}
           <button
             type="button"
-            className="hidden md:group-hover:flex absolute right-0 top-0 bottom-0 z-10 items-center justify-center w-10 translate-x-1/2 opacity-0 group-hover:opacity-100 transition-all duration-150 bg-transparent border-none p-0"
+            className="hidden md:group-hover:flex absolute right-1 top-0 bottom-0 z-10 items-center justify-center w-10 opacity-0 group-hover:opacity-100 transition-all duration-150 bg-transparent border-none p-0"
             onClick={(e) => {
               e.stopPropagation()
               onApprove(rec.id)
             }}
             aria-label="Approve"
           >
-            <span className="w-8 h-8 rounded-full bg-approve/20 border border-approve/40 text-approve hover:bg-approve/40 transition-colors flex items-center justify-center shadow-md">
+            <span className="w-8 h-8 rounded-full bg-surface/90 backdrop-blur-sm border border-approve/40 text-approve hover:bg-approve/30 transition-colors flex items-center justify-center shadow-lg">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary

- **Preview playback**: fetch Deezer audio as blob through auth'd proxy instead of bare Audio.src (which can't send auth headers -- was returning 401)
- **Action buttons**: solid surface background + backdrop-blur instead of transparent. Positioned inside card bounds to avoid edge clipping.
- **Mood discover**: seed artist resolved via MB only (no Lidarr/SkyHook dependency), stored before the rest of the pipeline starts. SkyHook outages no longer block the seed artist add.

## Test plan

- [x] 1132 tests passing, 0 type/lint errors
- [ ] Top tracks play button plays audio
- [ ] Action buttons (X/V on card hover) have visible backgrounds
- [ ] Mood discover adds the clicked artist even when Lidarr/SkyHook is down