### PR TITLE
feat(ci): push Docker images to Docker Hub alongside GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            docker.io/iuliandita/digarr
           tags: |
             type=semver,pattern={{version}},value=${{ steps.tag.outputs.value }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag.outputs.value }}


### PR DESCRIPTION
## Summary
- Add `docker.io/iuliandita/digarr` to the metadata-action images list
- Both GHCR and Docker Hub get identical multi-arch tags from the same build
- No duplicate builds -- metadata-action generates tags for both registries

## Test plan
- [ ] Trigger a release and verify `docker.io/iuliandita/digarr` shows the new tag
- [ ] `docker pull iuliandita/digarr:latest` works
- [ ] GHCR images still pushed correctly