### PR TITLE
chore: release v0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable user-facing changes are documented here.
 
+## v0.20.2 - 2026-04-10
+
+### Fixed
+
+- Search and job API query validation now match the documented contract, including limits, offsets, and allowed job types
+- Query-token auth is now limited to the documented SSE and preview-audio endpoints
+- Playlist ordering now follows stored track positions consistently
+
+### Changed
+
+- CI now separates mocked API route contract tests from browser E2E coverage, and the browser suite runs against an isolated Playwright database
+- PostgreSQL pool sizing and SSL behavior can now be configured explicitly through environment variables
+- Hot recommendation, playlist, subscription, target, and session query paths now have supporting indexes, and older migrations are safer to re-run
+
 ## v0.20.1 - 2026-04-09
 
 ### Fixed
@@ -86,7 +100,7 @@ All notable user-facing changes are documented here.
 ### Added
 
 - Admin job history and health endpoints for pipeline, subscription, target, and playlist work
-- API smoke tests, Playwright browser tests, and CI gates for critical workflows
+- API route tests, Playwright browser tests, and CI gates for critical workflows
 - Application-level backup and restore with encrypted field handling
 
 ### Changed

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -7,9 +7,9 @@ services:
   app:
     image: docker.io/iuliandita/digarr:0.20
     # Pin to a patch version for full stability:
-    # image: docker.io/iuliandita/digarr:0.20.1
+    # image: docker.io/iuliandita/digarr:0.20.2
     # Alpine variant (smaller image, musl libc):
-    # image: docker.io/iuliandita/digarr:0.20.1-alpine
+    # image: docker.io/iuliandita/digarr:0.20.2-alpine
     env_file:
       - path: .env
         required: false

--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.20.1
-appVersion: "0.20.1"
+version: 0.20.2
+appVersion: "0.20.2"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.20.1"
+  tag: "0.20.2"
   pullPolicy: IfNotPresent
 
 service:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -32,7 +32,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: ghcr.io/iuliandita/digarr:0.20.1
+          image: ghcr.io/iuliandita/digarr:0.20.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-   <Repository>docker.io/iuliandita/digarr:0.20.1</Repository>
-   <Tag>0.20.1</Tag>
-   <TagDescription>v0.20.1 stable release</TagDescription>
+   <Repository>docker.io/iuliandita/digarr:0.20.2</Repository>
+   <Tag>0.20.2</Tag>
+   <TagDescription>v0.20.2 stable release</TagDescription>
   </Branch>
   <Network>bridge</Network>
   <Shell>sh</Shell>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Updated: 2026-04-09 | Current: v0.20.1
+> Updated: 2026-04-10 | Current: v0.20.2
 >
 > Priorities change with feedback. This is current intent, not a promise.
 
@@ -101,6 +101,12 @@ Low confidence. Would build only with real demand.
 - Native mobile apps (Android/iOS) -- PWA is already installable; native value is mostly reliable push notifications
 
 ## Recently Shipped
+
+### v0.20.2
+
+- Tightened API contract validation for search, jobs, and query-token auth paths
+- Split mocked API route tests from browser E2E coverage and isolated Playwright runs on a dedicated database
+- Added DB pool controls, hot-path indexes, and replay-safe guards for older migrations
 
 ### v0.20.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- bump the app and deploy manifests to v0.20.2
- add changelog and roadmap entries for the API, testing, and database tightening work
- keep release-facing docs and compose examples aligned with the new patch version

## Verification
- bun run lint
- bun run typecheck
- bun run build
- bun run test
- bun run test:e2e