### PR TITLE
chore: add setup info to bug template, switch default theme to youtarr

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -48,6 +48,41 @@ body:
     validations:
       required: false
 
+  - type: checkboxes
+    id: listening-sources
+    attributes:
+      label: Listening sources
+      description: Which listening sources do you have connected?
+      options:
+        - label: ListenBrainz
+        - label: Last.fm
+        - label: Spotify
+        - label: Plex
+        - label: Jellyfin
+        - label: Discogs
+
+  - type: checkboxes
+    id: targets
+    attributes:
+      label: Targets / integrations
+      description: Which targets or integrations are you using?
+      options:
+        - label: Lidarr
+        - label: Navidrome
+        - label: Jellyfin playlists
+        - label: Plex playlists
+        - label: Spotify playlists
+        - label: None (discovery only)
+
+  - type: input
+    id: ai-provider
+    attributes:
+      label: AI provider and model
+      description: Which AI provider and model are you using for recommendations?
+      placeholder: "e.g. Gemini / gemini-2.5-flash, Anthropic / claude-haiku, Ollama / llama3"
+    validations:
+      required: false
+
   - type: textarea
     id: logs
     attributes:

--- a/src/web/lib/theme.ts
+++ b/src/web/lib/theme.ts
@@ -54,7 +54,7 @@ export function setStoredMode(mode: Mode): void {
 export function getStoredColorTheme(): ColorTheme {
   const stored = localStorage.getItem(COLOR_KEY)
   if (COLOR_THEMES.some((t) => t.id === stored)) return stored as ColorTheme
-  return 'tokyonight'
+  return 'youtarr'
 }
 
 export function setStoredColorTheme(theme: ColorTheme): void {


### PR DESCRIPTION
## Summary

- **Bug report template**: adds checkboxes for listening sources (LB, Last.fm, Spotify, Plex, Jellyfin, Discogs), targets (Lidarr, Navidrome, playlist targets, discovery-only), and a text field for AI provider/model. Would have saved a round-trip on #42.
- **Default theme**: switches from tokyonight to youtarr for new users. Existing users keep their stored preference (localStorage).

## Test plan

- [x] Typecheck + lint clean
- [ ] Preview the bug template on GitHub after merge