### PR TITLE
chore: bump version to 0.20.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable user-facing changes are documented here.
 
+## v0.20.1 - 2026-04-09
+
+### Fixed
+
+- Emby and Jellyfin connection tests now validate the configured user library scope instead of only checking server info
+- Playlist export to Emby and Jellyfin now respects TLS-skip settings, and Emby track matching prefers exact title and artist hits
+- Metadata fallback HTTP requests now block redirects, reject private hosts at request time, and keep no-content delete responses typed honestly
+
+### Changed
+
+- Provider and admin config typing is stricter at shared boundaries
+- API, README, roadmap, and issue template docs are aligned with shipped Emby support and local tooling rules
+
 ## v0.20.0 - 2026-04-09
 
 ### Added

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -7,9 +7,9 @@ services:
   app:
     image: docker.io/iuliandita/digarr:0.20
     # Pin to a patch version for full stability:
-    # image: docker.io/iuliandita/digarr:0.20.0
+    # image: docker.io/iuliandita/digarr:0.20.1
     # Alpine variant (smaller image, musl libc):
-    # image: docker.io/iuliandita/digarr:0.20.0-alpine
+    # image: docker.io/iuliandita/digarr:0.20.1-alpine
     env_file:
       - path: .env
         required: false

--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.20.0
-appVersion: "0.20.0"
+version: 0.20.1
+appVersion: "0.20.1"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.20.0"
+  tag: "0.20.1"
   pullPolicy: IfNotPresent
 
 service:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: ghcr.io/iuliandita/digarr:0.20.0
+          image: ghcr.io/iuliandita/digarr:0.20.1
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-   <Repository>docker.io/iuliandita/digarr:0.20.0</Repository>
-   <Tag>0.20.0</Tag>
-   <TagDescription>v0.20.0 stable release</TagDescription>
+   <Repository>docker.io/iuliandita/digarr:0.20.1</Repository>
+   <Tag>0.20.1</Tag>
+   <TagDescription>v0.20.1 stable release</TagDescription>
   </Branch>
   <Network>bridge</Network>
   <Shell>sh</Shell>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Updated: 2026-04-09 | Current: v0.20.0
+> Updated: 2026-04-09 | Current: v0.20.1
 >
 > Priorities change with feedback. This is current intent, not a promise.
 
@@ -101,6 +101,12 @@ Low confidence. Would build only with real demand.
 - Native mobile apps (Android/iOS) -- PWA is already installable; native value is mostly reliable push notifications
 
 ## Recently Shipped
+
+### v0.20.1
+
+- Hardened outbound metadata fallback requests against redirects and private-host SSRF paths
+- Fixed Emby and Jellyfin connection tests to validate configured user access
+- Carried TLS skip settings through playlist export paths and tightened docs around shipped support
 
 ### v0.20.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the app and deployment manifests to `0.20.1`
- document the review-fix patch release in the changelog and roadmap

## Verification
- bun run lint
- bun run typecheck
- bun run test
- bun run build
