### PR TITLE
ci: make macos compatibility non-blocking

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -53,6 +53,9 @@ jobs:
   docker-macos:
     name: Docker Desktop (macOS)
     runs-on: macos-latest
+    # Hosted macOS runners are flaky when booting Docker Desktop; keep the
+    # signal visible in PRs and scheduled runs without blocking merges.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## Summary
- mark the flaky macOS Docker Desktop compatibility job as non-blocking
- keep the job visible in PRs and scheduled runs for signal
- document why the override exists in the workflow

## Verification
- python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/compatibility.yml")); print("YAML OK")'
- git diff --check