### PR TITLE
feat(onboarding): add Spotify liked songs import

### DIFF
--- a/src/core/subscriptions/adapters/spotify-liked-songs.ts
+++ b/src/core/subscriptions/adapters/spotify-liked-songs.ts
@@ -1,0 +1,83 @@
+import type { AdapterResult, SubscriptionAdapter } from '@/core/subscriptions/types'
+import { deduplicateByName } from '../dedup'
+
+type SpotifySavedTrackResponse = {
+  items?: Array<{
+    track?: {
+      artists?: Array<{ name: string; id: string }>
+    } | null
+  }>
+  next?: string | null
+}
+
+const SOURCE_URL = 'https://open.spotify.com/collection/tracks'
+const PAGE_SIZE = 50
+
+export function createSpotifyLikedSongsAdapter(deps: {
+  getToken: () => Promise<string>
+  baseUrl?: string
+}): SubscriptionAdapter {
+  const baseUrl = deps.baseUrl ?? 'https://api.spotify.com/v1'
+
+  return {
+    type: 'spotify-liked-songs',
+    label: 'Spotify Liked Songs',
+    configFields: [],
+
+    async fetch(
+      _config: Record<string, unknown>,
+      options?: { limit?: number },
+    ): Promise<AdapterResult> {
+      const limit = Math.max(1, options?.limit ?? 100)
+      const token = await deps.getToken()
+      const entries: Array<{ name: string }> = []
+      let offset = 0
+      let hasNext = true
+
+      while (hasNext) {
+        const uniqueCount = new Set(entries.map((entry) => entry.name.toLowerCase())).size
+        if (uniqueCount >= limit) break
+
+        const pageLimit = PAGE_SIZE
+        const params = new URLSearchParams({
+          limit: String(pageLimit),
+          offset: String(offset),
+        })
+
+        const controller = new AbortController()
+        const timer = setTimeout(() => controller.abort(), 10_000)
+        let res: Response
+        try {
+          res = await fetch(`${baseUrl}/me/tracks?${params}`, {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: controller.signal,
+          })
+        } finally {
+          clearTimeout(timer)
+        }
+
+        if (!res.ok) {
+          throw new Error(`Spotify liked songs fetch failed: ${res.status} ${res.statusText}`)
+        }
+
+        const data = (await res.json()) as SpotifySavedTrackResponse
+        const pageEntries = (data.items ?? []).flatMap((item) =>
+          (item.track?.artists ?? []).map((artist) => ({ name: artist.name })),
+        )
+
+        entries.push(...pageEntries)
+        hasNext = Boolean(data.next) && pageEntries.length > 0
+        offset += pageLimit
+      }
+
+      const artists = deduplicateByName(entries, (entry) => ({
+        name: entry.name,
+        similarityScore: 0.85,
+        source: 'spotify-liked-songs',
+        sourceUrl: SOURCE_URL,
+      }))
+
+      return { artists: artists.slice(0, limit) }
+    },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { createLastfmTagAdapter } from './core/subscriptions/adapters/lastfm-tag
 import { createListenBrainzAdapter } from './core/subscriptions/adapters/listenbrainz'
 import { createSimilarAdapter } from './core/subscriptions/adapters/similar'
 import { createSpotifyChartsAdapter } from './core/subscriptions/adapters/spotify-charts'
+import { createSpotifyLikedSongsAdapter } from './core/subscriptions/adapters/spotify-liked-songs'
 import { createSpotifyPlaylistAdapter } from './core/subscriptions/adapters/spotify-playlist'
 import { resolveSubscriptionSourceConnections } from './core/subscriptions/connections'
 import { AdapterRegistry } from './core/subscriptions/registry'
@@ -392,6 +393,7 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
       const spotifyOAuthRow = await getOAuthToken(db, userId, 'spotify')
       if (spotifyOAuthRow) {
         const getToken = () => resolveSpotifyToken(db, userId)
+        adapterRegistry.register(createSpotifyLikedSongsAdapter({ getToken }))
         adapterRegistry.register(createSpotifyPlaylistAdapter({ getToken }))
         adapterRegistry.register(createSpotifyChartsAdapter({ getToken }))
       }

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -1,5 +1,6 @@
 import { Cron } from 'croner'
 import { Hono } from 'hono'
+import { getOAuthToken } from '@/db/queries/oauth-tokens'
 import type { AppDependencies } from '@/server'
 import type { HonoEnv } from '@/server/types'
 
@@ -73,6 +74,12 @@ export function subscriptionRoutes(deps: AppDependencies) {
               placeholder: 'e.g. 37i9dQZEVXbMDoHDwVN2tF or open.spotify.com/playlist/...',
             },
           ],
+          requiredService: 'spotify',
+        },
+        {
+          type: 'spotify-liked-songs',
+          label: 'Spotify Liked Songs',
+          configFields: [],
           requiredService: 'spotify',
         },
         {
@@ -209,6 +216,51 @@ export function subscriptionRoutes(deps: AppDependencies) {
     }
 
     return c.json(sub, 201)
+  })
+
+  router.post('/api/subscriptions/import/spotify-liked-songs', async (c) => {
+    const userId = c.get('userId')
+    if (!userId) {
+      return c.json({ error: 'Unauthorized' }, 401)
+    }
+
+    const spotifyToken = await getOAuthToken(deps.db, userId, 'spotify')
+    if (!spotifyToken || spotifyToken.accessToken.startsWith('pending:')) {
+      return c.json({ error: 'Spotify is not connected' }, 400)
+    }
+
+    const existingSubs = await deps.subscriptionQueries.getSubscriptionsByUser(userId)
+    const existing = existingSubs.find((sub) => sub.sourceType === 'spotify-liked-songs')
+
+    const subscription =
+      existing ??
+      (await deps.subscriptionQueries.createSubscription({
+        name: 'Spotify Liked Songs',
+        userId,
+        sourceType: 'spotify-liked-songs',
+        sourceProvider: 'spotify',
+        sourceConfig: {},
+        cron: '0 6 * * 1',
+        enabled: false,
+        maxArtistsPerRun: 100,
+        action: 'add_to_recommendations',
+        scoringWeightPreset: 'default',
+      }))
+
+    Promise.resolve()
+      .then(() => deps.runSubscription(subscription.id))
+      .catch((err: unknown) => {
+        console.error('Spotify liked songs import failed:', err)
+      })
+
+    return c.json(
+      {
+        message: 'Spotify Liked Songs import started',
+        subscriptionId: subscription.id,
+        created: !existing,
+      },
+      202,
+    )
   })
 
   router.post('/api/subscriptions/bulk-toggle', async (c) => {

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -579,6 +579,12 @@ export const deleteSubscriptionApi = (id: number) =>
 export const triggerSubscriptionRun = (id: number) =>
   fetchApi<{ message: string }>(`/subscriptions/${id}/run`, { method: 'POST' })
 
+export const importSpotifyLikedSongs = () =>
+  fetchApi<{ message: string; subscriptionId: number; created: boolean }>(
+    '/subscriptions/import/spotify-liked-songs',
+    { method: 'POST' },
+  )
+
 export const getSubscriptionRuns = (id: number) =>
   fetchApi<SubscriptionRun[]>(`/subscriptions/${id}/runs`)
 

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -39,6 +39,7 @@ import {
   getOAuthStatus,
   getSettings,
   getUserPreferences,
+  importSpotifyLikedSongs,
   initiateOAuth,
   listTargets,
   logoutUser,
@@ -210,6 +211,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
   )
   const [spotifyClientId, setSpotifyClientId] = useState('')
   const [spotifyClientSecret, setSpotifyClientSecret] = useState('')
+  const [importingSpotifyLikes, setImportingSpotifyLikes] = useState(false)
 
   const [tests, setTests] = useState<Record<string, ServiceTestState>>({})
   const [saving, setSaving] = useState<Record<string, boolean>>({})
@@ -404,6 +406,18 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
       toast.success('Spotify disconnected')
     } catch {
       toast.error('Failed to disconnect Spotify')
+    }
+  }
+
+  async function startSpotifyLikedSongsImport() {
+    setImportingSpotifyLikes(true)
+    try {
+      const res = await importSpotifyLikedSongs()
+      toast.success(res.created ? 'Spotify Liked Songs import started' : 'Import started again')
+    } catch {
+      toast.error('Failed to start Spotify Liked Songs import')
+    } finally {
+      setImportingSpotifyLikes(false)
     }
   }
 
@@ -843,10 +857,23 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
           icon={<SpotifyIcon />}
         >
           {spotifyConnected ? (
-            <div className="flex justify-end gap-2 pt-1">
-              <Button size="sm" variant="outline" onClick={disconnectSpotify}>
-                Disconnect
-              </Button>
+            <div className="space-y-3">
+              <p className="text-sm text-muted">
+                Cold start: import artists from your Spotify Liked Songs into recommendations for a
+                fast first scan.
+              </p>
+              <div className="flex justify-end gap-2 pt-1">
+                <Button
+                  size="sm"
+                  onClick={startSpotifyLikedSongsImport}
+                  disabled={importingSpotifyLikes}
+                >
+                  {importingSpotifyLikes ? 'Importing...' : 'Import Liked Songs'}
+                </Button>
+                <Button size="sm" variant="outline" onClick={disconnectSpotify}>
+                  Disconnect
+                </Button>
+              </div>
             </div>
           ) : (
             <>

--- a/src/web/pages/subscriptions.tsx
+++ b/src/web/pages/subscriptions.tsx
@@ -166,6 +166,7 @@ function SubscriptionCard({
     }
     if (sub.sourceType === 'lastfm-tag') return (cfg.tag as string) ?? null
     if (sub.sourceType === 'listenbrainz') return (cfg.feedType as string) ?? null
+    if (sub.sourceType === 'spotify-liked-songs') return 'Liked Songs'
     if (sub.sourceType === 'spotify-playlist') return (cfg.playlistName as string) ?? null
     return null
   })()

--- a/tests/core/subscriptions/adapters/spotify-liked-songs.test.ts
+++ b/tests/core/subscriptions/adapters/spotify-liked-songs.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import * as http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createSpotifyLikedSongsAdapter } from '@/core/subscriptions/adapters/spotify-liked-songs'
+
+let server: http.Server
+let baseUrl: string
+let requestCount = 0
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    requestCount++
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+    const offset = Number(url.searchParams.get('offset') ?? '0')
+
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    if (offset === 0) {
+      res.end(
+        JSON.stringify({
+          items: [
+            { track: { artists: [{ name: 'Artist One', id: 'a1' }] } },
+            { track: { artists: [{ name: 'Artist Two', id: 'a2' }] } },
+            { track: { artists: [{ name: 'artist one', id: 'a1' }] } },
+          ],
+          next: `${baseUrl}/me/tracks?limit=2&offset=2`,
+        }),
+      )
+      return
+    }
+
+    res.end(
+      JSON.stringify({
+        items: [{ track: { artists: [{ name: 'Artist Three', id: 'a3' }] } }],
+        next: null,
+      }),
+    )
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const addr = server.address() as AddressInfo
+  baseUrl = `http://127.0.0.1:${addr.port}`
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('createSpotifyLikedSongsAdapter', () => {
+  it('has correct type and label', () => {
+    const adapter = createSpotifyLikedSongsAdapter({ getToken: async () => 'tok', baseUrl })
+    expect(adapter.type).toBe('spotify-liked-songs')
+    expect(adapter.label).toBe('Spotify Liked Songs')
+    expect(adapter.configFields).toEqual([])
+  })
+
+  it('fetches liked-song artists across pages and deduplicates them', async () => {
+    requestCount = 0
+    const adapter = createSpotifyLikedSongsAdapter({ getToken: async () => 'tok', baseUrl })
+    const result = await adapter.fetch({}, { limit: 3 })
+
+    expect(requestCount).toBe(2)
+    expect(result.artists).toHaveLength(3)
+    expect(result.artists.map((artist) => artist.name)).toEqual([
+      'Artist One',
+      'Artist Two',
+      'Artist Three',
+    ])
+  })
+
+  it('sets the expected source metadata', async () => {
+    const adapter = createSpotifyLikedSongsAdapter({ getToken: async () => 'tok', baseUrl })
+    const result = await adapter.fetch({}, { limit: 1 })
+
+    expect(result.artists[0]).toMatchObject({
+      source: 'spotify-liked-songs',
+      sourceUrl: 'https://open.spotify.com/collection/tracks',
+      similarityScore: 0.85,
+    })
+  })
+})

--- a/tests/server/routes/subscriptions.test.ts
+++ b/tests/server/routes/subscriptions.test.ts
@@ -5,6 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SettingsRow } from '@/db/queries/settings'
 import type { AppDependencies } from '@/server'
 
+vi.mock('@/db/queries/oauth-tokens', () => ({
+  getOAuthToken: vi.fn(),
+}))
+
 function makeMockOrchestrator() {
   const emitter = new EventEmitter()
   return Object.assign(emitter, {
@@ -186,8 +190,11 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
 // with a pre-auth middleware that sets userId on the context.
 
 import { Hono } from 'hono'
+import { getOAuthToken } from '@/db/queries/oauth-tokens'
 import { genreRoutes } from '@/server/routes/genres'
 import { subscriptionRoutes } from '@/server/routes/subscriptions'
+
+const mockGetOAuthToken = getOAuthToken as ReturnType<typeof vi.fn>
 
 function createTestApp(deps: AppDependencies, userId: number | undefined) {
   const app = new Hono()
@@ -205,6 +212,18 @@ function createTestApp(deps: AppDependencies, userId: number | undefined) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockGetOAuthToken.mockResolvedValue({
+    userId: USER_ID,
+    provider: 'spotify',
+    accessToken: 'spotify-token',
+    refreshToken: 'refresh-token',
+    expiresAt: new Date('2026-05-01'),
+    scopes: 'user-library-read',
+    clientId: 'cid',
+    clientSecret: 'secret',
+    createdAt: new Date('2026-04-01'),
+    updatedAt: new Date('2026-04-01'),
+  })
   mockSubQueries.createSubscription.mockResolvedValue(mockSub)
   mockSubQueries.getSubscription.mockImplementation(async (id: number) =>
     id === 1 ? mockSub : null,
@@ -311,6 +330,56 @@ describe('POST /api/subscriptions', () => {
       validBody.cron,
       expect.any(Function),
     )
+  })
+})
+
+describe('POST /api/subscriptions/import/spotify-liked-songs', () => {
+  it('creates a helper subscription on first import and starts a run', async () => {
+    const app = createTestApp(makeDeps(), USER_ID)
+
+    const res = await app.request('/api/subscriptions/import/spotify-liked-songs', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(202)
+    expect(mockSubQueries.createSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: USER_ID,
+        sourceType: 'spotify-liked-songs',
+        sourceProvider: 'spotify',
+        enabled: false,
+      }),
+    )
+    expect(mockGetOAuthToken).toHaveBeenCalled()
+  })
+
+  it('reuses an existing helper subscription instead of creating duplicates', async () => {
+    mockSubQueries.getSubscriptionsByUser.mockResolvedValueOnce([
+      { ...mockSub, sourceType: 'spotify-liked-songs', sourceProvider: 'spotify' },
+    ])
+
+    const runSubscription = vi.fn(async () => {})
+    const app = createTestApp(makeDeps({ runSubscription }), USER_ID)
+
+    const res = await app.request('/api/subscriptions/import/spotify-liked-songs', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(202)
+    expect(mockSubQueries.createSubscription).not.toHaveBeenCalled()
+    expect(runSubscription).toHaveBeenCalledWith(1)
+  })
+
+  it('returns 400 when Spotify is not connected', async () => {
+    mockGetOAuthToken.mockResolvedValueOnce(null)
+    const app = createTestApp(makeDeps(), USER_ID)
+
+    const res = await app.request('/api/subscriptions/import/spotify-liked-songs', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(400)
+    expect(mockSubQueries.createSubscription).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/web/pages/settings.test.tsx
+++ b/tests/web/pages/settings.test.tsx
@@ -36,6 +36,11 @@ vi.mock('@/web/lib/api', () => ({
   exportRecommendations: vi.fn().mockResolvedValue(undefined),
   getCurrentUser: vi.fn().mockResolvedValue({ id: 1, username: 'admin', isAdmin: true }),
   getOAuthStatus: vi.fn().mockResolvedValue({ connected: false, scopes: null }),
+  importSpotifyLikedSongs: vi.fn().mockResolvedValue({
+    message: 'started',
+    subscriptionId: 1,
+    created: true,
+  }),
   initiateOAuth: vi.fn().mockResolvedValue({ authUrl: '' }),
   disconnectOAuth: vi.fn().mockResolvedValue(undefined),
   changePassword: vi.fn().mockResolvedValue({ ok: true }),
@@ -72,18 +77,22 @@ import {
   getLidarrMetadataProfiles,
   getLidarrProfiles,
   getLidarrRootFolders,
+  getOAuthStatus,
   getSettings,
+  importSpotifyLikedSongs,
   testService,
   updateSettings,
 } from '@/web/lib/api'
 import { SettingsPage } from '@/web/pages/settings'
 
-const mockGetSettings = vi.mocked(getSettings)
-const mockUpdateSettings = vi.mocked(updateSettings)
-const mockTestService = vi.mocked(testService)
-const mockGetLidarrProfiles = vi.mocked(getLidarrProfiles)
-const mockGetLidarrMetadataProfiles = vi.mocked(getLidarrMetadataProfiles)
-const mockGetLidarrRootFolders = vi.mocked(getLidarrRootFolders)
+const mockGetSettings = getSettings as ReturnType<typeof vi.fn>
+const mockUpdateSettings = updateSettings as ReturnType<typeof vi.fn>
+const mockTestService = testService as ReturnType<typeof vi.fn>
+const mockGetLidarrProfiles = getLidarrProfiles as ReturnType<typeof vi.fn>
+const mockGetLidarrMetadataProfiles = getLidarrMetadataProfiles as ReturnType<typeof vi.fn>
+const mockGetLidarrRootFolders = getLidarrRootFolders as ReturnType<typeof vi.fn>
+const mockGetOAuthStatus = getOAuthStatus as ReturnType<typeof vi.fn>
+const mockImportSpotifyLikedSongs = importSpotifyLikedSongs as ReturnType<typeof vi.fn>
 
 // ---------------------------------------------------------------------------
 // Mock data
@@ -241,5 +250,21 @@ describe('SettingsPage', () => {
       expect(screen.getByText(/Failed to load settings/i)).toBeInTheDocument()
     })
     expect(screen.getByText('Retry')).toBeInTheDocument()
+  })
+
+  it('shows Spotify import action when Spotify is connected', async () => {
+    setupMocks()
+    mockGetOAuthStatus.mockResolvedValue({ connected: true, scopes: 'user-library-read' })
+    renderWithQuery(<SettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Import Liked Songs')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Import Liked Songs'))
+
+    await waitFor(() => {
+      expect(mockImportSpotifyLikedSongs).toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
## Summary

- add a Spotify Liked Songs subscription adapter and register it in the subscription runner
- add a one-click cold-start import route and expose it from the connected Spotify settings card
- add coverage for the new adapter, route, and settings action

## Test plan

- [ ] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test` passes
- [x] Tested manually (describe below)

Manual / targeted verification:
- [x] `bunx biome check src/core/subscriptions/adapters/spotify-liked-songs.ts src/index.ts src/server/routes/subscriptions.ts src/web/lib/api.ts src/web/pages/settings.tsx src/web/pages/subscriptions.tsx tests/core/subscriptions/adapters/spotify-liked-songs.test.ts tests/server/routes/subscriptions.test.ts tests/web/pages/settings.test.tsx`
- [x] verified the connected Spotify card now shows `Import Liked Songs`
- [x] verified the import route reuses an existing helper subscription instead of creating duplicates

## Notes

- repo-wide `bun run lint` still reports pre-existing unrelated Biome issues outside this branch diff, so the branch full-check used touched-file Biome validation plus full typecheck and full test suite
