### PR TITLE
fix(pipeline): exclude top listened artists from recommendations

### DIFF
--- a/src/core/pipeline/filter.ts
+++ b/src/core/pipeline/filter.ts
@@ -6,6 +6,7 @@ export function filter(
   rejectedMbids: Set<string> | Map<string, Date>,
   cooldownDays: number,
   scoreThreshold: number,
+  topArtistNames?: Set<string>,
 ): ScoredArtist[] {
   const now = new Date()
   const cooldownMs = cooldownDays * 24 * 60 * 60 * 1000
@@ -13,6 +14,9 @@ export function filter(
   return artists.filter((artist) => {
     // Remove artists already in library
     if (libraryMbids.has(artist.mbid)) return false
+
+    // Remove artists the user already listens to (by name)
+    if (topArtistNames?.has(artist.name.toLowerCase())) return false
 
     // Remove artists rejected within the cooldown window
     if (rejectedMbids instanceof Map) {

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -229,12 +229,22 @@ export class PipelineOrchestrator extends EventEmitter {
       for (const mbid of existingMbids) {
         libraryMbids.add(mbid)
       }
+
+      // Also exclude top artists from listening history -- the AI prompt asks
+      // models to skip these, but smaller models ignore the instruction.
+      const topArtistNames = new Set<string>()
+      for (const artist of tasteProfile.topArtists) {
+        topArtistNames.add(artist.name.toLowerCase())
+        if (artist.mbid) libraryMbids.add(artist.mbid)
+      }
+
       const filtered = filter(
         scored,
         libraryMbids,
         rejectedMbids,
         prefs.rejectionCooldownDays,
         prefs.scoreThreshold,
+        topArtistNames,
       )
 
       this.emit('progress', {

--- a/src/core/subscriptions/runner.ts
+++ b/src/core/subscriptions/runner.ts
@@ -88,6 +88,7 @@ async function executePipeline(
     deps.rejectedMbids,
     deps.cooldownDays,
     threshold,
+    deps.topArtistNames,
   )
 
   let batchId: number | undefined

--- a/src/core/subscriptions/types.ts
+++ b/src/core/subscriptions/types.ts
@@ -113,6 +113,8 @@ export type SubscriptionRunDeps = {
   feedbackHistory: Map<string, { approved: number; total: number }>
   cooldownDays: number
   defaultScoreThreshold: number
+  /** Lowercase names of the user's top listened artists -- excluded from results. */
+  topArtistNames?: Set<string>
 }
 
 /** DB query interface for the subscription runner. */

--- a/tests/core/pipeline/filter.test.ts
+++ b/tests/core/pipeline/filter.test.ts
@@ -105,4 +105,45 @@ describe('filter()', () => {
     const result = filter([], new Set(), new Map(), 90, 0.5)
     expect(result).toEqual([])
   })
+
+  describe('top artist name exclusion', () => {
+    it('removes artists whose name matches a top listened artist', () => {
+      const artist = makeArtist('mbid-vu', 0.8)
+      artist.name = 'The Velvet Underground'
+      const topNames = new Set(['the velvet underground'])
+
+      const result = filter([artist], new Set(), new Map(), 90, 0.5, topNames)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('name check is case-insensitive (resolved name has different casing)', () => {
+      const artist = makeArtist('mbid-sy', 0.8)
+      artist.name = 'Sonic Youth'
+      const topNames = new Set(['sonic youth'])
+
+      const result = filter([artist], new Set(), new Map(), 90, 0.5, topNames)
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('does not exclude when topArtistNames is not provided', () => {
+      const artist = makeArtist('mbid-vu', 0.8)
+      artist.name = 'The Velvet Underground'
+
+      const result = filter([artist], new Set(), new Map(), 90, 0.5)
+
+      expect(result).toHaveLength(1)
+    })
+
+    it('does not exclude artists with different names', () => {
+      const artist = makeArtist('mbid-du', 0.8)
+      artist.name = 'Digital Underground'
+      const topNames = new Set(['the velvet underground'])
+
+      const result = filter([artist], new Set(), new Map(), 90, 0.5, topNames)
+
+      expect(result).toHaveLength(1)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Adds server-side exclusion of the user's top listened artists in the filter stage, as a backstop for when the AI prompt instruction is ignored (common with smaller models like gemini-flash)
- The taste profile's top artist names are checked case-insensitively against resolved artist names, and their MBIDs are folded into the library exclusion set
- The subscription runner's deps type gains an optional `topArtistNames` field for future use

Ref #42

## Test plan

- [x] New filter tests: name exclusion, case-insensitivity, no-op when omitted, no false positives
- [x] Full test suite passes (1140 tests)
- [x] Lint + typecheck clean