### PR TITLE
docs: sync docs with recent releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ docs/superpowers/
 .superpowers/
 .planning/
 UI-REVIEW.md
+mempalace.yaml
+entities.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable user-facing changes are documented here.
+
+## v0.18.0 - 2026-04-08
+
+### Added
+
+- Album-level library sync for Lidarr, Plex, and Jellyfin
+- Per-source album sync counts in the admin Library Sources panel
+- MusicBrainz-backed album reconciliation during library sync
+
+### Changed
+
+- Library sync writes artist and album snapshots atomically to avoid partial source updates
+
+## v0.17.1 - 2026-04-08
+
+### Fixed
+
+- Playlist-only approval targets now work correctly
+
+## v0.17.0 - 2026-04-07
+
+### Added
+
+- Plex and Jellyfin library sync alongside Lidarr
+- Library reconciliation review with correct and ignore override flows
+- Library sync status surfaces in the admin UI and setup wizard
+
+### Changed
+
+- Pipeline and quick-discover flows can use the library cache when available
+
+## v0.16.0 - 2026-04-06
+
+### Added
+
+- Admin job history and health endpoints for pipeline, subscription, target, and playlist work
+- API smoke tests, Playwright browser tests, and CI gates for critical workflows
+- Application-level backup and restore with encrypted field handling
+
+### Changed
+
+- Startup now performs a pre-flight migration check and auto-backup before applying schema changes
+
+## v0.15.0 - v0.15.5 - 2026-04-04
+
+### Added
+
+- Data hygiene tools for genre rebuilds, rescoring, dedupe repair, AI reasoning audit, and session cleanup
+
+### Fixed
+
+- Security and resilience hardening across auth, backup/restore, scoring, webhooks, and deployment manifests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,13 +61,17 @@ TypeScript strict mode is enforced. No `any` -- use `unknown`, generics, or prop
 ## Testing
 
 ```sh
+bun run lint
+bun run typecheck
 bun run test         # run once
 bun run test:watch   # watch mode
 bun run test:e2e     # Playwright browser tests (needs dev servers running)
 bun run test:e2e:ui  # Playwright UI mode
 ```
 
-Tests live in `tests/`. Keep them close to the code they cover. E2E tests are in `tests/e2e/` with `api/` (vitest, API smoke tests) and `browser/` (Playwright) subdirectories. Browser tests require `bunx playwright install --with-deps chromium` first.
+Tests live in `tests/`. Keep them close to the code they cover. E2E coverage lives in `tests/e2e/` with `api/` (Vitest smoke tests) and `browser/` (Playwright) subdirectories. Browser tests require `bunx playwright install --with-deps chromium` first, plus both dev servers running (`bun run dev` on `:3000` and `bun run dev:web` on `:5173`).
+
+For route, workflow, or UI changes, run `bun run test:e2e` before opening a PR. CI also runs the smoke and browser suites, but the expectation is that branch diffs affecting those paths get a local pass first.
 
 ---
 
@@ -76,8 +80,9 @@ Tests live in `tests/`. Keep them close to the code they cover. E2E tests are in
 1. Fork and create a branch: `git checkout -b feat/my-thing`
 2. Make your changes, keeping commits focused
 3. Confirm `lint`, `typecheck`, and `test` all pass
-4. Open a PR against `main` -- fill in the template
-5. A maintainer will review; be ready to iterate
+4. Run `bun run test:e2e` if your change affects routes, workflows, or UI behavior
+5. Open a PR against `main` -- fill in the template
+6. A maintainer will review; be ready to iterate
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 **AI-powered music discovery for your *arr stack.** Connect your listening sources (ListenBrainz, Last.fm, Spotify, Plex, Jellyfin, Discogs), pick an AI provider, and Digarr builds a taste profile, discovers new artists through a 7-stage pipeline, and scores them with a weighted formula that learns from your feedback. Approve what you like -- artists go straight to Lidarr, Spotify playlists, or your media server. Describe a mood in plain English and get instant results. Import artists from Spotify Liked Songs for a faster cold start. Set up subscriptions that discover new music on a schedule while you sleep. Generate weekly digest playlists automatically. Browse your library by genre with deep-cut discovery. All self-hosted, all yours.
 
-> **Beta software -- working toward v1.0.** Usable and actively developed, but expect rough edges. Things move fast during the beta -- there may be several releases per day with bug fixes, new features, and improvements. Check the [releases page](https://github.com/iuliandita/digarr/releases) frequently and read the release notes before updating. We'd love your help: set it up, break things, [report issues](https://github.com/iuliandita/digarr/issues), and share your feature ideas.
+> **Beta software -- working toward v1.0.** Usable and actively developed, but expect rough edges. Things move fast during the beta -- there may be several releases per day with bug fixes, new features, and improvements. Check the [releases page](https://github.com/iuliandita/digarr/releases) and [CHANGELOG.md](CHANGELOG.md) before updating. We'd love your help: set it up, break things, [report issues](https://github.com/iuliandita/digarr/issues), and share your feature ideas.
 >
 > Free and open source, forever. No tracking, no telemetry, no data collection -- your music taste stays on your server.
 
@@ -85,6 +85,8 @@ docker compose up -d
 
 Open `http://localhost:3000` and complete the setup wizard. Alternatively, fill in the service env vars in `.env` and setup completes automatically on first boot. Database migrations run automatically on every startup.
 
+For zero-touch boot, set `DIGARR_INITIAL_USERNAME`, `DIGARR_INITIAL_PASSWORD`, `AI_PROVIDER`, `AI_MODEL`, and at least one listening source (`LISTENBRAINZ_USERNAME` or `LASTFM_USERNAME`). Lidarr stays optional: omit `LIDARR_URL` / `LIDARR_API_KEY` to run in discovery-only mode.
+
 For local development, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
@@ -118,7 +120,7 @@ Runs on a cron schedule, manually, or via subscriptions for targeted discovery.
 
 ## Configuration
 
-All configuration is done through the web UI after initial setup -- connections, scoring weights, cron schedule, and preferences are all set there. If you connect Spotify, Settings > Connections now includes a one-click `Import Liked Songs` action to seed recommendations for a faster first scan. See [`.env.example`](.env.example) for the full list of environment variable fallbacks (useful for zero-touch Docker deployments).
+All configuration is done through the web UI after initial setup -- connections, scoring weights, cron schedule, and preferences are all set there. If you connect Spotify, Settings > Connections now includes a one-click `Import Liked Songs` action to seed recommendations for a faster first scan. Env-var auto-setup needs initial admin credentials, AI provider/model, and at least one listening source; the UI setup wizard enforces the same minimums. See [`.env.example`](.env.example) for local development fallbacks and [`deploy/docker/.env.example`](deploy/docker/.env.example) for Compose deployments.
 
 ---
 
@@ -131,6 +133,8 @@ Digarr provides application-level backup and restore through the admin UI (Setti
 **Restore:** `POST /api/admin/restore` accepts a backup JSON file. Runs in a single transaction (atomic rollback on failure). Uses upsert with natural keys for cross-instance compatibility. If the encryption key differs from the backup, affected credential fields are listed for manual re-entry.
 
 **Auto-backup before migrations:** When the app detects pending database migrations on startup, it automatically saves a backup to `DIGARR_BACKUP_DIR` (default: `./backups/`). Keeps the last 5 auto-backups. Disable with `DIGARR_AUTO_BACKUP=false`.
+
+**Kubernetes / Helm note:** Auto-backup needs a writable `/app/backups` volume. The bundled Helm chart and raw manifests mount one by default; custom deployments should do the same.
 
 ### Data Hygiene
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,11 +39,16 @@ Admin-only endpoints return 403 for non-admin users.
 | GET | `/api/setup/status` | No | Check if setup is complete |
 | POST | `/api/setup/complete` | No | Complete initial setup |
 
+Setup validation rules:
+- `aiProvider` and `aiModel` are required
+- At least one listening source is required: `listenbrainzUsername` or `lastfmUsername`
+- Lidarr is optional, but `lidarrUrl` and `lidarrApiKey` must be provided together when used
+
 **POST /api/setup/complete** body:
 ```json
 {
-  "aiProvider": "anthropic",
-  "aiModel": "claude-sonnet-4-20250514",
+  "aiProvider": "openai",
+  "aiModel": "gpt-4o-mini",
   "listenbrainzUsername": "user",
   "lastfmUsername": "user",
   "lidarrUrl": "http://lidarr:8686",
@@ -234,12 +239,19 @@ Admin-only endpoints return 403 for non-admin users.
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/api/search?q=&sources=&limit=` | Yes | Cross-platform artist search |
+| GET | `/api/search` | Yes | Cross-platform artist search |
 | GET | `/api/search/sources` | Yes | Available search sources |
 
 **Sources**: `spotify`, `deezer`, `musicbrainz`, `tidal`, `bandcamp`
 
 Each source includes a `stability` field (`stable` or `experimental`). TIDAL and Bandcamp are experimental.
+
+**GET /api/search** query params:
+- `q` -- required search string
+- `sources` -- optional comma-separated source IDs
+- `limit` -- 1-50 (default 20)
+
+When one enabled source fails, Digarr still returns results from the healthy sources when possible.
 
 ---
 
@@ -266,7 +278,7 @@ Each source includes a `stability` field (`stable` or `experimental`). TIDAL and
 | POST | `/api/library/health/:checkId/fix` | Admin | Apply fix for a health check |
 | GET | `/api/library/stats` | Admin | Library statistics |
 | POST | `/api/library/warm` | Admin | Warm SkyHook cache for MBIDs (202) |
-| GET | `/api/library/warm/status?mbids=` | Admin | SkyHook warm status |
+| GET | `/api/library/warm/status` | Admin | SkyHook warm status |
 | GET | `/api/library/sources` | Admin | Per-source sync state for global + per-user library sources |
 | POST | `/api/library/sync` | Admin | Run a manual library sync for all sources or a specific source |
 | GET | `/api/library/unreconciled` | Admin | List unreconciled library artists still needing a match |
@@ -277,6 +289,54 @@ Each source includes a `stability` field (`stable` or `experimental`). TIDAL and
 **GET /api/library/sources** response notes:
 - `lastSyncCounts.albumsSynced` is present for album-capable sources after a successful sync
 - Lidarr, Plex, and Jellyfin source rows now include artist sync counts plus the number of reconciled album rows written for that source snapshot
+
+**POST /api/library/warm** body:
+```json
+{
+  "mbids": ["f59c5520-5f46-4d2c-b2c4-822eabf53419"]
+}
+```
+
+Notes:
+- `mbids` must be a non-empty array of strings
+- Only the first 50 MBIDs are queued per request
+
+**GET /api/library/warm/status** query params:
+- `mbids` -- comma-separated MBIDs to inspect (up to 100)
+
+**POST /api/library/sync** notes:
+- Rate limited: 5/min
+- Empty body runs global source sync plus a forced sync for the current user and returns `202`
+- `{ "source": "lidarr" }` runs a single source and returns `200` on completion, `202` if still running, or `502` on sync failure
+- If the requested source is not configured for the current user, Digarr retries it as a global source
+
+**POST /api/library/sync** body:
+```json
+{
+  "source": "plex"
+}
+```
+
+**GET /api/library/unreconciled** response notes:
+- Returns unreconciled rows from both the current user's sources and any global sources visible to that user
+
+**POST /api/library/overrides** body:
+```json
+{
+  "source": "plex",
+  "sourceArtistId": "artist-123",
+  "correctMbid": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+  "note": "Matched against album overlap"
+}
+```
+
+Override notes:
+- Set `correctMbid` to `null` or `""` to store an ignore decision instead of a correction
+- `correctMbid`, when present, must be a valid UUID
+
+**POST /api/library/reconcile** notes:
+- Triggers a forced sync for the current user and returns `202`
+- This currently re-fetches source data; there is no reconcile-only path yet
 
 ---
 
@@ -335,6 +395,10 @@ Query params: `range` (week/month/year), `limit` (1-50).
 | POST | `/api/settings/test-webhook` | Admin | Send test webhook |
 
 **Testable services**: `lidarr`, `listenbrainz`, `lastfm`, `ai`, `plex`, `jellyfin`, `discogs`, `spotify`, `oidc`
+
+Settings notes:
+- Non-admin users can update only their own connection fields; global setting changes return `403`
+- `lidarr` and `ai` test calls require admin access when user-session auth is active
 
 ---
 

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -40,11 +40,11 @@ All screenshots use the Youtarr theme.
 
 ## Library Reconciliation
 
-Screenshot pending. This page covers the unreconciled-artist review and manual override flow.
+No committed screenshot yet. This page shipped in `v0.17.0` and covers unreconciled-artist review plus manual correct/ignore override flow.
 
 ## Library Sources Panel
 
-Screenshot pending. This panel lives on the Library Health page and shows per-source sync status.
+No committed screenshot yet. This admin panel shipped in `v0.17.0` and expanded in `v0.18.0` with per-source album sync counts and snapshot status.
 
 ## Analytics
 


### PR DESCRIPTION
## Summary
- add a tracked changelog for the recent release burst
- document zero-touch setup requirements and auto-backup deployment notes
- expand the API reference for library sync, search, and settings behavior
- clarify local E2E expectations and current screenshot coverage

## Verification
- git diff --check
- forbidden-term scan on changed docs
- markdown link check on changed docs