### PR TITLE
fix(web): UI audit fixes -- color tokens, confirm dialogs, text sizes, error boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ SECURITY-AUDIT.md
 .playwright-mcp/
 docs/local/
 .superpowers/
+.planning/
+UI-REVIEW.md

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -32,6 +32,7 @@ import { errMsg } from '@/core/validation'
 import { VERSION } from '@/version'
 import { AuthGate } from './components/auth-gate'
 import { BottomNav } from './components/bottom-nav'
+import { ErrorBoundary } from './components/error-boundary'
 import { KeyboardShortcuts } from './components/keyboard-shortcuts'
 import { PreviewPlayer } from './components/preview-player'
 import { useClickOutside } from './hooks/use-click-outside'
@@ -196,7 +197,7 @@ function ThemePicker({
           role="menu"
           className="absolute right-0 top-full mt-1 w-48 bg-surface border border-border rounded-lg shadow-lg z-50 py-1"
         >
-          <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted">Mode</div>
+          <div className="px-3 py-1.5 text-micro uppercase tracking-wider text-muted">Mode</div>
           {(['dark', 'light', 'system'] as const).map((m) => {
             const Icon = m === 'dark' ? Moon : m === 'light' ? Sun : Monitor
             return (
@@ -216,7 +217,7 @@ function ThemePicker({
           <div className="max-h-[320px] overflow-y-auto">
             {(['Editor', 'Streaming'] as const).map((group) => (
               <div key={group}>
-                <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted sticky top-0 bg-surface">
+                <div className="px-3 py-1.5 text-micro uppercase tracking-wider text-muted sticky top-0 bg-surface">
                   {group}
                 </div>
                 {COLOR_THEMES.filter((t) => t.group === group).map((t) => (
@@ -563,7 +564,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
           loading={preview.state.loading}
           onStop={preview.stop}
         />
-        <footer className="hidden md:block fixed bottom-2 right-3 text-[10px] text-muted select-none pointer-events-none z-10">
+        <footer className="hidden md:block fixed bottom-2 right-3 text-micro text-muted select-none pointer-events-none z-10">
           v{VERSION}
         </footer>
       </div>
@@ -595,23 +596,25 @@ function InnerApp() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <AppShell>
-          <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/search" element={<SearchPage />} />
-            <Route path="/discover" element={<DiscoverPage />} />
-            <Route path="/genres" element={<GenresPage />} />
-            <Route path="/genres/:slug" element={<GenreDetailPage />} />
-            <Route path="/playlists" element={<PlaylistsPage />} />
-            <Route path="/playlists/:id" element={<PlaylistDetailPage />} />
-            <Route path="/subscriptions" element={<SubscriptionsPage />} />
-            <Route path="/library/health" element={<LibraryHealthPage />} />
-            <Route path="/analytics" element={<AnalyticsPage />} />
-            <Route path="/settings" element={<SettingsPage />} />
-            <Route path="/users" element={<UserManagementPage />} />
-            <Route path="*" element={<Navigate to="/" />} />
-          </Routes>
-        </AppShell>
+        <ErrorBoundary>
+          <AppShell>
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/search" element={<SearchPage />} />
+              <Route path="/discover" element={<DiscoverPage />} />
+              <Route path="/genres" element={<GenresPage />} />
+              <Route path="/genres/:slug" element={<GenreDetailPage />} />
+              <Route path="/playlists" element={<PlaylistsPage />} />
+              <Route path="/playlists/:id" element={<PlaylistDetailPage />} />
+              <Route path="/subscriptions" element={<SubscriptionsPage />} />
+              <Route path="/library/health" element={<LibraryHealthPage />} />
+              <Route path="/analytics" element={<AnalyticsPage />} />
+              <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/users" element={<UserManagementPage />} />
+              <Route path="*" element={<Navigate to="/" />} />
+            </Routes>
+          </AppShell>
+        </ErrorBoundary>
         <Toaster theme="system" />
       </BrowserRouter>
     </QueryClientProvider>

--- a/src/web/components/album-picker.tsx
+++ b/src/web/components/album-picker.tsx
@@ -17,7 +17,7 @@ function AlbumCover({ mbid, title }: { mbid: string; title: string }) {
   const [failed, setFailed] = useState(false)
   if (failed) {
     return (
-      <div className="w-10 h-10 rounded bg-bg shrink-0 flex items-center justify-center text-[10px] font-bold text-muted">
+      <div className="w-10 h-10 rounded bg-bg shrink-0 flex items-center justify-center text-micro font-bold text-muted">
         {title.slice(0, 2).toUpperCase()}
       </div>
     )
@@ -180,7 +180,7 @@ export function AlbumPicker({
                           <div className="flex items-center gap-1.5">
                             <span className="text-sm text-text truncate">{album.title}</span>
                             {isSuggested && (
-                              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-accent/20 text-accent shrink-0">
+                              <span className="text-micro px-1.5 py-0.5 rounded-full bg-accent/20 text-accent shrink-0">
                                 AI pick
                               </span>
                             )}

--- a/src/web/components/bottom-nav.tsx
+++ b/src/web/components/bottom-nav.tsx
@@ -121,7 +121,7 @@ export function BottomNav() {
             {({ isActive }) => (
               <>
                 <Icon className={isActive ? 'text-accent' : undefined} />
-                <span className="text-[10px] font-medium leading-none">{label}</span>
+                <span className="text-micro font-medium leading-none">{label}</span>
               </>
             )}
           </NavLink>

--- a/src/web/components/card-stack.tsx
+++ b/src/web/components/card-stack.tsx
@@ -104,7 +104,7 @@ function StackCard({
               <span
                 key={tag}
                 className={cn(
-                  'text-[10px] px-1.5 py-0.5 rounded-full',
+                  'text-micro px-1.5 py-0.5 rounded-full',
                   i % 4 === 0 && 'bg-accent/10 text-accent',
                   i % 4 === 1 && 'bg-info/10 text-info',
                   i % 4 === 2 && 'bg-approve/10 text-approve',
@@ -378,7 +378,7 @@ export function CardStack({ recommendations, onApprove, onReject, onDetail }: Ca
 
       {/* Swipe hint */}
       {rec?.status === 'pending' && (
-        <p className="text-[10px] text-muted">Swipe right to approve, left to reject</p>
+        <p className="text-micro text-muted">Swipe right to approve, left to reject</p>
       )}
     </div>
   )

--- a/src/web/components/confirm-dialog.tsx
+++ b/src/web/components/confirm-dialog.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react'
+import { Button } from './ui/button'
+
+type Props = {
+  title: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  destructive = true,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const confirmRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    confirmRef.current?.focus()
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onCancel])
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-bg/70 backdrop-blur-sm z-50"
+        onClick={onCancel}
+        aria-hidden="true"
+      />
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: dialog content wrapper prevents click-through */}
+        <div
+          className="bg-surface border border-border rounded-lg shadow-lg w-full max-w-sm p-4"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') onCancel()
+          }}
+        >
+          <h3 className="text-sm font-medium text-text">{title}</h3>
+          <p className="text-sm text-muted mt-2">{message}</p>
+
+          <div className="flex justify-end gap-2 mt-4">
+            <Button size="sm" variant="outline" onClick={onCancel}>
+              {cancelLabel}
+            </Button>
+            <Button
+              ref={confirmRef}
+              size="sm"
+              variant={destructive ? 'destructive' : 'default'}
+              onClick={onConfirm}
+            >
+              {confirmLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/web/components/error-boundary.tsx
+++ b/src/web/components/error-boundary.tsx
@@ -1,0 +1,36 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { Button } from './ui/button'
+
+type Props = { children: ReactNode }
+type State = { error: Error | null }
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Unhandled render error:', error, info.componentStack)
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children
+
+    return (
+      <div className="min-h-screen bg-bg flex items-center justify-center p-6">
+        <div className="bg-surface border border-border rounded-lg p-6 max-w-md w-full space-y-4 text-center">
+          <h1 className="text-lg font-semibold text-text">Something went wrong</h1>
+          <p className="text-sm text-muted">{this.state.error.message}</p>
+          <div className="flex justify-center gap-3">
+            <Button variant="outline" onClick={() => this.setState({ error: null })}>
+              Try again
+            </Button>
+            <Button onClick={() => window.location.assign('/')}>Go home</Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/web/components/genre-card.tsx
+++ b/src/web/components/genre-card.tsx
@@ -33,7 +33,7 @@ export function GenreCard({ name, slug, artistCount, exampleArtists }: GenreCard
         {artistCount} artist{artistCount !== 1 ? 's' : ''}
       </p>
       {exampleArtists && exampleArtists.length > 0 && (
-        <p className="text-[11px] text-muted/70 mt-1.5 truncate">{exampleArtists.join(', ')}</p>
+        <p className="text-micro-lg text-muted/70 mt-1.5 truncate">{exampleArtists.join(', ')}</p>
       )}
     </button>
   )

--- a/src/web/components/keyboard-shortcuts.tsx
+++ b/src/web/components/keyboard-shortcuts.tsx
@@ -89,7 +89,7 @@ export function KeyboardShortcuts({ open, onClose }: KeyboardShortcutsProps) {
           ))}
         </div>
 
-        <p className="mt-5 text-[10px] text-muted text-center">
+        <p className="mt-5 text-micro text-muted text-center">
           Shortcuts are disabled when a text field is focused.
         </p>
       </div>

--- a/src/web/components/mood-prompt-bar.tsx
+++ b/src/web/components/mood-prompt-bar.tsx
@@ -94,7 +94,7 @@ export function MoodPromptBar({
                       {r.genres.slice(0, 3).map((g) => (
                         <span
                           key={g}
-                          className="text-[10px] px-1.5 py-0.5 bg-bg border border-border rounded text-muted"
+                          className="text-micro px-1.5 py-0.5 bg-bg border border-border rounded text-muted"
                         >
                           {g}
                         </span>
@@ -103,22 +103,22 @@ export function MoodPromptBar({
                   </div>
                   <div className="shrink-0">
                     {r.inLibrary ? (
-                      <span className="text-[10px] text-muted px-2 py-1 bg-bg border border-border rounded">
+                      <span className="text-micro text-muted px-2 py-1 bg-bg border border-border rounded">
                         In library
                       </span>
                     ) : existingArtistNames.has(r.artistName.toLowerCase()) ? (
-                      <span className="text-[10px] text-muted px-2 py-1 bg-bg border border-border rounded">
+                      <span className="text-micro text-muted px-2 py-1 bg-bg border border-border rounded">
                         Pending review
                       </span>
                     ) : queued.has(r.artistName) ? (
-                      <span className="text-[10px] text-approve px-2 py-1 bg-approve/10 border border-approve/20 rounded">
+                      <span className="text-micro text-approve px-2 py-1 bg-approve/10 border border-approve/20 rounded">
                         Added
                       </span>
                     ) : (
                       <button
                         type="button"
                         onClick={() => handleAddToQueue(r.artistName)}
-                        className="text-[10px] px-2 py-1 bg-accent/10 text-accent border border-accent/20 rounded hover:bg-accent/20 transition-colors"
+                        className="text-micro px-2 py-1 bg-accent/10 text-accent border border-accent/20 rounded hover:bg-accent/20 transition-colors"
                       >
                         + Discover
                       </button>

--- a/src/web/components/playlist-card.tsx
+++ b/src/web/components/playlist-card.tsx
@@ -8,6 +8,7 @@ import {
   type PlaylistRow,
   updatePlaylistApi,
 } from '../lib/api'
+import { ConfirmDialog } from './confirm-dialog'
 
 function formatRelativeTime(dateStr: string | null): string {
   if (!dateStr) return 'Never'
@@ -85,6 +86,7 @@ type PlaylistCardProps = {
 
 export function PlaylistCard({ playlist, onEdit, onRefetch }: PlaylistCardProps) {
   const [generating, setGenerating] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const navigate = useNavigate()
 
   const badge = STRATEGY_BADGES[playlist.strategy] ?? {
@@ -115,7 +117,6 @@ export function PlaylistCard({ playlist, onEdit, onRefetch }: PlaylistCardProps)
   }
 
   async function handleDelete() {
-    if (!confirm(`Delete playlist "${playlist.name}"? This cannot be undone.`)) return
     try {
       await deletePlaylistApi(playlist.id)
       toast.success(`Deleted "${playlist.name}"`)
@@ -142,7 +143,7 @@ export function PlaylistCard({ playlist, onEdit, onRefetch }: PlaylistCardProps)
           {playlist.name}
         </p>
         <span
-          className={`shrink-0 text-[11px] font-medium px-2 py-0.5 rounded-full ${badge.className}`}
+          className={`shrink-0 text-micro-lg font-medium px-2 py-0.5 rounded-full ${badge.className}`}
         >
           {badge.label}
         </span>
@@ -212,7 +213,10 @@ export function PlaylistCard({ playlist, onEdit, onRefetch }: PlaylistCardProps)
           </button>
           <button
             type="button"
-            onClick={handleDelete}
+            onClick={(e) => {
+              e.stopPropagation()
+              setShowDeleteConfirm(true)
+            }}
             className="p-2 text-muted hover:text-reject transition-colors"
             title="Delete playlist"
             aria-label="Delete playlist"
@@ -229,7 +233,21 @@ export function PlaylistCard({ playlist, onEdit, onRefetch }: PlaylistCardProps)
         />
       </div>
 
-      {!playlist.enabled && <p className="text-[11px] text-muted/60 text-center -mt-1">Disabled</p>}
+      {!playlist.enabled && (
+        <p className="text-micro-lg text-muted/60 text-center -mt-1">Disabled</p>
+      )}
+      {showDeleteConfirm && (
+        <ConfirmDialog
+          title="Delete playlist"
+          message={`Delete "${playlist.name}"? This cannot be undone.`}
+          confirmLabel="Delete"
+          onConfirm={() => {
+            setShowDeleteConfirm(false)
+            handleDelete()
+          }}
+          onCancel={() => setShowDeleteConfirm(false)}
+        />
+      )}
     </div>
   )
 }

--- a/src/web/components/recommendation-card.tsx
+++ b/src/web/components/recommendation-card.tsx
@@ -56,10 +56,10 @@ type RecommendationCardProps = {
 // Source dot config
 
 const SOURCE_COLORS: Record<string, { label: string; color: string }> = {
-  listenbrainz: { label: 'LB', color: '#7a9cb8' },
-  lastfm: { label: 'LFM', color: '#c47a7a' },
-  musicbrainz: { label: 'MB', color: '#d4a574' },
-  ai: { label: 'Rec', color: '#9b7ab8' },
+  listenbrainz: { label: 'LB', color: 'var(--color-svc-listenbrainz)' },
+  lastfm: { label: 'LFM', color: 'var(--color-svc-lastfm)' },
+  musicbrainz: { label: 'MB', color: 'var(--color-svc-musicbrainz)' },
+  ai: { label: 'Rec', color: 'var(--color-svc-ai)' },
 }
 
 const SUBSCRIPTION_COLORS: Record<string, string> = {
@@ -161,7 +161,7 @@ function GenrePills({
         <span
           key={g}
           className={cn(
-            'text-[10px] px-1.5 py-0.5 rounded-full shrink-0',
+            'text-micro px-1.5 py-0.5 rounded-full shrink-0',
             GENRE_COLORS[i % GENRE_COLORS.length],
           )}
         >
@@ -169,7 +169,7 @@ function GenrePills({
         </span>
       ))}
       {genres.length > max && (
-        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-surface text-muted shrink-0">
+        <span className="text-micro px-1.5 py-0.5 rounded-full bg-surface text-muted shrink-0">
           +{genres.length - max}
         </span>
       )}
@@ -734,7 +734,7 @@ export function RecommendationCard({
               )}
               <div className="absolute top-3 right-3 bg-black/60 backdrop-blur-sm rounded-lg px-2.5 py-1.5 flex items-baseline gap-0.5">
                 <span className="text-accent text-lg font-bold leading-none">{pct}</span>
-                <span className="text-white/50 text-[9px] ml-1 uppercase tracking-wider">
+                <span className="text-white/50 text-micro-sm ml-1 uppercase tracking-wider">
                   match
                 </span>
               </div>
@@ -791,7 +791,7 @@ export function RecommendationCard({
                       <div key={key} className="flex items-center gap-1.5">
                         <span
                           className={cn(
-                            'text-[10px] px-1.5 py-0.5 rounded-full font-medium',
+                            'text-micro px-1.5 py-0.5 rounded-full font-medium',
                             getSourceBadgeClass(key),
                           )}
                         >

--- a/src/web/components/search-result-card.tsx
+++ b/src/web/components/search-result-card.tsx
@@ -83,12 +83,12 @@ export function SearchResultCard({ result }: SearchResultCardProps) {
           <h3 className="font-semibold text-text text-sm leading-tight truncate">{result.name}</h3>
           <div className="flex items-center gap-1 shrink-0">
             {result.inLibrary && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-approve/15 text-approve font-medium">
+              <span className="text-micro px-1.5 py-0.5 rounded bg-approve/15 text-approve font-medium">
                 Library
               </span>
             )}
             {(result.inRecommendations || queued) && !result.inLibrary && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-info/15 text-info font-medium">
+              <span className="text-micro px-1.5 py-0.5 rounded bg-info/15 text-info font-medium">
                 In queue
               </span>
             )}
@@ -102,7 +102,7 @@ export function SearchResultCard({ result }: SearchResultCardProps) {
               <span
                 key={g}
                 className={cn(
-                  'text-[10px] px-1.5 py-0.5 rounded font-medium',
+                  'text-micro px-1.5 py-0.5 rounded font-medium',
                   GENRE_COLORS[i % GENRE_COLORS.length],
                 )}
               >
@@ -123,7 +123,7 @@ export function SearchResultCard({ result }: SearchResultCardProps) {
             const badge = (
               <span
                 className={cn(
-                  'text-[10px] px-1.5 py-0.5 rounded font-medium',
+                  'text-micro px-1.5 py-0.5 rounded font-medium',
                   style.bg,
                   style.text,
                   s.url ? 'cursor-pointer hover:opacity-80 transition-opacity' : '',
@@ -143,7 +143,7 @@ export function SearchResultCard({ result }: SearchResultCardProps) {
           })}
 
           {typeof result.popularity === 'number' && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-border text-muted font-medium">
+            <span className="text-micro px-1.5 py-0.5 rounded bg-border text-muted font-medium">
               {result.popularity}% pop
             </span>
           )}
@@ -155,7 +155,7 @@ export function SearchResultCard({ result }: SearchResultCardProps) {
             <button
               type="button"
               onClick={handlePreview}
-              className="flex items-center gap-1 text-[11px] text-muted hover:text-text transition-colors"
+              className="flex items-center gap-1 text-micro-lg text-muted hover:text-text transition-colors"
               title={isPlaying ? 'Stop preview' : 'Preview'}
             >
               {isPlaying ? <Pause size={12} /> : <Play size={12} />}
@@ -168,7 +168,7 @@ export function SearchResultCard({ result }: SearchResultCardProps) {
               type="button"
               onClick={handleQuickDiscover}
               disabled={queuing}
-              className="flex items-center gap-1 text-[11px] text-accent hover:opacity-80 transition-opacity disabled:opacity-50"
+              className="flex items-center gap-1 text-micro-lg text-accent hover:opacity-80 transition-opacity disabled:opacity-50"
               title="Add to discovery queue"
             >
               <Zap size={12} />

--- a/src/web/components/service-icons.tsx
+++ b/src/web/components/service-icons.tsx
@@ -5,7 +5,7 @@ function ServiceLogo({ src, alt }: { src: string; alt: string }) {
   const [failed, setFailed] = useState(false)
   if (failed) {
     return (
-      <span className="flex items-center justify-center w-6 h-6 rounded bg-surface text-[10px] font-bold text-muted">
+      <span className="flex items-center justify-center w-6 h-6 rounded bg-surface text-micro font-bold text-muted">
         {alt.charAt(0)}
       </span>
     )
@@ -56,7 +56,7 @@ export function DiscogsIcon() {
 
 export function WebhookIcon() {
   return (
-    <span className="flex items-center justify-center w-6 h-6 text-[#60a5fa]">
+    <span className="flex items-center justify-center w-6 h-6 text-svc-webhook">
       <Bell size={18} />
     </span>
   )

--- a/src/web/components/streaming-links.tsx
+++ b/src/web/components/streaming-links.tsx
@@ -21,37 +21,37 @@ type ServiceConfig = {
 const SERVICES: Record<string, ServiceConfig> = {
   spotify: {
     label: 'Spotify',
-    color: '#1db954',
+    color: 'var(--color-svc-spotify)',
     fallback: (name) => `https://open.spotify.com/search/${encodeURIComponent(name)}`,
   },
   youtube: {
     label: 'YT Music',
-    color: '#ff0000',
+    color: 'var(--color-svc-youtube)',
     fallback: (name) => `https://music.youtube.com/search?q=${encodeURIComponent(name)}`,
   },
   appleMusic: {
     label: 'Apple Music',
-    color: '#fc3c44',
+    color: 'var(--color-svc-apple)',
     fallback: (name) => `https://music.apple.com/search?term=${encodeURIComponent(name)}`,
   },
   deezer: {
     label: 'Deezer',
-    color: '#a238ff',
+    color: 'var(--color-svc-deezer)',
     fallback: (name) => `https://www.deezer.com/search/${encodeURIComponent(name)}`,
   },
   tidal: {
     label: 'Tidal',
-    color: '#00ffff',
+    color: 'var(--color-svc-tidal)',
     fallback: () => '',
   },
   soundcloud: {
     label: 'SoundCloud',
-    color: '#ff5500',
+    color: 'var(--color-svc-soundcloud)',
     fallback: () => '',
   },
   bandcamp: {
     label: 'Bandcamp',
-    color: '#1da0c3',
+    color: 'var(--color-svc-bandcamp)',
     fallback: () => '',
   },
 }
@@ -123,7 +123,7 @@ export function StreamingLinks({
   // Also include any extra keys from streamingUrls that aren't in SERVICES
   for (const [key, url] of Object.entries(urls)) {
     if (!SERVICES[key] && url) {
-      links.push({ key, label: key, url, color: '#6b7084' })
+      links.push({ key, label: key, url, color: 'var(--color-svc-unknown)' })
     }
   }
 
@@ -138,7 +138,7 @@ export function StreamingLinks({
           <button
             type="button"
             onClick={onPlay}
-            className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-[10px] font-bold border border-green-500/40 text-green-500 bg-surface/50 hover:opacity-80 transition-opacity"
+            className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-micro font-bold border border-green-500/40 text-green-500 bg-surface/50 hover:opacity-80 transition-opacity"
           >
             {isPlaying ? 'STOP' : 'PLAY'}
           </button>
@@ -151,7 +151,7 @@ export function StreamingLinks({
             rel="noopener noreferrer"
             title={label}
             style={{ borderColor: `${color}40`, color }}
-            className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-[10px] font-bold border bg-surface/50 hover:opacity-80 transition-opacity"
+            className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-micro font-bold border bg-surface/50 hover:opacity-80 transition-opacity"
           >
             {SERVICE_INITIALS[key] ?? label.slice(0, 2).toUpperCase()}
           </a>

--- a/src/web/components/todays-pick.tsx
+++ b/src/web/components/todays-pick.tsx
@@ -155,7 +155,7 @@ export function TodaysPick({
         >
           <span className="text-accent text-xl font-bold leading-none">{scorePercent}</span>
           <span className="text-accent/70 text-xs font-semibold">%</span>
-          <span className="text-white/50 text-[9px] ml-1 uppercase tracking-wider">match</span>
+          <span className="text-white/50 text-micro-sm ml-1 uppercase tracking-wider">match</span>
         </div>
 
         {/* Artist name / logo */}
@@ -187,7 +187,7 @@ export function TodaysPick({
             {artist.genres.slice(0, 6).map((genre) => (
               <span
                 key={genre}
-                className="text-[10px] px-1.5 py-0.5 bg-bg border border-border rounded text-muted"
+                className="text-micro px-1.5 py-0.5 bg-bg border border-border rounded text-muted"
               >
                 {genre}
               </span>

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -11,6 +11,26 @@
   --color-info: #7dcfff;
   --color-text: #c0caf5;
   --color-muted: #565f89;
+
+  /* Compact text sizes for badges, pills, labels */
+  --font-size-micro: 0.625rem; /* 10px */
+  --font-size-micro-sm: 0.5625rem; /* 9px */
+  --font-size-micro-lg: 0.6875rem; /* 11px */
+
+  /* Service brand colors -- overridable per theme */
+  --color-svc-spotify: #1db954;
+  --color-svc-youtube: #ff0000;
+  --color-svc-apple: #fc3c44;
+  --color-svc-deezer: #a238ff;
+  --color-svc-tidal: #00ffff;
+  --color-svc-soundcloud: #ff5500;
+  --color-svc-bandcamp: #1da0c3;
+  --color-svc-unknown: #6b7084;
+  --color-svc-listenbrainz: #7a9cb8;
+  --color-svc-lastfm: #c47a7a;
+  --color-svc-musicbrainz: #d4a574;
+  --color-svc-ai: #9b7ab8;
+  --color-svc-webhook: #60a5fa;
 }
 
 /* Tokyo Night - Dark (Storm) */

--- a/src/web/pages/analytics.tsx
+++ b/src/web/pages/analytics.tsx
@@ -159,7 +159,7 @@ function DiscoveryChart({ batches }: { batches: AnalyticsBatch[] }) {
           )
         })}
       </div>
-      <div className="flex justify-between mt-2 text-[10px] text-muted">
+      <div className="flex justify-between mt-2 text-micro text-muted">
         <span>{firstDate ? formatDate(firstDate).split(',')[0] : ''}</span>
         <span>{lastDate ? formatDate(lastDate).split(',')[0] : ''}</span>
       </div>
@@ -281,7 +281,7 @@ function ScoreDistribution({ buckets }: { buckets: ScoreBucket[] }) {
       </div>
       <div className="flex gap-1 mt-1.5">
         {buckets.map((b) => (
-          <span key={b.bucket} className="flex-1 text-center text-[9px] text-muted truncate">
+          <span key={b.bucket} className="flex-1 text-center text-micro-sm text-muted truncate">
             {b.bucket.replace('%', '')}
           </span>
         ))}
@@ -336,7 +336,7 @@ function ApprovalTrendChart({ trend }: { trend: ApprovalTrend[] }) {
           )
         })}
       </svg>
-      <div className="flex justify-between mt-1.5 text-[10px] text-muted">
+      <div className="flex justify-between mt-1.5 text-micro text-muted">
         <span>{firstDate ? formatDate(firstDate).split(',')[0] : ''}</span>
         <span>{lastDate ? formatDate(lastDate).split(',')[0] : ''}</span>
       </div>

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -5,6 +5,7 @@ import { errMsg } from '@/core/validation'
 import { AlbumPicker } from '../components/album-picker'
 import { ApproveDialog } from '../components/approve-dialog'
 import { CardStack } from '../components/card-stack'
+import { ConfirmDialog } from '../components/confirm-dialog'
 import { Hint } from '../components/hint'
 import { MonitoringOptions, type MonitorOption } from '../components/monitoring-options'
 import { MoodPromptBar } from '../components/mood-prompt-bar'
@@ -220,11 +221,11 @@ function FeedbackInsights() {
                     style={{ width: `${Math.round(g.rate * 100)}%` }}
                   />
                 </div>
-                <span className="text-[10px] text-muted tabular-nums">
+                <span className="text-micro text-muted tabular-nums">
                   {Math.round(g.rate * 100)}%
                 </span>
               </div>
-              <div className="text-[10px] text-muted mt-0.5">{g.total} rated</div>
+              <div className="text-micro text-muted mt-0.5">{g.total} rated</div>
             </div>
           ))}
         </div>
@@ -310,6 +311,7 @@ export function DiscoverPage() {
   const [checkedIds, setCheckedIds] = useState<Set<number>>(new Set())
   const [bulkActing, setBulkActing] = useState(false)
   const [albumPickerRecId, setAlbumPickerRecId] = useState<number | null>(null)
+  const [showClearAllConfirm, setShowClearAllConfirm] = useState(false)
   const [activeDecades, setActiveDecades] = useState<Set<Decade>>(new Set())
   const [approveDialogState, setApproveDialogState] = useState<{
     recId: number
@@ -609,7 +611,6 @@ export function DiscoverPage() {
   }
 
   async function handleClearAll() {
-    if (!confirm('Reject all pending recommendations? This cannot be undone.')) return
     try {
       const pending = await getRecommendations({ status: 'pending', limit: '10000' })
       const ids = (pending.items as Array<{ id: number }>).map((r) => r.id)
@@ -879,7 +880,7 @@ export function DiscoverPage() {
                 {filter === 'pending' && (
                   <button
                     type="button"
-                    onClick={handleClearAll}
+                    onClick={() => setShowClearAllConfirm(true)}
                     className="px-2 py-1 text-xs text-muted hover:text-red-400 transition-colors"
                     title="Rejects all pending recommendations at once -- useful after reviewing a batch"
                   >
@@ -1288,6 +1289,18 @@ export function DiscoverPage() {
             />
           )
         })()}
+      {showClearAllConfirm && (
+        <ConfirmDialog
+          title="Reject all pending"
+          message="Reject all pending recommendations? This cannot be undone."
+          confirmLabel="Reject All"
+          onConfirm={() => {
+            setShowClearAllConfirm(false)
+            handleClearAll()
+          }}
+          onCancel={() => setShowClearAllConfirm(false)}
+        />
+      )}
     </div>
   )
 }

--- a/src/web/pages/genre-detail.tsx
+++ b/src/web/pages/genre-detail.tsx
@@ -53,7 +53,7 @@ function LibraryArtistCard({ artist }: { artist: LibraryArtist }) {
           <p className="text-xs text-muted truncate">{artist.disambiguation}</p>
         )}
         {genres.length > 0 && (
-          <p className="text-[10px] text-muted truncate mt-0.5">{genres.slice(0, 3).join(', ')}</p>
+          <p className="text-micro text-muted truncate mt-0.5">{genres.slice(0, 3).join(', ')}</p>
         )}
       </div>
     </div>
@@ -88,7 +88,7 @@ function GenreArtistCard({ artist }: { artist: GenreArtist }) {
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <p className="text-sm font-medium text-text truncate">{artist.name}</p>
-          <span className="shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-accent/20 text-accent">
+          <span className="shrink-0 text-micro font-semibold px-1.5 py-0.5 rounded bg-accent/20 text-accent">
             {(artist.score * 100).toFixed(0)}
           </span>
         </div>
@@ -96,7 +96,7 @@ function GenreArtistCard({ artist }: { artist: GenreArtist }) {
           <p className="text-xs text-muted truncate mt-0.5">{artist.aiReasoning}</p>
         )}
         {genres.length > 0 && (
-          <p className="text-[10px] text-muted truncate mt-0.5">{genres.slice(0, 3).join(', ')}</p>
+          <p className="text-micro text-muted truncate mt-0.5">{genres.slice(0, 3).join(', ')}</p>
         )}
       </div>
       <div className="shrink-0 flex items-center gap-1.5">

--- a/src/web/pages/playlist-detail.tsx
+++ b/src/web/pages/playlist-detail.tsx
@@ -106,7 +106,7 @@ function TrackRow({ track, index }: { track: PlaylistTrackRow; index: number }) 
         </p>
         <p className="text-xs text-muted truncate">{track.artistName}</p>
       </div>
-      <span className={`shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded ${badge.className}`}>
+      <span className={`shrink-0 text-micro font-medium px-1.5 py-0.5 rounded ${badge.className}`}>
         {badge.label}
       </span>
     </div>
@@ -262,7 +262,7 @@ export function PlaylistDetailPage() {
         <div className="flex items-start gap-3 flex-wrap">
           <h1 className="text-2xl font-bold text-text leading-tight">{playlist.name}</h1>
           <span
-            className={`mt-0.5 text-[11px] font-medium px-2 py-0.5 rounded-full ${badge.className}`}
+            className={`mt-0.5 text-micro-lg font-medium px-2 py-0.5 rounded-full ${badge.className}`}
           >
             {badge.label}
           </span>

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -1187,7 +1187,7 @@ function TargetTypeIcon({ type }: { type: string }) {
   const src = iconMap[type]
   if (src) return <img src={src} alt="" className="w-5 h-5" />
   return (
-    <span className="w-5 h-5 rounded bg-accent/20 text-accent text-[10px] font-bold flex items-center justify-center uppercase">
+    <span className="w-5 h-5 rounded bg-accent/20 text-accent text-micro font-bold flex items-center justify-center uppercase">
       {type.charAt(0)}
     </span>
   )

--- a/src/web/pages/subscriptions.tsx
+++ b/src/web/pages/subscriptions.tsx
@@ -12,6 +12,7 @@ import {
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
+import { ConfirmDialog } from '../components/confirm-dialog'
 import { Hint } from '../components/hint'
 import { SubscriptionForm, type SubscriptionFormData } from '../components/subscription-form'
 import { SubscriptionPresets } from '../components/subscription-presets'
@@ -294,6 +295,10 @@ export default function SubscriptionsPage() {
     | null
   >(null)
   const [showPresets, setShowPresets] = useState(false)
+  const [confirmDeleteSub, setConfirmDeleteSub] = useState<{
+    id: number
+    name: string
+  } | null>(null)
 
   // Auto-open create form when ?genre= is present
   useEffect(() => {
@@ -547,11 +552,7 @@ export default function SubscriptionsPage() {
                   sub,
                 })
               }
-              onDelete={() => {
-                if (confirm(`Delete "${sub.name}"?`)) {
-                  deleteMutation.mutate(sub.id)
-                }
-              }}
+              onDelete={() => setConfirmDeleteSub({ id: sub.id, name: sub.name })}
               onToggle={() => toggleMutation.mutate({ id: sub.id, enabled: !sub.enabled })}
               onRunNow={() => runNowMutation.mutate(sub.id)}
             />
@@ -588,6 +589,18 @@ export default function SubscriptionsPage() {
             }
           }}
           onCancel={() => setShowForm(null)}
+        />
+      )}
+      {confirmDeleteSub && (
+        <ConfirmDialog
+          title="Delete subscription"
+          message={`Delete "${confirmDeleteSub.name}"? This cannot be undone.`}
+          confirmLabel="Delete"
+          onConfirm={() => {
+            deleteMutation.mutate(confirmDeleteSub.id)
+            setConfirmDeleteSub(null)
+          }}
+          onCancel={() => setConfirmDeleteSub(null)}
         />
       )}
     </div>

--- a/src/web/pages/user-management.tsx
+++ b/src/web/pages/user-management.tsx
@@ -3,6 +3,7 @@ import { Plus } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { errMsg } from '@/core/validation'
+import { ConfirmDialog } from '../components/confirm-dialog'
 import { Hint } from '../components/hint'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
@@ -17,6 +18,10 @@ import {
 export function UserManagementPage() {
   const queryClient = useQueryClient()
   const [showForm, setShowForm] = useState(false)
+  const [confirmDeleteUser, setConfirmDeleteUser] = useState<{
+    id: number
+    username: string
+  } | null>(null)
   const [newUsername, setNewUsername] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [newIsAdmin, setNewIsAdmin] = useState(false)
@@ -174,11 +179,7 @@ export function UserManagementPage() {
                 <Button
                   size="sm"
                   variant="destructive"
-                  onClick={() => {
-                    if (confirm(`Delete user "${user.username}"?`)) {
-                      deleteUser.mutate(user.id)
-                    }
-                  }}
+                  onClick={() => setConfirmDeleteUser({ id: user.id, username: user.username })}
                   disabled={deleteUser.isPending || isSelf || isLastAdmin}
                   title={
                     isSelf
@@ -195,6 +196,18 @@ export function UserManagementPage() {
           )
         })}
       </div>
+      {confirmDeleteUser && (
+        <ConfirmDialog
+          title="Delete user"
+          message={`Delete user "${confirmDeleteUser.username}"? This cannot be undone.`}
+          confirmLabel="Delete"
+          onConfirm={() => {
+            deleteUser.mutate(confirmDeleteUser.id)
+            setConfirmDeleteUser(null)
+          }}
+          onCancel={() => setConfirmDeleteUser(null)}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Addresses the top findings from a 6-pillar UI audit (scored 20/24):

- **Service brand color tokens**: 13 hardcoded hex colors in streaming-links and recommendation-card extracted to `--color-svc-*` CSS custom properties, overridable per theme
- **Custom ConfirmDialog**: 4 native `confirm()` dialogs replaced with a themed modal component matching existing patterns (user delete, bulk reject, subscription delete, playlist delete)
- **Text size tokens**: `--font-size-micro` (10px), `micro-sm` (9px), `micro-lg` (11px) added to `@theme` -- 44 arbitrary `text-[Npx]` values replaced across 18 files
- **ErrorBoundary**: wraps the route tree to prevent white-screen on unhandled render errors, with "Try again" / "Go home" recovery UI

## Test plan
- [x] `bun run lint` -- clean (our files)
- [x] `bun run typecheck` -- clean
- [x] `bun run test` -- 1132/1132 passing
- [ ] CI passes (lint, typecheck, test, build)
- [ ] Visual spot-check: streaming link pills still show correct brand colors
- [ ] Visual spot-check: confirm dialogs appear styled on delete/reject actions
- [ ] Visual spot-check: micro text sizes render correctly in badges/pills