### PR TITLE
feat: deeper ListenBrainz radio and similar-users discovery

### DIFF
--- a/src/core/clients/listenbrainz.ts
+++ b/src/core/clients/listenbrainz.ts
@@ -27,6 +27,15 @@ export type RadioArtist = {
   score: number
 }
 
+export type PopularityRange = 'low' | 'medium' | 'high' | 'all'
+
+const POP_RANGES: Record<PopularityRange, [number, number]> = {
+  low: [0, 40],
+  medium: [30, 70],
+  high: [60, 100],
+  all: [0, 100],
+}
+
 // Raw LB response shapes
 type LbTopArtistsResponse = {
   payload: {
@@ -144,6 +153,33 @@ export function createListenBrainzClient(username: string, token: string) {
     return extractRadioArtists(res, mbid)
   }
 
+  async function getTagRadio(
+    tag: string,
+    popularity: PopularityRange = 'all',
+    mode: RadioMode = 'medium',
+  ): Promise<RadioArtist[]> {
+    const [popBegin, popEnd] = POP_RANGES[popularity]
+    const params = new URLSearchParams({
+      tag,
+      pop_begin: String(popBegin),
+      pop_end: String(popEnd),
+      mode,
+    })
+    const res = await http.get<LbRadioResponse>(`/1/lb-radio/tags?${params.toString()}`)
+    return extractRadioArtists(res)
+  }
+
+  async function getUserRadio(
+    targetUsername: string,
+    mode: RadioMode = 'medium',
+  ): Promise<RadioArtist[]> {
+    const params = new URLSearchParams({ mode })
+    const res = await http.get<LbRadioResponse>(
+      `/1/lb-radio/user/${encodeURIComponent(targetUsername)}?${params.toString()}`,
+    )
+    return extractRadioArtists(res)
+  }
+
   async function testConnection(): Promise<ServiceTestResult> {
     try {
       const count = await getListenCount()
@@ -163,6 +199,8 @@ export function createListenBrainzClient(username: string, token: string) {
     getListeningActivity,
     getSimilarArtists,
     getArtistRadio,
+    getTagRadio,
+    getUserRadio,
     testConnection,
   }
 }

--- a/src/core/clients/listenbrainz.ts
+++ b/src/core/clients/listenbrainz.ts
@@ -19,6 +19,14 @@ export type SimilarArtist = {
   score: number
 }
 
+export type RadioMode = 'easy' | 'medium' | 'hard'
+
+export type RadioArtist = {
+  name: string
+  mbid: string
+  score: number
+}
+
 // Raw LB response shapes
 type LbTopArtistsResponse = {
   payload: {
@@ -48,6 +56,27 @@ type LbRadioRecording = {
 }
 
 type LbRadioResponse = Record<string, LbRadioRecording[]>
+
+function extractRadioArtists(res: LbRadioResponse, excludeMbid?: string): RadioArtist[] {
+  const seen = new Set<string>()
+  const artists: RadioArtist[] = []
+  let position = 0
+  for (const recordings of Object.values(res)) {
+    for (const rec of recordings) {
+      if (excludeMbid && rec.similar_artist_mbid === excludeMbid) continue
+      if (seen.has(rec.similar_artist_mbid)) continue
+      seen.add(rec.similar_artist_mbid)
+      position++
+      artists.push({
+        name: rec.similar_artist_name,
+        mbid: rec.similar_artist_mbid,
+        // Position-based decay: ~0.97 for first result, floors at 0.3 (reached at position 24)
+        score: Math.max(0.3, 1 - position * 0.03),
+      })
+    }
+  }
+  return artists
+}
 
 export function createListenBrainzClient(username: string, token: string) {
   const http = createHttpClient({
@@ -103,6 +132,18 @@ export function createListenBrainzClient(username: string, token: string) {
     return artists
   }
 
+  async function getArtistRadio(mbid: string, mode: RadioMode = 'medium'): Promise<RadioArtist[]> {
+    const params = new URLSearchParams({
+      mode,
+      max_similar_artists: '25',
+      max_recordings_per_artist: '2',
+      pop_begin: '0',
+      pop_end: '100',
+    })
+    const res = await http.get<LbRadioResponse>(`/1/lb-radio/artist/${mbid}?${params.toString()}`)
+    return extractRadioArtists(res, mbid)
+  }
+
   async function testConnection(): Promise<ServiceTestResult> {
     try {
       const count = await getListenCount()
@@ -121,6 +162,7 @@ export function createListenBrainzClient(username: string, token: string) {
     getListenCount,
     getListeningActivity,
     getSimilarArtists,
+    getArtistRadio,
     testConnection,
   }
 }

--- a/src/core/clients/listenbrainz.ts
+++ b/src/core/clients/listenbrainz.ts
@@ -66,6 +66,20 @@ type LbRadioRecording = {
 
 type LbRadioResponse = Record<string, LbRadioRecording[]>
 
+type LbSimilarUser = {
+  user_name: string
+  similarity: number
+}
+
+type LbSimilarUsersResponse = {
+  payload: LbSimilarUser[]
+}
+
+export type SimilarUser = {
+  username: string
+  similarity: number
+}
+
 function extractRadioArtists(res: LbRadioResponse, excludeMbid?: string): RadioArtist[] {
   const seen = new Set<string>()
   const artists: RadioArtist[] = []
@@ -180,6 +194,29 @@ export function createListenBrainzClient(username: string, token: string) {
     return extractRadioArtists(res)
   }
 
+  async function getSimilarUsers(): Promise<SimilarUser[]> {
+    const res = await http.get<LbSimilarUsersResponse>(`/1/user/${username}/similar-users`)
+    return (res.payload ?? []).map((u) => ({
+      username: u.user_name,
+      similarity: u.similarity,
+    }))
+  }
+
+  async function getTopArtistsForUser(
+    targetUsername: string,
+    range: ListenBrainzRange,
+  ): Promise<TopArtist[]> {
+    const res = await http.get<LbTopArtistsResponse>(
+      `/1/stats/user/${targetUsername}/artists?range=${range}`,
+    )
+    return res.payload.artists.map((a) => ({
+      name: a.artist_name,
+      mbid: a.artist_mbid || undefined,
+      playCount: a.listen_count,
+      source: 'listenbrainz' as const,
+    }))
+  }
+
   async function testConnection(): Promise<ServiceTestResult> {
     try {
       const count = await getListenCount()
@@ -201,6 +238,8 @@ export function createListenBrainzClient(username: string, token: string) {
     getArtistRadio,
     getTagRadio,
     getUserRadio,
+    getSimilarUsers,
+    getTopArtistsForUser,
     testConnection,
   }
 }

--- a/src/core/clients/listenbrainz.ts
+++ b/src/core/clients/listenbrainz.ts
@@ -27,15 +27,6 @@ export type RadioArtist = {
   score: number
 }
 
-export type PopularityRange = 'low' | 'medium' | 'high' | 'all'
-
-const POP_RANGES: Record<PopularityRange, [number, number]> = {
-  low: [0, 40],
-  medium: [30, 70],
-  high: [60, 100],
-  all: [0, 100],
-}
-
 // Raw LB response shapes
 type LbTopArtistsResponse = {
   payload: {
@@ -167,31 +158,16 @@ export function createListenBrainzClient(username: string, token: string) {
     return extractRadioArtists(res, mbid)
   }
 
-  async function getTagRadio(
-    tag: string,
-    popularity: PopularityRange = 'all',
-    mode: RadioMode = 'medium',
-  ): Promise<RadioArtist[]> {
-    const [popBegin, popEnd] = POP_RANGES[popularity]
-    const params = new URLSearchParams({
-      tag,
-      pop_begin: String(popBegin),
-      pop_end: String(popEnd),
-      mode,
-    })
-    const res = await http.get<LbRadioResponse>(`/1/lb-radio/tags?${params.toString()}`)
-    return extractRadioArtists(res)
-  }
-
+  // No direct user radio endpoint exists in the LB API. Instead, get the
+  // user's top artist and run artist radio seeded from it.
   async function getUserRadio(
     targetUsername: string,
     mode: RadioMode = 'medium',
   ): Promise<RadioArtist[]> {
-    const params = new URLSearchParams({ mode })
-    const res = await http.get<LbRadioResponse>(
-      `/1/lb-radio/user/${encodeURIComponent(targetUsername)}?${params.toString()}`,
-    )
-    return extractRadioArtists(res)
+    const topArtists = await getTopArtistsForUser(targetUsername, 'month')
+    const seed = topArtists.find((a) => a.mbid)
+    if (!seed?.mbid) return []
+    return getArtistRadio(seed.mbid, mode)
   }
 
   async function getSimilarUsers(): Promise<SimilarUser[]> {
@@ -236,7 +212,6 @@ export function createListenBrainzClient(username: string, token: string) {
     getListeningActivity,
     getSimilarArtists,
     getArtistRadio,
-    getTagRadio,
     getUserRadio,
     getSimilarUsers,
     getTopArtistsForUser,

--- a/src/core/discovery-modes/modes/listenbrainz.ts
+++ b/src/core/discovery-modes/modes/listenbrainz.ts
@@ -1,4 +1,4 @@
-import type { PopularityRange, RadioMode } from '@/core/clients/listenbrainz'
+import type { RadioMode } from '@/core/clients/listenbrainz'
 import { createListenBrainzClient } from '@/core/clients/listenbrainz'
 import { createListenBrainzAdapter } from '@/core/subscriptions/adapters/listenbrainz'
 import type {
@@ -204,53 +204,10 @@ export function createListenBrainzRadioModes(): DiscoveryModeDefinition[] {
     },
   }
 
-  const tagRadio: DiscoveryModeDefinition = {
-    id: 'lb-tag-radio',
-    label: 'Genre Radio',
-    description: 'Discover artists by genre tag via ListenBrainz radio',
-    availability: 'strict',
-    easyFields: [
-      {
-        key: 'tag',
-        label: 'Genre Tag',
-        type: 'text',
-        required: true,
-        helpText: 'e.g. rock, jazz, electronic',
-      },
-      adventurenessField,
-    ],
-    advancedFields: [
-      { key: 'tag', label: 'Genre Tag', type: 'text', required: true },
-      {
-        key: 'popularity',
-        label: 'Popularity',
-        type: 'select',
-        options: [
-          { value: 'all', label: 'All' },
-          { value: 'low', label: 'Underground' },
-          { value: 'medium', label: 'Mid-range' },
-          { value: 'high', label: 'Popular' },
-        ],
-      },
-      adventurenessField,
-      { key: 'limit', label: 'Limit', type: 'number' },
-    ],
-    executor: async (request) => {
-      const { client } = await getConnectedClient(request.userId)
-      const tag = String(request.normalizedSettings.tag)
-      const popularity = (request.normalizedSettings.popularity as PopularityRange) ?? 'all'
-      const mode = (request.normalizedSettings.adventurousness as RadioMode) ?? 'medium'
-      const limit = getNormalizedLimit(request, 25)
-      const artists = await client.getTagRadio(tag, popularity, mode)
-      return mapRadioArtists(artists, 'listenbrainz:tag-radio', limit)
-    },
-  }
-
   const userRadio: DiscoveryModeDefinition = {
     id: 'lb-user-radio',
     label: 'User Radio',
-    description:
-      'Discover artists from a personalized ListenBrainz radio based on listening history',
+    description: "Discover artists via radio seeded from a user's top listened artist",
     availability: 'strict',
     easyFields: [],
     advancedFields: [
@@ -321,5 +278,5 @@ export function createListenBrainzRadioModes(): DiscoveryModeDefinition[] {
     },
   }
 
-  return [artistRadio, tagRadio, userRadio, similarUsersDeep]
+  return [artistRadio, userRadio, similarUsersDeep]
 }

--- a/src/core/discovery-modes/modes/listenbrainz.ts
+++ b/src/core/discovery-modes/modes/listenbrainz.ts
@@ -56,7 +56,7 @@ async function executeSimilarUsers(userId: number, limit: number) {
       candidates.push({
         candidateType: 'artist',
         name: artist.name,
-        provenanceProvider: 'listenbrainz:similar-users',
+        provenanceProvider: 'listenbrainz:similar-users-quick',
         confidenceHint: artist.score,
         fallbackUsed: false,
       })
@@ -93,7 +93,7 @@ export function createListenBrainzMode(): DiscoveryModeDefinition {
         required: true,
         options: [
           { value: 'weekly-jams', label: 'Weekly Jams' },
-          { value: 'similar-users', label: 'Similar Users' },
+          { value: 'similar-users-quick', label: 'Similar Users (Quick)' },
         ],
       },
       { key: 'limit', label: 'Limit', type: 'number', required: true },
@@ -107,10 +107,12 @@ export function createListenBrainzMode(): DiscoveryModeDefinition {
       }
 
       const feedType =
-        request.normalizedSettings.feedType === 'similar-users' ? 'similar-users' : 'weekly-jams'
+        request.normalizedSettings.feedType === 'similar-users-quick'
+          ? 'similar-users-quick'
+          : 'weekly-jams'
       const limit = getNormalizedLimit(request, 25)
 
-      if (feedType === 'similar-users') {
+      if (feedType === 'similar-users-quick') {
         return executeSimilarUsers(request.userId, limit)
       }
 
@@ -271,5 +273,53 @@ export function createListenBrainzRadioModes(): DiscoveryModeDefinition[] {
     },
   }
 
-  return [artistRadio, tagRadio, userRadio]
+  const similarUsersDeep: DiscoveryModeDefinition = {
+    id: 'similar-users-deep',
+    label: 'Similar Users (Deep)',
+    description: 'Discover from top artists of ListenBrainz users with similar taste',
+    availability: 'strict',
+    easyFields: [],
+    advancedFields: [
+      {
+        key: 'maxUsers',
+        label: 'Users to sample',
+        type: 'number',
+        helpText: 'How many similar users to pull top artists from (1-10)',
+      },
+      { key: 'limit', label: 'Limit', type: 'number' },
+    ],
+    executor: async (request) => {
+      const { client } = await getConnectedClient(request.userId)
+      const maxUsers = Math.min(Math.max(1, Number(request.normalizedSettings.maxUsers) || 3), 10)
+      const limit = getNormalizedLimit(request, 25)
+
+      const similarUsers = await client.getSimilarUsers()
+      const topUsers = similarUsers.slice(0, maxUsers)
+
+      const seen = new Set<string>()
+      const candidates: RawDiscoveryExecutionResult['candidates'] = []
+
+      for (const simUser of topUsers) {
+        const topArtists = await client.getTopArtistsForUser(simUser.username, 'month')
+        for (const artist of topArtists) {
+          const normalized = normalizeDiscoveryName(artist.name)
+          if (!normalized || seen.has(normalized)) continue
+          seen.add(normalized)
+          candidates.push({
+            candidateType: 'artist',
+            name: artist.name,
+            mbid: artist.mbid,
+            provenanceProvider: 'listenbrainz:similar-users-deep',
+            confidenceHint: simUser.similarity * 0.8,
+            fallbackUsed: false,
+          })
+          if (candidates.length >= limit) return { candidates }
+        }
+      }
+
+      return { candidates }
+    },
+  }
+
+  return [artistRadio, tagRadio, userRadio, similarUsersDeep]
 }

--- a/src/core/discovery-modes/modes/listenbrainz.ts
+++ b/src/core/discovery-modes/modes/listenbrainz.ts
@@ -1,6 +1,11 @@
+import type { PopularityRange, RadioMode } from '@/core/clients/listenbrainz'
 import { createListenBrainzClient } from '@/core/clients/listenbrainz'
 import { createListenBrainzAdapter } from '@/core/subscriptions/adapters/listenbrainz'
-import type { DiscoveryModeDefinition } from '../types'
+import type {
+  DiscoveryConfigField,
+  DiscoveryModeDefinition,
+  RawDiscoveryExecutionResult,
+} from '../types'
 import { getDiscoveryModeConnections, getNormalizedLimit, normalizeDiscoveryName } from './runtime'
 
 function mapFeedArtists(
@@ -120,4 +125,151 @@ export function createListenBrainzMode(): DiscoveryModeDefinition {
       }
     },
   }
+}
+
+async function getConnectedClient(userId: number) {
+  const connections = await getDiscoveryModeConnections(userId)
+  const username = connections?.listenbrainzUsername?.trim()
+  const token = connections?.listenbrainzToken?.trim()
+  if (!username || !token) {
+    throw new Error('Connect ListenBrainz to use this mode.')
+  }
+  return { client: createListenBrainzClient(username, token), username }
+}
+
+function mapRadioArtists(
+  artists: Array<{ name: string; mbid: string; score: number }>,
+  provenance: string,
+  limit: number,
+): RawDiscoveryExecutionResult {
+  return {
+    candidates: artists.slice(0, limit).map((a) => ({
+      candidateType: 'artist' as const,
+      name: a.name,
+      mbid: a.mbid,
+      provenanceProvider: provenance,
+      confidenceHint: a.score,
+      fallbackUsed: false,
+    })),
+  }
+}
+
+export function createListenBrainzRadioModes(): DiscoveryModeDefinition[] {
+  const adventurenessField: DiscoveryConfigField = {
+    key: 'adventurousness',
+    label: 'Adventurousness',
+    type: 'select',
+    options: [
+      { value: 'easy', label: 'Safe' },
+      { value: 'medium', label: 'Medium' },
+      { value: 'hard', label: 'Adventurous' },
+    ],
+  }
+
+  const artistRadio: DiscoveryModeDefinition = {
+    id: 'lb-artist-radio',
+    label: 'Artist Radio',
+    description: 'Discover artists similar to a seed artist via ListenBrainz radio',
+    availability: 'strict',
+    easyFields: [
+      {
+        key: 'seedArtistMbid',
+        label: 'Artist',
+        type: 'text',
+        required: true,
+        helpText: 'Artist name or MBID to seed the radio',
+      },
+      adventurenessField,
+    ],
+    advancedFields: [
+      {
+        key: 'seedArtistMbid',
+        label: 'Artist',
+        type: 'text',
+        required: true,
+        helpText: 'Artist name or MBID to seed the radio',
+      },
+      adventurenessField,
+      { key: 'limit', label: 'Limit', type: 'number' },
+    ],
+    executor: async (request) => {
+      const { client } = await getConnectedClient(request.userId)
+      const mbid = String(request.normalizedSettings.seedArtistMbid)
+      const mode = (request.normalizedSettings.adventurousness as RadioMode) ?? 'medium'
+      const limit = getNormalizedLimit(request, 25)
+      const artists = await client.getArtistRadio(mbid, mode)
+      return mapRadioArtists(artists, 'listenbrainz:artist-radio', limit)
+    },
+  }
+
+  const tagRadio: DiscoveryModeDefinition = {
+    id: 'lb-tag-radio',
+    label: 'Genre Radio',
+    description: 'Discover artists by genre tag via ListenBrainz radio',
+    availability: 'strict',
+    easyFields: [
+      {
+        key: 'tag',
+        label: 'Genre Tag',
+        type: 'text',
+        required: true,
+        helpText: 'e.g. rock, jazz, electronic',
+      },
+      adventurenessField,
+    ],
+    advancedFields: [
+      { key: 'tag', label: 'Genre Tag', type: 'text', required: true },
+      {
+        key: 'popularity',
+        label: 'Popularity',
+        type: 'select',
+        options: [
+          { value: 'all', label: 'All' },
+          { value: 'low', label: 'Underground' },
+          { value: 'medium', label: 'Mid-range' },
+          { value: 'high', label: 'Popular' },
+        ],
+      },
+      adventurenessField,
+      { key: 'limit', label: 'Limit', type: 'number' },
+    ],
+    executor: async (request) => {
+      const { client } = await getConnectedClient(request.userId)
+      const tag = String(request.normalizedSettings.tag)
+      const popularity = (request.normalizedSettings.popularity as PopularityRange) ?? 'all'
+      const mode = (request.normalizedSettings.adventurousness as RadioMode) ?? 'medium'
+      const limit = getNormalizedLimit(request, 25)
+      const artists = await client.getTagRadio(tag, popularity, mode)
+      return mapRadioArtists(artists, 'listenbrainz:tag-radio', limit)
+    },
+  }
+
+  const userRadio: DiscoveryModeDefinition = {
+    id: 'lb-user-radio',
+    label: 'User Radio',
+    description:
+      'Discover artists from a personalized ListenBrainz radio based on listening history',
+    availability: 'strict',
+    easyFields: [],
+    advancedFields: [
+      {
+        key: 'targetUsername',
+        label: 'Username',
+        type: 'text',
+        helpText: 'Leave blank to use your connected account',
+      },
+      adventurenessField,
+      { key: 'limit', label: 'Limit', type: 'number' },
+    ],
+    executor: async (request) => {
+      const { client, username } = await getConnectedClient(request.userId)
+      const target = String(request.normalizedSettings.targetUsername || username)
+      const mode = (request.normalizedSettings.adventurousness as RadioMode) ?? 'medium'
+      const limit = getNormalizedLimit(request, 25)
+      const artists = await client.getUserRadio(target, mode)
+      return mapRadioArtists(artists, 'listenbrainz:user-radio', limit)
+    },
+  }
+
+  return [artistRadio, tagRadio, userRadio]
 }

--- a/src/core/discovery-modes/registry.ts
+++ b/src/core/discovery-modes/registry.ts
@@ -1,6 +1,6 @@
 import { createArtistRelationshipsMode } from './modes/artist-relationships'
 import { createLabelsMode } from './modes/labels'
-import { createListenBrainzMode } from './modes/listenbrainz'
+import { createListenBrainzMode, createListenBrainzRadioModes } from './modes/listenbrainz'
 import { createReleaseRadarMode } from './modes/release-radar'
 import { createSimilarArtistWebMode } from './modes/similar-artist-web'
 import type { DiscoveryModeDefinition } from './types'
@@ -28,6 +28,9 @@ export function registerDefaultDiscoveryModes(
   registry: DiscoveryModeRegistry,
 ): DiscoveryModeRegistry {
   registry.register(createListenBrainzMode())
+  for (const mode of createListenBrainzRadioModes()) {
+    registry.register(mode)
+  }
   registry.register(createReleaseRadarMode())
   registry.register(createArtistRelationshipsMode())
   registry.register(createSimilarArtistWebMode())

--- a/src/core/subscriptions/adapters/listenbrainz.ts
+++ b/src/core/subscriptions/adapters/listenbrainz.ts
@@ -1,3 +1,5 @@
+import type { PopularityRange, RadioMode } from '@/core/clients/listenbrainz'
+import { createListenBrainzClient } from '@/core/clients/listenbrainz'
 import { deduplicateByName } from '@/core/subscriptions/dedup'
 import type {
   AdapterConfigField,
@@ -14,6 +16,9 @@ const CONFIG_FIELDS: AdapterConfigField[] = [
     options: [
       { value: 'fresh-releases', label: 'Fresh Releases' },
       { value: 'weekly-jams', label: 'Weekly Jams' },
+      { value: 'artist-radio', label: 'Artist Radio' },
+      { value: 'tag-radio', label: 'Genre Tag Radio' },
+      { value: 'similar-users', label: 'Similar Users' },
     ],
     helpText: 'Which ListenBrainz feed to pull artists from.',
   },
@@ -73,6 +78,16 @@ export function createListenBrainzAdapter(deps: {
         return fetchWeeklyJams(deps.username, deps.token)
       }
 
+      if (feedType === 'artist-radio') {
+        return fetchArtistRadio(deps, config)
+      }
+      if (feedType === 'tag-radio') {
+        return fetchTagRadio(deps, config)
+      }
+      if (feedType === 'similar-users') {
+        return fetchSimilarUsers(deps, config)
+      }
+
       return { artists: [] }
     },
   }
@@ -106,6 +121,72 @@ async function fetchFreshReleases(token: string): Promise<AdapterResult> {
     similarityScore: 0.6,
     source: 'listenbrainz:fresh-releases',
   }))
+
+  return { artists }
+}
+
+async function fetchArtistRadio(
+  deps: { username: string; token: string },
+  config: Record<string, unknown>,
+): Promise<AdapterResult> {
+  const client = createListenBrainzClient(deps.username, deps.token)
+  const mbid = String(config.seedArtistMbid ?? '')
+  const mode = (config.adventurousness as RadioMode) ?? 'medium'
+  if (!mbid) return { artists: [] }
+  const radio = await client.getArtistRadio(mbid, mode)
+  return {
+    artists: radio.map((a) => ({
+      name: a.name,
+      similarityScore: a.score,
+      source: 'listenbrainz:artist-radio',
+    })),
+  }
+}
+
+async function fetchTagRadio(
+  deps: { username: string; token: string },
+  config: Record<string, unknown>,
+): Promise<AdapterResult> {
+  const client = createListenBrainzClient(deps.username, deps.token)
+  const tag = String(config.tag ?? '')
+  const popularity = (config.popularity as PopularityRange) ?? 'all'
+  const mode = (config.adventurousness as RadioMode) ?? 'medium'
+  if (!tag) return { artists: [] }
+  const radio = await client.getTagRadio(tag, popularity, mode)
+  return {
+    artists: radio.map((a) => ({
+      name: a.name,
+      similarityScore: a.score,
+      source: 'listenbrainz:tag-radio',
+    })),
+  }
+}
+
+async function fetchSimilarUsers(
+  deps: { username: string; token: string },
+  config: Record<string, unknown>,
+): Promise<AdapterResult> {
+  const client = createListenBrainzClient(deps.username, deps.token)
+  const maxUsers = Math.min(Math.max(1, Number(config.maxUsers) || 3), 10)
+  const similarUsers = await client.getSimilarUsers()
+  const topUsers = similarUsers.slice(0, maxUsers)
+
+  const seen = new Set<string>()
+  const artists: AdapterResult['artists'] = []
+
+  for (const simUser of topUsers) {
+    const topArtists = await client.getTopArtistsForUser(simUser.username, 'month')
+    for (const artist of topArtists) {
+      const key = artist.name.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      artists.push({
+        name: artist.name,
+        similarityScore: simUser.similarity * 0.8,
+        source: 'listenbrainz:similar-users',
+      })
+    }
+  }
 
   return { artists }
 }

--- a/src/core/subscriptions/adapters/listenbrainz.ts
+++ b/src/core/subscriptions/adapters/listenbrainz.ts
@@ -1,4 +1,4 @@
-import type { PopularityRange, RadioMode } from '@/core/clients/listenbrainz'
+import type { RadioMode } from '@/core/clients/listenbrainz'
 import { createListenBrainzClient } from '@/core/clients/listenbrainz'
 import { deduplicateByName } from '@/core/subscriptions/dedup'
 import type {
@@ -17,7 +17,7 @@ const CONFIG_FIELDS: AdapterConfigField[] = [
       { value: 'fresh-releases', label: 'Fresh Releases' },
       { value: 'weekly-jams', label: 'Weekly Jams' },
       { value: 'artist-radio', label: 'Artist Radio' },
-      { value: 'tag-radio', label: 'Genre Tag Radio' },
+
       { value: 'similar-users', label: 'Similar Users' },
     ],
     helpText: 'Which ListenBrainz feed to pull artists from.',
@@ -81,9 +81,7 @@ export function createListenBrainzAdapter(deps: {
       if (feedType === 'artist-radio') {
         return fetchArtistRadio(deps, config)
       }
-      if (feedType === 'tag-radio') {
-        return fetchTagRadio(deps, config)
-      }
+
       if (feedType === 'similar-users') {
         return fetchSimilarUsers(deps, config)
       }
@@ -139,25 +137,6 @@ async function fetchArtistRadio(
       name: a.name,
       similarityScore: a.score,
       source: 'listenbrainz:artist-radio',
-    })),
-  }
-}
-
-async function fetchTagRadio(
-  deps: { username: string; token: string },
-  config: Record<string, unknown>,
-): Promise<AdapterResult> {
-  const client = createListenBrainzClient(deps.username, deps.token)
-  const tag = String(config.tag ?? '')
-  const popularity = (config.popularity as PopularityRange) ?? 'all'
-  const mode = (config.adventurousness as RadioMode) ?? 'medium'
-  if (!tag) return { artists: [] }
-  const radio = await client.getTagRadio(tag, popularity, mode)
-  return {
-    artists: radio.map((a) => ({
-      name: a.name,
-      similarityScore: a.score,
-      source: 'listenbrainz:tag-radio',
     })),
   }
 }

--- a/tests/core/clients/listenbrainz.test.ts
+++ b/tests/core/clients/listenbrainz.test.ts
@@ -336,53 +336,21 @@ describe('createListenBrainzClient', () => {
     })
   })
 
-  describe('getTagRadio(tag, popularity, mode)', () => {
-    it('sends tag and popularity params', async () => {
-      mockGet.mockResolvedValueOnce({
-        '0': [
-          {
-            recording_mbid: 'rec-1',
-            similar_artist_mbid: 'artist-1',
-            similar_artist_name: 'Tag Artist',
-            total_listen_count: 100,
-          },
-        ],
-      })
-
-      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
-      const result = await client.getTagRadio('rock', 'medium', 'hard')
-
-      expect(result).toHaveLength(1)
-      expect(result[0]).toEqual({
-        name: 'Tag Artist',
-        mbid: 'artist-1',
-        score: expect.any(Number),
-      })
-      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('/1/lb-radio/tags'))
-      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('tag=rock'))
-      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('mode=hard'))
-    })
-
-    it('maps popularity preset to numeric range', async () => {
-      mockGet.mockResolvedValueOnce({})
-
-      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
-      await client.getTagRadio('jazz', 'low')
-
-      const call = mockGet.mock.calls[0]?.[0] as string
-      expect(call).toContain('pop_begin=0')
-      expect(call).toContain('pop_end=40')
-    })
-  })
-
   describe('getUserRadio(targetUsername, mode)', () => {
-    it('calls user radio endpoint', async () => {
+    it('fetches top artists then runs artist radio on the top one', async () => {
+      // First call: getTopArtistsForUser
+      mockGet.mockResolvedValueOnce({
+        payload: {
+          artists: [{ artist_name: 'Top Artist', artist_mbid: 'top-mbid', listen_count: 500 }],
+        },
+      })
+      // Second call: getArtistRadio on top-mbid
       mockGet.mockResolvedValueOnce({
         '0': [
           {
             recording_mbid: 'rec-1',
             similar_artist_mbid: 'artist-1',
-            similar_artist_name: 'User Pick',
+            similar_artist_name: 'Radio Result',
             total_listen_count: 200,
           },
         ],
@@ -392,8 +360,24 @@ describe('createListenBrainzClient', () => {
       const result = await client.getUserRadio('targetuser', 'easy')
 
       expect(result).toHaveLength(1)
-      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('/1/lb-radio/user/targetuser'))
-      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('mode=easy'))
+      expect(result[0]).toMatchObject({ name: 'Radio Result', mbid: 'artist-1' })
+      // First call fetches top artists for targetuser
+      expect(mockGet).toHaveBeenCalledWith('/1/stats/user/targetuser/artists?range=month')
+      // Second call runs artist radio seeded from top artist
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('/1/lb-radio/artist/top-mbid'))
+    })
+
+    it('returns empty when user has no artists with MBIDs', async () => {
+      mockGet.mockResolvedValueOnce({
+        payload: {
+          artists: [{ artist_name: 'No MBID', artist_mbid: '', listen_count: 100 }],
+        },
+      })
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getUserRadio('targetuser')
+
+      expect(result).toEqual([])
     })
   })
 

--- a/tests/core/clients/listenbrainz.test.ts
+++ b/tests/core/clients/listenbrainz.test.ts
@@ -369,7 +369,7 @@ describe('createListenBrainzClient', () => {
       const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
       await client.getTagRadio('jazz', 'low')
 
-      const call = mockGet.mock.calls[0][0] as string
+      const call = mockGet.mock.calls[0]?.[0] as string
       expect(call).toContain('pop_begin=0')
       expect(call).toContain('pop_end=40')
     })

--- a/tests/core/clients/listenbrainz.test.ts
+++ b/tests/core/clients/listenbrainz.test.ts
@@ -397,6 +397,53 @@ describe('createListenBrainzClient', () => {
     })
   })
 
+  describe('getSimilarUsers()', () => {
+    it('returns similar users ranked by similarity', async () => {
+      mockGet.mockResolvedValueOnce({
+        payload: [
+          { user_name: 'alice', similarity: 0.85 },
+          { user_name: 'bob', similarity: 0.72 },
+        ],
+      })
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getSimilarUsers()
+
+      expect(result).toEqual([
+        { username: 'alice', similarity: 0.85 },
+        { username: 'bob', similarity: 0.72 },
+      ])
+      expect(mockGet).toHaveBeenCalledWith(`/1/user/${TEST_USERNAME}/similar-users`)
+    })
+
+    it('returns empty array when no similar users found', async () => {
+      mockGet.mockResolvedValueOnce({ payload: [] })
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getSimilarUsers()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('getTopArtistsForUser(targetUsername, range)', () => {
+    it('fetches top artists for an arbitrary user', async () => {
+      mockGet.mockResolvedValueOnce({
+        payload: {
+          artists: [{ artist_name: 'Radiohead', artist_mbid: 'mbid-1', listen_count: 500 }],
+        },
+      })
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getTopArtistsForUser('otheruser', 'month')
+
+      expect(result).toEqual([
+        { name: 'Radiohead', mbid: 'mbid-1', playCount: 500, source: 'listenbrainz' },
+      ])
+      expect(mockGet).toHaveBeenCalledWith('/1/stats/user/otheruser/artists?range=month')
+    })
+  })
+
   describe('testConnection()', () => {
     it('returns success:true when getListenCount() resolves', async () => {
       mockGet.mockResolvedValueOnce({ payload: { count: 999 } })

--- a/tests/core/clients/listenbrainz.test.ts
+++ b/tests/core/clients/listenbrainz.test.ts
@@ -229,6 +229,113 @@ describe('createListenBrainzClient', () => {
     })
   })
 
+  describe('getArtistRadio(mbid, mode)', () => {
+    it('extracts unique artists from radio response', async () => {
+      mockGet.mockResolvedValueOnce({
+        '0': [
+          {
+            recording_mbid: 'rec-1',
+            similar_artist_mbid: 'artist-1',
+            similar_artist_name: 'Artist One',
+            total_listen_count: 100,
+          },
+          {
+            recording_mbid: 'rec-2',
+            similar_artist_mbid: 'artist-1',
+            similar_artist_name: 'Artist One',
+            total_listen_count: 80,
+          },
+          {
+            recording_mbid: 'rec-3',
+            similar_artist_mbid: 'artist-2',
+            similar_artist_name: 'Artist Two',
+            total_listen_count: 50,
+          },
+        ],
+      })
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getArtistRadio('seed-mbid', 'medium')
+
+      expect(result).toEqual([
+        { name: 'Artist One', mbid: 'artist-1', score: expect.any(Number) },
+        { name: 'Artist Two', mbid: 'artist-2', score: expect.any(Number) },
+      ])
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('/1/lb-radio/artist/seed-mbid'))
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('mode=medium'))
+    })
+
+    it('defaults mode to medium', async () => {
+      mockGet.mockResolvedValueOnce({})
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      await client.getArtistRadio('seed-mbid')
+
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('mode=medium'))
+    })
+
+    it('filters out the seed MBID from results', async () => {
+      mockGet.mockResolvedValueOnce({
+        '0': [
+          {
+            recording_mbid: 'rec-seed',
+            similar_artist_mbid: 'seed-mbid',
+            similar_artist_name: 'Seed Artist',
+            total_listen_count: 999,
+          },
+          {
+            recording_mbid: 'rec-other',
+            similar_artist_mbid: 'other-artist',
+            similar_artist_name: 'Other Artist',
+            total_listen_count: 50,
+          },
+        ],
+      })
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getArtistRadio('seed-mbid', 'medium')
+
+      expect(result).toHaveLength(1)
+      expect(result[0]?.mbid).toBe('other-artist')
+    })
+
+    it('deduplicates artists appearing across multiple groups', async () => {
+      mockGet.mockResolvedValueOnce({
+        '0': [
+          {
+            recording_mbid: 'rec-1',
+            similar_artist_mbid: 'shared-artist',
+            similar_artist_name: 'Shared Artist',
+            total_listen_count: 100,
+          },
+        ],
+        '1': [
+          {
+            recording_mbid: 'rec-2',
+            similar_artist_mbid: 'shared-artist',
+            similar_artist_name: 'Shared Artist',
+            total_listen_count: 200,
+          },
+        ],
+      })
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getArtistRadio('seed-mbid', 'medium')
+
+      expect(result).toHaveLength(1)
+      expect(result[0]?.mbid).toBe('shared-artist')
+    })
+
+    it('returns empty array for empty response', async () => {
+      mockGet.mockResolvedValueOnce({})
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getArtistRadio('seed-mbid')
+
+      expect(result).toEqual([])
+    })
+  })
+
   describe('testConnection()', () => {
     it('returns success:true when getListenCount() resolves', async () => {
       mockGet.mockResolvedValueOnce({ payload: { count: 999 } })

--- a/tests/core/clients/listenbrainz.test.ts
+++ b/tests/core/clients/listenbrainz.test.ts
@@ -336,6 +336,67 @@ describe('createListenBrainzClient', () => {
     })
   })
 
+  describe('getTagRadio(tag, popularity, mode)', () => {
+    it('sends tag and popularity params', async () => {
+      mockGet.mockResolvedValueOnce({
+        '0': [
+          {
+            recording_mbid: 'rec-1',
+            similar_artist_mbid: 'artist-1',
+            similar_artist_name: 'Tag Artist',
+            total_listen_count: 100,
+          },
+        ],
+      })
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getTagRadio('rock', 'medium', 'hard')
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        name: 'Tag Artist',
+        mbid: 'artist-1',
+        score: expect.any(Number),
+      })
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('/1/lb-radio/tags'))
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('tag=rock'))
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('mode=hard'))
+    })
+
+    it('maps popularity preset to numeric range', async () => {
+      mockGet.mockResolvedValueOnce({})
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      await client.getTagRadio('jazz', 'low')
+
+      const call = mockGet.mock.calls[0][0] as string
+      expect(call).toContain('pop_begin=0')
+      expect(call).toContain('pop_end=40')
+    })
+  })
+
+  describe('getUserRadio(targetUsername, mode)', () => {
+    it('calls user radio endpoint', async () => {
+      mockGet.mockResolvedValueOnce({
+        '0': [
+          {
+            recording_mbid: 'rec-1',
+            similar_artist_mbid: 'artist-1',
+            similar_artist_name: 'User Pick',
+            total_listen_count: 200,
+          },
+        ],
+      })
+
+      const client = createListenBrainzClient(TEST_USERNAME, TEST_TOKEN)
+      const result = await client.getUserRadio('targetuser', 'easy')
+
+      expect(result).toHaveLength(1)
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('/1/lb-radio/user/targetuser'))
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('mode=easy'))
+    })
+  })
+
   describe('testConnection()', () => {
     it('returns success:true when getListenCount() resolves', async () => {
       mockGet.mockResolvedValueOnce({ payload: { count: 999 } })

--- a/tests/core/discovery-modes/listenbrainz-radio.test.ts
+++ b/tests/core/discovery-modes/listenbrainz-radio.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/core/clients/listenbrainz', () => ({
+  createListenBrainzClient: vi.fn(),
+}))
+
+vi.mock('@/core/discovery-modes/modes/runtime', () => ({
+  getDiscoveryModeConnections: vi.fn(),
+  getNormalizedLimit: vi.fn(),
+  normalizeDiscoveryName: vi.fn((name: string) => name.toLowerCase()),
+}))
+
+import { createListenBrainzClient } from '@/core/clients/listenbrainz'
+import { createListenBrainzRadioModes } from '@/core/discovery-modes/modes/listenbrainz'
+import {
+  getDiscoveryModeConnections,
+  getNormalizedLimit,
+} from '@/core/discovery-modes/modes/runtime'
+
+const mockClient = {
+  getArtistRadio: vi.fn(),
+  getTagRadio: vi.fn(),
+  getUserRadio: vi.fn(),
+  getSimilarUsers: vi.fn(),
+  getTopArtistsForUser: vi.fn(),
+  getTopArtists: vi.fn(),
+  getSimilarArtists: vi.fn(),
+  getListenCount: vi.fn(),
+  getListeningActivity: vi.fn(),
+  testConnection: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(createListenBrainzClient).mockReturnValue(mockClient)
+  vi.mocked(getDiscoveryModeConnections).mockResolvedValue({
+    listenbrainzUsername: 'testuser',
+    listenbrainzToken: 'testtoken',
+  })
+  vi.mocked(getNormalizedLimit).mockReturnValue(25)
+})
+
+describe('lb-artist-radio mode', () => {
+  it('calls getArtistRadio and maps candidates', async () => {
+    mockClient.getArtistRadio.mockResolvedValueOnce([
+      { name: 'Found Artist', mbid: 'mbid-1', score: 0.9 },
+      { name: 'Another Artist', mbid: 'mbid-2', score: 0.7 },
+    ])
+
+    const modes = createListenBrainzRadioModes()
+    const artistRadio = modes.find((m) => m.id === 'lb-artist-radio')!
+
+    const result = await artistRadio.executor({
+      userId: 1,
+      normalizedSettings: {
+        seedArtistMbid: 'seed-mbid',
+        adventurousness: 'medium',
+      },
+      settingsMode: 'easy',
+    } as any)
+
+    expect(mockClient.getArtistRadio).toHaveBeenCalledWith('seed-mbid', 'medium')
+    expect(result.candidates).toHaveLength(2)
+    expect(result.candidates[0]).toMatchObject({
+      candidateType: 'artist',
+      name: 'Found Artist',
+      mbid: 'mbid-1',
+      provenanceProvider: 'listenbrainz:artist-radio',
+    })
+  })
+
+  it('throws when LB not connected', async () => {
+    vi.mocked(getDiscoveryModeConnections).mockResolvedValue({})
+
+    const modes = createListenBrainzRadioModes()
+    const artistRadio = modes.find((m) => m.id === 'lb-artist-radio')!
+
+    await expect(
+      artistRadio.executor({
+        userId: 1,
+        normalizedSettings: { seedArtistMbid: 'x', adventurousness: 'easy' },
+        settingsMode: 'easy',
+      } as any),
+    ).rejects.toThrow('Connect ListenBrainz')
+  })
+})
+
+describe('lb-tag-radio mode', () => {
+  it('calls getTagRadio with tag and popularity', async () => {
+    mockClient.getTagRadio.mockResolvedValueOnce([
+      { name: 'Jazz Artist', mbid: 'mbid-j', score: 0.8 },
+    ])
+
+    const modes = createListenBrainzRadioModes()
+    const tagRadio = modes.find((m) => m.id === 'lb-tag-radio')!
+
+    const result = await tagRadio.executor({
+      userId: 1,
+      normalizedSettings: { tag: 'jazz', popularity: 'low', adventurousness: 'hard' },
+      settingsMode: 'advanced',
+    } as any)
+
+    expect(mockClient.getTagRadio).toHaveBeenCalledWith('jazz', 'low', 'hard')
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0].provenanceProvider).toBe('listenbrainz:tag-radio')
+  })
+})
+
+describe('lb-user-radio mode', () => {
+  it('uses connected username when no target specified', async () => {
+    mockClient.getUserRadio.mockResolvedValueOnce([])
+
+    const modes = createListenBrainzRadioModes()
+    const userRadio = modes.find((m) => m.id === 'lb-user-radio')!
+
+    await userRadio.executor({
+      userId: 1,
+      normalizedSettings: { targetUsername: '', adventurousness: 'medium' },
+      settingsMode: 'advanced',
+    } as any)
+
+    expect(mockClient.getUserRadio).toHaveBeenCalledWith('testuser', 'medium')
+  })
+
+  it('uses explicit target username when provided', async () => {
+    mockClient.getUserRadio.mockResolvedValueOnce([])
+
+    const modes = createListenBrainzRadioModes()
+    const userRadio = modes.find((m) => m.id === 'lb-user-radio')!
+
+    await userRadio.executor({
+      userId: 1,
+      normalizedSettings: { targetUsername: 'friend', adventurousness: 'easy' },
+      settingsMode: 'advanced',
+    } as any)
+
+    expect(mockClient.getUserRadio).toHaveBeenCalledWith('friend', 'easy')
+  })
+})

--- a/tests/core/discovery-modes/listenbrainz-radio.test.ts
+++ b/tests/core/discovery-modes/listenbrainz-radio.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
   vi.mocked(getDiscoveryModeConnections).mockResolvedValue({
     listenbrainzUsername: 'testuser',
     listenbrainzToken: 'testtoken',
-  })
+  } as any)
   vi.mocked(getNormalizedLimit).mockReturnValue(25)
 })
 
@@ -70,7 +70,7 @@ describe('lb-artist-radio mode', () => {
   })
 
   it('throws when LB not connected', async () => {
-    vi.mocked(getDiscoveryModeConnections).mockResolvedValue({})
+    vi.mocked(getDiscoveryModeConnections).mockResolvedValue({} as any)
 
     const modes = createListenBrainzRadioModes()
     const artistRadio = modes.find((m) => m.id === 'lb-artist-radio')!
@@ -102,7 +102,7 @@ describe('lb-tag-radio mode', () => {
 
     expect(mockClient.getTagRadio).toHaveBeenCalledWith('jazz', 'low', 'hard')
     expect(result.candidates).toHaveLength(1)
-    expect(result.candidates[0].provenanceProvider).toBe('listenbrainz:tag-radio')
+    expect(result.candidates[0]?.provenanceProvider).toBe('listenbrainz:tag-radio')
   })
 })
 

--- a/tests/core/discovery-modes/listenbrainz-radio.test.ts
+++ b/tests/core/discovery-modes/listenbrainz-radio.test.ts
@@ -19,7 +19,6 @@ import {
 
 const mockClient = {
   getArtistRadio: vi.fn(),
-  getTagRadio: vi.fn(),
   getUserRadio: vi.fn(),
   getSimilarUsers: vi.fn(),
   getTopArtistsForUser: vi.fn(),
@@ -82,27 +81,6 @@ describe('lb-artist-radio mode', () => {
         settingsMode: 'easy',
       } as any),
     ).rejects.toThrow('Connect ListenBrainz')
-  })
-})
-
-describe('lb-tag-radio mode', () => {
-  it('calls getTagRadio with tag and popularity', async () => {
-    mockClient.getTagRadio.mockResolvedValueOnce([
-      { name: 'Jazz Artist', mbid: 'mbid-j', score: 0.8 },
-    ])
-
-    const modes = createListenBrainzRadioModes()
-    const tagRadio = modes.find((m) => m.id === 'lb-tag-radio')!
-
-    const result = await tagRadio.executor({
-      userId: 1,
-      normalizedSettings: { tag: 'jazz', popularity: 'low', adventurousness: 'hard' },
-      settingsMode: 'advanced',
-    } as any)
-
-    expect(mockClient.getTagRadio).toHaveBeenCalledWith('jazz', 'low', 'hard')
-    expect(result.candidates).toHaveLength(1)
-    expect(result.candidates[0]?.provenanceProvider).toBe('listenbrainz:tag-radio')
   })
 })
 

--- a/tests/core/discovery-modes/listenbrainz-radio.test.ts
+++ b/tests/core/discovery-modes/listenbrainz-radio.test.ts
@@ -137,3 +137,62 @@ describe('lb-user-radio mode', () => {
     expect(mockClient.getUserRadio).toHaveBeenCalledWith('friend', 'easy')
   })
 })
+
+describe('similar-users-deep mode', () => {
+  it('fetches similar users then their top artists', async () => {
+    mockClient.getSimilarUsers.mockResolvedValueOnce([
+      { username: 'alice', similarity: 0.9 },
+      { username: 'bob', similarity: 0.7 },
+    ])
+    mockClient.getTopArtistsForUser
+      .mockResolvedValueOnce([
+        { name: 'Alice Pick', mbid: 'mbid-a1', playCount: 100, source: 'listenbrainz' },
+        { name: 'Shared Pick', mbid: 'mbid-s1', playCount: 80, source: 'listenbrainz' },
+      ])
+      .mockResolvedValueOnce([
+        { name: 'Bob Pick', mbid: 'mbid-b1', playCount: 90, source: 'listenbrainz' },
+        { name: 'Shared Pick', mbid: 'mbid-s1', playCount: 70, source: 'listenbrainz' },
+      ])
+
+    const modes = createListenBrainzRadioModes()
+    const deep = modes.find((m) => m.id === 'similar-users-deep')!
+
+    const result = await deep.executor({
+      userId: 1,
+      normalizedSettings: { maxUsers: 2 },
+      settingsMode: 'advanced',
+    } as any)
+
+    expect(mockClient.getSimilarUsers).toHaveBeenCalled()
+    expect(mockClient.getTopArtistsForUser).toHaveBeenCalledTimes(2)
+    expect(mockClient.getTopArtistsForUser).toHaveBeenCalledWith('alice', 'month')
+    expect(mockClient.getTopArtistsForUser).toHaveBeenCalledWith('bob', 'month')
+
+    const names = result.candidates.map((c) => c.name)
+    expect(names).toContain('Alice Pick')
+    expect(names).toContain('Bob Pick')
+    expect(names).toContain('Shared Pick')
+    // Shared Pick should appear only once (deduplicated)
+    expect(names.filter((n) => n === 'Shared Pick')).toHaveLength(1)
+  })
+
+  it('caps at maxUsers parameter', async () => {
+    mockClient.getSimilarUsers.mockResolvedValueOnce([
+      { username: 'alice', similarity: 0.9 },
+      { username: 'bob', similarity: 0.7 },
+      { username: 'carol', similarity: 0.5 },
+    ])
+    mockClient.getTopArtistsForUser.mockResolvedValue([])
+
+    const modes = createListenBrainzRadioModes()
+    const deep = modes.find((m) => m.id === 'similar-users-deep')!
+
+    await deep.executor({
+      userId: 1,
+      normalizedSettings: { maxUsers: 2 },
+      settingsMode: 'advanced',
+    } as any)
+
+    expect(mockClient.getTopArtistsForUser).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/core/discovery-modes/modes/listenbrainz.test.ts
+++ b/tests/core/discovery-modes/modes/listenbrainz.test.ts
@@ -105,8 +105,8 @@ describe('createListenBrainzMode', () => {
       triggerType: 'manual',
       settingsMode: 'advanced',
       userId: 7,
-      rawUserSettings: { feedType: 'similar-users', limit: 2 },
-      normalizedSettings: { feedType: 'similar-users', limit: 2 },
+      rawUserSettings: { feedType: 'similar-users-quick', limit: 2 },
+      normalizedSettings: { feedType: 'similar-users-quick', limit: 2 },
       providerContext: { providerPath: ['listenbrainz'] },
       fallbackPolicy: 'strict',
     }
@@ -118,13 +118,13 @@ describe('createListenBrainzMode', () => {
       expect.objectContaining({
         candidateType: 'artist',
         name: 'Casino Versus Japan',
-        provenanceProvider: 'listenbrainz:similar-users',
+        provenanceProvider: 'listenbrainz:similar-users-quick',
         fallbackUsed: false,
       }),
       expect.objectContaining({
         candidateType: 'artist',
         name: 'Plaid',
-        provenanceProvider: 'listenbrainz:similar-users',
+        provenanceProvider: 'listenbrainz:similar-users-quick',
         fallbackUsed: false,
       }),
     ])

--- a/tests/core/plugins/listenbrainz.test.ts
+++ b/tests/core/plugins/listenbrainz.test.ts
@@ -25,7 +25,6 @@ describe('createListenBrainzSource()', () => {
       testConnection: vi.fn().mockResolvedValue({ success: true, message: 'Connected' }),
       getListenCount: vi.fn().mockResolvedValue(5000),
       getArtistRadio: vi.fn().mockResolvedValue([]),
-      getTagRadio: vi.fn().mockResolvedValue([]),
       getUserRadio: vi.fn().mockResolvedValue([]),
       getSimilarUsers: vi.fn().mockResolvedValue([]),
       getTopArtistsForUser: vi.fn().mockResolvedValue([]),

--- a/tests/core/plugins/listenbrainz.test.ts
+++ b/tests/core/plugins/listenbrainz.test.ts
@@ -24,6 +24,11 @@ describe('createListenBrainzSource()', () => {
         .mockResolvedValue([{ listen_count: 100, from_ts: 1000, to_ts: 2000 }]),
       testConnection: vi.fn().mockResolvedValue({ success: true, message: 'Connected' }),
       getListenCount: vi.fn().mockResolvedValue(5000),
+      getArtistRadio: vi.fn().mockResolvedValue([]),
+      getTagRadio: vi.fn().mockResolvedValue([]),
+      getUserRadio: vi.fn().mockResolvedValue([]),
+      getSimilarUsers: vi.fn().mockResolvedValue([]),
+      getTopArtistsForUser: vi.fn().mockResolvedValue([]),
     }
     vi.mocked(createListenBrainzClient).mockReturnValue(client)
     return client

--- a/tests/core/subscriptions/listenbrainz.test.ts
+++ b/tests/core/subscriptions/listenbrainz.test.ts
@@ -62,7 +62,7 @@ describe('tag-radio feed type', () => {
     })
 
     expect(mockClient.getTagRadio).toHaveBeenCalledWith('electronic', 'high', 'medium')
-    expect(result.artists[0].source).toBe('listenbrainz:tag-radio')
+    expect(result.artists[0]?.source).toBe('listenbrainz:tag-radio')
   })
 })
 

--- a/tests/core/subscriptions/listenbrainz.test.ts
+++ b/tests/core/subscriptions/listenbrainz.test.ts
@@ -9,7 +9,6 @@ import { createListenBrainzAdapter } from '@/core/subscriptions/adapters/listenb
 
 const mockClient = {
   getArtistRadio: vi.fn(),
-  getTagRadio: vi.fn(),
   getSimilarUsers: vi.fn(),
   getTopArtistsForUser: vi.fn(),
   getTopArtists: vi.fn(),
@@ -44,25 +43,6 @@ describe('artist-radio feed type', () => {
       similarityScore: 0.8,
       source: 'listenbrainz:artist-radio',
     })
-  })
-})
-
-describe('tag-radio feed type', () => {
-  it('calls getTagRadio and maps results', async () => {
-    mockClient.getTagRadio.mockResolvedValueOnce([
-      { name: 'Genre Artist', mbid: 'mbid-g', score: 0.7 },
-    ])
-
-    const adapter = createListenBrainzAdapter({ username: 'user', token: 'tok' })
-    const result = await adapter.fetch({
-      feedType: 'tag-radio',
-      tag: 'electronic',
-      popularity: 'high',
-      adventurousness: 'medium',
-    })
-
-    expect(mockClient.getTagRadio).toHaveBeenCalledWith('electronic', 'high', 'medium')
-    expect(result.artists[0]?.source).toBe('listenbrainz:tag-radio')
   })
 })
 

--- a/tests/core/subscriptions/listenbrainz.test.ts
+++ b/tests/core/subscriptions/listenbrainz.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/core/clients/listenbrainz', () => ({
+  createListenBrainzClient: vi.fn(),
+}))
+
+import { createListenBrainzClient } from '@/core/clients/listenbrainz'
+import { createListenBrainzAdapter } from '@/core/subscriptions/adapters/listenbrainz'
+
+const mockClient = {
+  getArtistRadio: vi.fn(),
+  getTagRadio: vi.fn(),
+  getSimilarUsers: vi.fn(),
+  getTopArtistsForUser: vi.fn(),
+  getTopArtists: vi.fn(),
+  getSimilarArtists: vi.fn(),
+  getUserRadio: vi.fn(),
+  getListenCount: vi.fn(),
+  getListeningActivity: vi.fn(),
+  testConnection: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(createListenBrainzClient).mockReturnValue(mockClient)
+})
+
+describe('artist-radio feed type', () => {
+  it('calls getArtistRadio and maps to DiscoveredArtist', async () => {
+    mockClient.getArtistRadio.mockResolvedValueOnce([
+      { name: 'Radio Artist', mbid: 'mbid-1', score: 0.8 },
+    ])
+
+    const adapter = createListenBrainzAdapter({ username: 'user', token: 'tok' })
+    const result = await adapter.fetch({
+      feedType: 'artist-radio',
+      seedArtistMbid: 'seed-mbid',
+      adventurousness: 'hard',
+    })
+
+    expect(result.artists).toHaveLength(1)
+    expect(result.artists[0]).toMatchObject({
+      name: 'Radio Artist',
+      similarityScore: 0.8,
+      source: 'listenbrainz:artist-radio',
+    })
+  })
+})
+
+describe('tag-radio feed type', () => {
+  it('calls getTagRadio and maps results', async () => {
+    mockClient.getTagRadio.mockResolvedValueOnce([
+      { name: 'Genre Artist', mbid: 'mbid-g', score: 0.7 },
+    ])
+
+    const adapter = createListenBrainzAdapter({ username: 'user', token: 'tok' })
+    const result = await adapter.fetch({
+      feedType: 'tag-radio',
+      tag: 'electronic',
+      popularity: 'high',
+      adventurousness: 'medium',
+    })
+
+    expect(mockClient.getTagRadio).toHaveBeenCalledWith('electronic', 'high', 'medium')
+    expect(result.artists[0].source).toBe('listenbrainz:tag-radio')
+  })
+})
+
+describe('similar-users feed type', () => {
+  it('fetches similar users top artists', async () => {
+    mockClient.getSimilarUsers.mockResolvedValueOnce([{ username: 'peer1', similarity: 0.9 }])
+    mockClient.getTopArtistsForUser.mockResolvedValueOnce([
+      { name: 'Peer Pick', mbid: 'mbid-p', playCount: 50, source: 'listenbrainz' },
+    ])
+
+    const adapter = createListenBrainzAdapter({ username: 'user', token: 'tok' })
+    const result = await adapter.fetch({
+      feedType: 'similar-users',
+      maxUsers: 1,
+    })
+
+    expect(result.artists).toHaveLength(1)
+    expect(result.artists[0]).toMatchObject({
+      name: 'Peer Pick',
+      source: 'listenbrainz:similar-users',
+    })
+  })
+
+  it('deduplicates across users', async () => {
+    mockClient.getSimilarUsers.mockResolvedValueOnce([
+      { username: 'peer1', similarity: 0.9 },
+      { username: 'peer2', similarity: 0.8 },
+    ])
+    mockClient.getTopArtistsForUser
+      .mockResolvedValueOnce([{ name: 'Shared', mbid: 's', playCount: 50, source: 'listenbrainz' }])
+      .mockResolvedValueOnce([{ name: 'Shared', mbid: 's', playCount: 40, source: 'listenbrainz' }])
+
+    const adapter = createListenBrainzAdapter({ username: 'user', token: 'tok' })
+    const result = await adapter.fetch({ feedType: 'similar-users', maxUsers: 2 })
+
+    expect(result.artists).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Add 3 new LB client methods: `getArtistRadio` (configurable mode), `getUserRadio` (composition of top-artist + artist-radio), `getSimilarUsers` + `getTopArtistsForUser`
- Add 3 new discovery modes: `lb-artist-radio`, `lb-user-radio`, `similar-users-deep` (fetches similar users' top artists with dedup)
- Add 2 new subscription feed types: `artist-radio`, `similar-users`
- Rename existing `similar-users` discovery mode to `similar-users-quick` for clarity
- Register all new modes in the discovery mode registry

Tag radio was removed after API verification showed `/lb-radio/tags` returns flat recording arrays without artist info. User radio was reimplemented as a composition (top artist lookup + artist radio seed) after confirming `/lb-radio/user/{username}` does not exist.

## Test plan

- [x] 19 new tests across 3 test files (client, discovery modes, subscription adapter)
- [x] Full suite passes (1653 tests, 0 failures)
- [x] Typecheck clean
- [x] Lint clean (0 errors)
- [ ] CI green on both Forgejo and GitHub