### PR TITLE
feat: ListenBrainz tag radio discovery and subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-facing changes are documented here.
 
+## Unreleased
+
+### Added
+
+- **Tag Radio discovery mode** (`lb-tag-radio`): discover artists by genre/style tags via ListenBrainz radio. Supports multiple tags with per-tag weights, raw LB syntax, and popularity filtering.
+- **Tag Radio subscription feed**: recurring tag-based artist discovery via the ListenBrainz adapter.
+- **Recording-artist cache**: persistent cache for MusicBrainz recording-to-artist lookups, improving performance on repeat tag radio runs.
+
 ## v0.23.0 - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Digarr takes signals from up to 7 sources, runs them through an AI-assisted pipe
 Type "something like Boards of Canada but darker" or "upbeat 90s pop for a road trip" and Digarr turns that into a result set. You do not have to translate the idea into filters first.
 
 ### Discovery Modes
-Run focused discovery flows for the currently shipped modes: ListenBrainz (Artist Radio, User Radio, Similar Users Quick and Deep), Release Radar, and Similar Artist Web. Labels and Artist Relationships stay visible in the UI so you can see what is planned, but they are marked unavailable and rejected server-side until they have real implementations. Available discovery modes can be saved as subscriptions, and those subscriptions now reuse the same provider/fallback path as the manual run you configured.
+Run focused discovery flows for the currently shipped modes: ListenBrainz (Artist Radio, User Radio, Tag Radio, Similar Users Quick and Deep), Release Radar, and Similar Artist Web. Labels and Artist Relationships stay visible in the UI so you can see what is planned, but they are marked unavailable and rejected server-side until they have real implementations. Available discovery modes can be saved as subscriptions, and those subscriptions now reuse the same provider/fallback path as the manual run you configured.
 
 ### Auto-Playlists
 Build playlists from approved recommendations and send them to Navidrome, Jellyfin, Emby, Plex, or Spotify, or export them as M3U/XSPF. The built-in playlist types are Weekly Digest, Genre Focus, Mood Mix, and Rediscover.
@@ -63,7 +63,7 @@ Search across Spotify, Deezer, MusicBrainz, TIDAL, and Bandcamp in one pass. Dig
 - **8 data sources:** ListenBrainz, Last.fm, Spotify (OAuth), Deezer (OAuth), Plex, Jellyfin, Emby, and Discogs
 - **Smart scoring:** weighted composite scoring across consensus, similarity, genre overlap, AI confidence, feedback learning, and popularity
 - **Auto-approve:** send high-scoring recommendations to your targets automatically
-- **Discovery modes:** manual and subscription flows for ListenBrainz (Artist Radio, User Radio, Similar Users Quick/Deep), Release Radar, and Similar Artist Web, with unavailable planned modes exposed in metadata but blocked from execution until they ship
+- **Discovery modes:** manual and subscription flows for ListenBrainz (Artist Radio, User Radio, Tag Radio, Similar Users Quick/Deep), Release Radar, and Similar Artist Web, with unavailable planned modes exposed in metadata but blocked from execution until they ship
 - **Subscriptions:** scheduled discovery from discovery modes, Spotify Liked Songs, playlists and charts, Deezer favorites, followed artists and Flow, Last.fm tags and charts, ListenBrainz feeds, genre searches, and similar-artist seeds
 - **Genre deep dive:** browse by genre with Recommended, Trending, and Deep Cuts tabs
 - **Library sync and reconciliation:** background artist and album sync, per-source status, album sync coverage, unreconciled artist and album review, album coverage badges on recommendation cards, and 6 automated health checks with one-click fixes

--- a/drizzle/0021_lumpy_squadron_supreme.sql
+++ b/drizzle/0021_lumpy_squadron_supreme.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS "recording_artist_cache" (
+	"recording_mbid" uuid PRIMARY KEY NOT NULL,
+	"artist_mbid" uuid NOT NULL,
+	"artist_name" text NOT NULL,
+	"cached_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,2513 @@
+{
+  "id": "7c8a976c-f010-4f8a-8951-bdda5ce4eccb",
+  "prevId": "617dbf4b-e4f5-4660-b0ac-555538586def",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.artist_metadata": {
+      "name": "artist_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_normalized": {
+          "name": "name_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spotify_genres": {
+          "name": "spotify_genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_popularity": {
+          "name": "spotify_popularity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deezer_fans": {
+          "name": "deezer_fans",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_metadata_name_normalized_unique": {
+          "name": "artist_metadata_name_normalized_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_normalized"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disambiguation": {
+          "name": "disambiguation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_urls": {
+          "name": "streaming_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_failed_at": {
+          "name": "image_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "begin_year": {
+          "name": "begin_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_year": {
+          "name": "end_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_tracks": {
+          "name": "top_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artists_mbid_unique": {
+          "name": "artists_mbid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mbid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_genre_id": {
+          "name": "parent_genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_count": {
+          "name": "artist_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "genres_parent_genre_id_genres_id_fk": {
+          "name": "genres_parent_genre_id_genres_id_fk",
+          "tableFrom": "genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "parent_genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_slug_unique": {
+          "name": "genres_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_runs": {
+      "name": "job_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_results": {
+          "name": "source_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_runs_user_id_users_id_fk": {
+          "name": "job_runs_user_id_users_id_fk",
+          "tableFrom": "job_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "job_runs_subscription_id_subscriptions_id_fk": {
+          "name": "job_runs_subscription_id_subscriptions_id_fk",
+          "tableFrom": "job_runs",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "job_runs_batch_id_recommendation_batches_id_fk": {
+          "name": "job_runs_batch_id_recommendation_batches_id_fk",
+          "tableFrom": "job_runs",
+          "tableTo": "recommendation_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_album_match_overrides": {
+      "name": "library_album_match_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_album_id": {
+          "name": "source_album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_album_mbid": {
+          "name": "correct_album_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_album_match_overrides_natural_key_idx": {
+          "name": "library_album_match_overrides_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_album_match_overrides_user_id_users_id_fk": {
+          "name": "library_album_match_overrides_user_id_users_id_fk",
+          "tableFrom": "library_album_match_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_albums": {
+      "name": "library_albums",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_album_id": {
+          "name": "source_album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_normalized": {
+          "name": "title_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_mbid": {
+          "name": "album_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_mbid": {
+          "name": "artist_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_albums_natural_key_idx": {
+          "name": "library_albums_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_albums_artist_idx": {
+          "name": "library_albums_artist_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_mbid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_albums_user_id_users_id_fk": {
+          "name": "library_albums_user_id_users_id_fk",
+          "tableFrom": "library_albums",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_artists": {
+      "name": "library_artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_normalized": {
+          "name": "name_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_artists_natural_key_idx": {
+          "name": "library_artists_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_artists_dedup_idx": {
+          "name": "library_artists_dedup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mbid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_artists_name_idx": {
+          "name": "library_artists_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artists_user_id_users_id_fk": {
+          "name": "library_artists_user_id_users_id_fk",
+          "tableFrom": "library_artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_match_overrides": {
+      "name": "library_match_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_mbid": {
+          "name": "correct_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_match_overrides_natural_key_idx": {
+          "name": "library_match_overrides_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_match_overrides_user_id_users_id_fk": {
+          "name": "library_match_overrides_user_id_users_id_fk",
+          "tableFrom": "library_match_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_sync_state": {
+      "name": "library_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_counts": {
+          "name": "last_sync_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_sync_state_natural_key_idx": {
+          "name": "library_sync_state_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_sync_state_user_id_users_id_fk": {
+          "name": "library_sync_state_user_id_users_id_fk",
+          "tableFrom": "library_sync_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_tokens": {
+      "name": "oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_tokens_user_id_users_id_fk": {
+          "name": "oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_tokens_user_provider": {
+          "name": "oauth_tokens_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_tokens": {
+      "name": "oidc_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oidc_tokens_user_id_users_id_fk": {
+          "name": "oidc_tokens_user_id_users_id_fk",
+          "tableFrom": "oidc_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_tracks": {
+      "name": "playlist_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_uri": {
+          "name": "spotify_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deezer_id": {
+          "name": "deezer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_tracks_playlist_position_idx": {
+          "name": "playlist_tracks_playlist_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_tracks_playlist_id_playlists_id_fk": {
+          "name": "playlist_tracks_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_tracks",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ids": {
+          "name": "target_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_count": {
+          "name": "track_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "playlists_user_id_idx": {
+          "name": "playlists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_enabled_last_generated_idx": {
+          "name": "playlists_enabled_last_generated_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlists_user_id_users_id_fk": {
+          "name": "playlists_user_id_users_id_fk",
+          "tableFrom": "playlists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendation_batches": {
+      "name": "recommendation_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recommendation_batches_subscription_id_subscriptions_id_fk": {
+          "name": "recommendation_batches_subscription_id_subscriptions_id_fk",
+          "tableFrom": "recommendation_batches",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendations": {
+      "name": "recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_reasoning": {
+          "name": "ai_reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lidarr_artist_id": {
+          "name": "lidarr_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lidarr_error": {
+          "name": "lidarr_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_release_group_id": {
+          "name": "recommended_release_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_release_group_title": {
+          "name": "recommended_release_group_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_actions": {
+          "name": "target_actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acted_on_at": {
+          "name": "acted_on_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recommendations_batch_idx": {
+          "name": "recommendations_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_artist_idx": {
+          "name": "recommendations_artist_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_user_status_score_idx": {
+          "name": "recommendations_user_status_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_user_created_idx": {
+          "name": "recommendations_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_user_acted_on_idx": {
+          "name": "recommendations_user_acted_on_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acted_on_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_status_acted_on_idx": {
+          "name": "recommendations_status_acted_on_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acted_on_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendations_user_id_users_id_fk": {
+          "name": "recommendations_user_id_users_id_fk",
+          "tableFrom": "recommendations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recommendations_artist_id_artists_id_fk": {
+          "name": "recommendations_artist_id_artists_id_fk",
+          "tableFrom": "recommendations",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recommendations_batch_id_recommendation_batches_id_fk": {
+          "name": "recommendations_batch_id_recommendation_batches_id_fk",
+          "tableFrom": "recommendations",
+          "tableTo": "recommendation_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recording_artist_cache": {
+      "name": "recording_artist_cache",
+      "schema": "",
+      "columns": {
+        "recording_mbid": {
+          "name": "recording_mbid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_mbid": {
+          "name": "artist_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_expires_idx": {
+          "name": "sessions_user_expires_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lidarr_url": {
+          "name": "lidarr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lidarr_api_key": {
+          "name": "lidarr_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listenbrainz_username": {
+          "name": "listenbrainz_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listenbrainz_token": {
+          "name": "listenbrainz_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm_username": {
+          "name": "lastfm_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm_api_key": {
+          "name": "lastfm_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_api_key": {
+          "name": "ai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_base_url": {
+          "name": "ai_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_issuer_url": {
+          "name": "oidc_issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_client_id": {
+          "name": "oidc_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_client_secret": {
+          "name": "oidc_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_scopes": {
+          "name": "oidc_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_tls_verify": {
+          "name": "skip_tls_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_complete": {
+          "name": "setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "library_sync_interval_hours": {
+          "name": "library_sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_provider": {
+          "name": "source_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_artists_per_run": {
+          "name": "max_artists_per_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "listener_range": {
+          "name": "listener_range",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'add_to_recommendations'"
+        },
+        "score_threshold": {
+          "name": "score_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scoring_weight_preset": {
+          "name": "scoring_weight_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "scoring_weight_overrides": {
+          "name": "scoring_weight_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_result_count": {
+          "name": "last_result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_enabled_idx": {
+          "name": "subscriptions_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.targets": {
+      "name": "targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "targets_user_id_idx": {
+          "name": "targets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "targets_type_idx": {
+          "name": "targets_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "targets_user_id_users_id_fk": {
+          "name": "targets_user_id_users_id_fk",
+          "tableFrom": "targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferred_locale": {
+          "name": "preferred_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listenbrainz_username": {
+          "name": "listenbrainz_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listenbrainz_token": {
+          "name": "listenbrainz_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm_username": {
+          "name": "lastfm_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm_api_key": {
+          "name": "lastfm_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_url": {
+          "name": "plex_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_token": {
+          "name": "plex_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jellyfin_url": {
+          "name": "jellyfin_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jellyfin_api_key": {
+          "name": "jellyfin_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jellyfin_user_id": {
+          "name": "jellyfin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emby_url": {
+          "name": "emby_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emby_api_key": {
+          "name": "emby_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emby_user_id": {
+          "name": "emby_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_token": {
+          "name": "discogs_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_username": {
+          "name": "discogs_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1775905644292,
       "tag": "0020_multilingual_locale",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1775993860990,
+      "tag": "0021_lumpy_squadron_supreme",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/clients/listenbrainz.ts
+++ b/src/core/clients/listenbrainz.ts
@@ -92,7 +92,7 @@ type LbTagRadioRecording = {
 }
 
 function buildTagExpression(tags: TagRadioInput[]): string {
-  if (tags.length === 1) return tags[0]!.tag
+  if (tags.length === 1) return tags[0]?.tag ?? ''
   return tags.map((t) => `(${t.tag}):${t.weight}`).join(':')
 }
 

--- a/src/core/clients/listenbrainz.ts
+++ b/src/core/clients/listenbrainz.ts
@@ -71,6 +71,31 @@ export type SimilarUser = {
   similarity: number
 }
 
+export type TagRadioInput = {
+  tag: string
+  weight: number
+}
+
+export type TagRadioRecording = {
+  recordingMbid: string
+  percent: number
+  source: string
+  tagCount: number
+}
+
+// Raw LB tag radio response shape
+type LbTagRadioRecording = {
+  recording_mbid: string
+  percent: number
+  source: string
+  tag_count: number
+}
+
+function buildTagExpression(tags: TagRadioInput[]): string {
+  if (tags.length === 1) return tags[0]!.tag
+  return tags.map((t) => `(${t.tag}):${t.weight}`).join(':')
+}
+
 function extractRadioArtists(res: LbRadioResponse, excludeMbid?: string): RadioArtist[] {
   const seen = new Set<string>()
   const artists: RadioArtist[] = []
@@ -193,6 +218,25 @@ export function createListenBrainzClient(username: string, token: string) {
     }))
   }
 
+  async function getTagRadio(
+    tags: TagRadioInput[],
+    options?: { count?: number; popBegin?: number; popEnd?: number },
+  ): Promise<TagRadioRecording[]> {
+    const params = new URLSearchParams({
+      tag: buildTagExpression(tags),
+      count: String(options?.count ?? 25),
+      pop_begin: String(options?.popBegin ?? 0),
+      pop_end: String(options?.popEnd ?? 100),
+    })
+    const res = await http.get<LbTagRadioRecording[]>(`/1/lb-radio/tags?${params.toString()}`)
+    return (res ?? []).map((r) => ({
+      recordingMbid: r.recording_mbid,
+      percent: r.percent,
+      source: r.source,
+      tagCount: r.tag_count,
+    }))
+  }
+
   async function testConnection(): Promise<ServiceTestResult> {
     try {
       const count = await getListenCount()
@@ -215,6 +259,7 @@ export function createListenBrainzClient(username: string, token: string) {
     getUserRadio,
     getSimilarUsers,
     getTopArtistsForUser,
+    getTagRadio,
     testConnection,
   }
 }

--- a/src/core/clients/musicbrainz.ts
+++ b/src/core/clients/musicbrainz.ts
@@ -52,6 +52,20 @@ export type MBRecording = {
   isrcs?: string[]
 }
 
+export type RecordingArtistCredit = {
+  recordingMbid: string
+  artistMbid: string
+  artistName: string
+}
+
+type MBRecordingLookup = {
+  id: string
+  title: string
+  'artist-credit'?: Array<{
+    artist: { id: string; name: string }
+  }>
+}
+
 export type StreamingUrls = {
   spotify?: string
   youtube?: string
@@ -154,6 +168,24 @@ export function createMusicBrainzClient() {
     }))
   }
 
+  async function lookupRecording(mbid: string): Promise<RecordingArtistCredit | null> {
+    const params = new URLSearchParams({ inc: 'artist-credits', fmt: 'json' })
+    let data: MBRecordingLookup
+    try {
+      data = await request<MBRecordingLookup>(`/recording/${mbid}?${params}`)
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('404')) return null
+      throw err
+    }
+    const credit = data['artist-credit']?.[0]
+    if (!credit) return null
+    return {
+      recordingMbid: mbid,
+      artistMbid: credit.artist.id,
+      artistName: credit.artist.name,
+    }
+  }
+
   function extractStreamingUrls(relations: MBRelation[]): StreamingUrls {
     const result: StreamingUrls = {}
 
@@ -179,6 +211,7 @@ export function createMusicBrainzClient() {
     searchArtist,
     getReleaseGroups,
     getRecordings,
+    lookupRecording,
     extractStreamingUrls,
   }
 }

--- a/src/core/clients/tag-radio-resolver.ts
+++ b/src/core/clients/tag-radio-resolver.ts
@@ -1,4 +1,3 @@
-import PQueue from 'p-queue'
 import type { TagRadioRecording } from '@/core/clients/listenbrainz'
 import type { RecordingArtistCredit } from '@/core/clients/musicbrainz'
 import type { Database } from '@/db'
@@ -32,11 +31,11 @@ export async function resolveTagRadioRecordings(
   // 2. Partition into hits and misses
   const misses = recordings.filter((r) => !cacheMap.has(r.recordingMbid))
 
-  // 3. Resolve misses via MB with rate limiting
-  const queue = new PQueue({ concurrency: 1, interval: 1000, intervalCap: 1 })
-  const resolved = await Promise.all(
-    misses.map((r) => queue.add(() => mbClient.lookupRecording(r.recordingMbid))),
-  )
+  // 3. Resolve misses via MB (client handles rate limiting internally)
+  const resolved: (RecordingArtistCredit | null)[] = []
+  for (const r of misses) {
+    resolved.push(await mbClient.lookupRecording(r.recordingMbid))
+  }
 
   // 4. Write newly resolved to cache
   const newEntries = resolved.filter((r): r is RecordingArtistCredit => r != null)

--- a/src/core/clients/tag-radio-resolver.ts
+++ b/src/core/clients/tag-radio-resolver.ts
@@ -1,0 +1,89 @@
+import PQueue from 'p-queue'
+import type { TagRadioRecording } from '@/core/clients/listenbrainz'
+import type { RecordingArtistCredit } from '@/core/clients/musicbrainz'
+import type { Database } from '@/db'
+import {
+  getCachedRecordingArtists,
+  insertCachedRecordingArtists,
+} from '@/db/queries/recording-artist-cache'
+
+export type ResolvedTagArtist = {
+  artistMbid: string
+  artistName: string
+  score: number
+}
+
+type MbClientForTagRadio = {
+  lookupRecording(mbid: string): Promise<RecordingArtistCredit | null>
+}
+
+export async function resolveTagRadioRecordings(
+  recordings: TagRadioRecording[],
+  mbClient: MbClientForTagRadio,
+  db: Database,
+): Promise<ResolvedTagArtist[]> {
+  if (recordings.length === 0) return []
+
+  // 1. Batch cache lookup
+  const allMbids = recordings.map((r) => r.recordingMbid)
+  const cached = await getCachedRecordingArtists(db, allMbids)
+  const cacheMap = new Map(cached.map((c) => [c.recordingMbid, c]))
+
+  // 2. Partition into hits and misses
+  const misses = recordings.filter((r) => !cacheMap.has(r.recordingMbid))
+
+  // 3. Resolve misses via MB with rate limiting
+  const queue = new PQueue({ concurrency: 1, interval: 1000, intervalCap: 1 })
+  const resolved = await Promise.all(
+    misses.map((r) => queue.add(() => mbClient.lookupRecording(r.recordingMbid))),
+  )
+
+  // 4. Write newly resolved to cache
+  const newEntries = resolved.filter((r): r is RecordingArtistCredit => r != null)
+  await insertCachedRecordingArtists(
+    db,
+    newEntries.map((e) => ({
+      recordingMbid: e.recordingMbid,
+      artistMbid: e.artistMbid,
+      artistName: e.artistName,
+    })),
+  )
+
+  // 5. Build unified recording -> artist map
+  const recordingToArtist = new Map<string, { artistMbid: string; artistName: string }>()
+  for (const c of cached) {
+    recordingToArtist.set(c.recordingMbid, {
+      artistMbid: c.artistMbid,
+      artistName: c.artistName,
+    })
+  }
+  for (const e of newEntries) {
+    recordingToArtist.set(e.recordingMbid, {
+      artistMbid: e.artistMbid,
+      artistName: e.artistName,
+    })
+  }
+
+  // 6. Group by artist, take max percent
+  const artistMap = new Map<string, { artistName: string; maxPercent: number }>()
+  for (const rec of recordings) {
+    const artist = recordingToArtist.get(rec.recordingMbid)
+    if (!artist) continue
+    const existing = artistMap.get(artist.artistMbid)
+    if (!existing || rec.percent > existing.maxPercent) {
+      artistMap.set(artist.artistMbid, {
+        artistName: artist.artistName,
+        maxPercent: rec.percent,
+      })
+    }
+  }
+
+  // 7. Return sorted by score descending
+  return Array.from(artistMap.entries())
+    .map(([artistMbid, { artistName, maxPercent }]) => ({
+      artistMbid,
+      artistName,
+      score: maxPercent / 100,
+    }))
+    .sort((a, b) => b.score - a.score)
+}

--- a/src/core/discovery-modes/modes/listenbrainz.ts
+++ b/src/core/discovery-modes/modes/listenbrainz.ts
@@ -1,5 +1,6 @@
-import type { RadioMode } from '@/core/clients/listenbrainz'
+import type { RadioMode, TagRadioInput } from '@/core/clients/listenbrainz'
 import { createListenBrainzClient } from '@/core/clients/listenbrainz'
+import { resolveTagRadioRecordings } from '@/core/clients/tag-radio-resolver'
 import { createListenBrainzAdapter } from '@/core/subscriptions/adapters/listenbrainz'
 import type {
   DiscoveryConfigField,
@@ -156,6 +157,17 @@ function mapRadioArtists(
   }
 }
 
+function parseRawTagExpression(raw: string): TagRadioInput[] {
+  const results: TagRadioInput[] = []
+  for (const m of raw.matchAll(/\(([^)]+)\):(\d+)/g)) {
+    if (m[1]) results.push({ tag: m[1], weight: Number(m[2]) })
+  }
+  if (results.length === 0) {
+    return [{ tag: raw.trim(), weight: 1 }]
+  }
+  return results
+}
+
 export function createListenBrainzRadioModes(): DiscoveryModeDefinition[] {
   const adventurenessField: DiscoveryConfigField = {
     key: 'adventurousness',
@@ -279,4 +291,100 @@ export function createListenBrainzRadioModes(): DiscoveryModeDefinition[] {
   }
 
   return [artistRadio, userRadio, similarUsersDeep]
+}
+
+export function createListenBrainzTagRadioMode(): DiscoveryModeDefinition {
+  return {
+    id: 'lb-tag-radio',
+    label: 'Tag Radio',
+    description: 'Discover artists matching genre tags via ListenBrainz radio',
+    availability: 'strict',
+    easyFields: [
+      {
+        key: 'tags',
+        label: 'Tags',
+        type: 'tags' as DiscoveryConfigField['type'],
+        required: true,
+        helpText: 'Genre or style tags to discover from. Add multiple tags with weights.',
+      },
+    ],
+    advancedFields: [
+      {
+        key: 'tags',
+        label: 'Tags',
+        type: 'tags' as DiscoveryConfigField['type'],
+        required: true,
+        helpText: 'Genre or style tags to discover from. Add multiple tags with weights.',
+      },
+      {
+        key: 'rawTagExpression',
+        label: 'Raw tag expression',
+        type: 'text',
+        helpText: 'Override tag builder with raw LB syntax, e.g. (trip hop):2:(ambient):1',
+      },
+      {
+        key: 'count',
+        label: 'Recordings to fetch',
+        type: 'number',
+        helpText:
+          'Default 25. Higher values improve diversity but are slower due to MusicBrainz rate limiting (~1 second per recording).',
+      },
+      {
+        key: 'popBegin',
+        label: 'Popularity min',
+        type: 'number',
+        helpText: '0-100. Filter out recordings below this popularity.',
+      },
+      {
+        key: 'popEnd',
+        label: 'Popularity max',
+        type: 'number',
+        helpText: '0-100. Filter out recordings above this popularity.',
+      },
+    ],
+    executor: async (request) => {
+      const { client } = await getConnectedClient(request.userId)
+      const [{ db }, { createMusicBrainzClient }] = await Promise.all([
+        import('@/db'),
+        import('@/core/clients/musicbrainz'),
+      ])
+      const mbClient = createMusicBrainzClient()
+
+      const rawExpr = String(request.normalizedSettings.rawTagExpression ?? '').trim()
+      let tags: TagRadioInput[]
+      if (rawExpr) {
+        tags = parseRawTagExpression(rawExpr)
+      } else {
+        const tagsRaw = request.normalizedSettings.tags
+        tags = Array.isArray(tagsRaw)
+          ? (tagsRaw as Array<Record<string, unknown>>)
+              .filter((t) => typeof t.tag === 'string' && t.tag.trim())
+              .map((t) => ({ tag: String(t.tag).trim(), weight: Number(t.weight) || 1 }))
+          : []
+      }
+
+      if (tags.length === 0) {
+        throw new Error('At least one tag is required.')
+      }
+
+      const count = Number(request.normalizedSettings.count) || 25
+      const popBegin = Number(request.normalizedSettings.popBegin) || 0
+      const popEnd = Number(request.normalizedSettings.popEnd) || 100
+
+      const recordings = await client.getTagRadio(tags, { count, popBegin, popEnd })
+      const resolved = await resolveTagRadioRecordings(recordings, mbClient, db)
+
+      const limit = getNormalizedLimit(request, 25)
+      return {
+        candidates: resolved.slice(0, limit).map((a) => ({
+          candidateType: 'artist' as const,
+          name: a.artistName,
+          mbid: a.artistMbid,
+          provenanceProvider: 'listenbrainz:tag-radio',
+          confidenceHint: a.score,
+          fallbackUsed: false,
+        })),
+      }
+    },
+  }
 }

--- a/src/core/discovery-modes/registry.ts
+++ b/src/core/discovery-modes/registry.ts
@@ -1,6 +1,10 @@
 import { createArtistRelationshipsMode } from './modes/artist-relationships'
 import { createLabelsMode } from './modes/labels'
-import { createListenBrainzMode, createListenBrainzRadioModes } from './modes/listenbrainz'
+import {
+  createListenBrainzMode,
+  createListenBrainzRadioModes,
+  createListenBrainzTagRadioMode,
+} from './modes/listenbrainz'
 import { createReleaseRadarMode } from './modes/release-radar'
 import { createSimilarArtistWebMode } from './modes/similar-artist-web'
 import type { DiscoveryModeDefinition } from './types'
@@ -31,6 +35,7 @@ export function registerDefaultDiscoveryModes(
   for (const mode of createListenBrainzRadioModes()) {
     registry.register(mode)
   }
+  registry.register(createListenBrainzTagRadioMode())
   registry.register(createReleaseRadarMode())
   registry.register(createArtistRelationshipsMode())
   registry.register(createSimilarArtistWebMode())

--- a/src/core/discovery-modes/types.ts
+++ b/src/core/discovery-modes/types.ts
@@ -1,6 +1,6 @@
 import type { DiscoveryModeRequest } from './request'
 
-export type DiscoveryFieldType = 'text' | 'number' | 'select' | 'multiselect' | 'toggle'
+export type DiscoveryFieldType = 'text' | 'number' | 'select' | 'multiselect' | 'toggle' | 'tags'
 
 export type DiscoveryConfigField = {
   key: string

--- a/src/core/subscriptions/adapters/listenbrainz.ts
+++ b/src/core/subscriptions/adapters/listenbrainz.ts
@@ -1,5 +1,7 @@
-import type { RadioMode } from '@/core/clients/listenbrainz'
+import type { RadioMode, TagRadioInput } from '@/core/clients/listenbrainz'
 import { createListenBrainzClient } from '@/core/clients/listenbrainz'
+import { createMusicBrainzClient } from '@/core/clients/musicbrainz'
+import { resolveTagRadioRecordings } from '@/core/clients/tag-radio-resolver'
 import { deduplicateByName } from '@/core/subscriptions/dedup'
 import type {
   AdapterConfigField,
@@ -19,6 +21,7 @@ const CONFIG_FIELDS: AdapterConfigField[] = [
       { value: 'artist-radio', label: 'Artist Radio' },
 
       { value: 'similar-users', label: 'Similar Users' },
+      { value: 'tag-radio', label: 'Tag Radio' },
     ],
     helpText: 'Which ListenBrainz feed to pull artists from.',
   },
@@ -84,6 +87,10 @@ export function createListenBrainzAdapter(deps: {
 
       if (feedType === 'similar-users') {
         return fetchSimilarUsers(deps, config)
+      }
+
+      if (feedType === 'tag-radio') {
+        return fetchTagRadio(deps, config)
       }
 
       return { artists: [] }
@@ -168,6 +175,49 @@ async function fetchSimilarUsers(
   }
 
   return { artists }
+}
+
+async function fetchTagRadio(
+  deps: { username: string; token: string },
+  config: Record<string, unknown>,
+): Promise<AdapterResult> {
+  const client = createListenBrainzClient(deps.username, deps.token)
+
+  const rawExpr = String(config.rawTagExpression ?? '').trim()
+  let tags: TagRadioInput[]
+  if (rawExpr) {
+    const pattern = /\(([^)]+)\):(\d+)/g
+    const results: TagRadioInput[] = []
+    for (const matchResult of rawExpr.matchAll(pattern)) {
+      results.push({ tag: String(matchResult[1]), weight: Number(matchResult[2]) })
+    }
+    tags = results.length > 0 ? results : [{ tag: rawExpr, weight: 1 }]
+  } else {
+    const tagsRaw = config.tags
+    type TagEntry = { tag?: unknown; weight?: unknown }
+    tags = Array.isArray(tagsRaw)
+      ? (tagsRaw as TagEntry[])
+          .filter((t) => String(t.tag ?? '').trim())
+          .map((t) => ({ tag: String(t.tag).trim(), weight: Number(t.weight) || 1 }))
+      : []
+  }
+
+  if (tags.length === 0) return { artists: [] }
+
+  const count = Number(config.count) || 25
+  const recordings = await client.getTagRadio(tags, { count })
+
+  const { db } = await import('@/db')
+  const mbClient = createMusicBrainzClient()
+  const resolved = await resolveTagRadioRecordings(recordings, mbClient, db)
+
+  return {
+    artists: resolved.map((a) => ({
+      name: a.artistName,
+      similarityScore: a.score,
+      source: 'listenbrainz:tag-radio',
+    })),
+  }
 }
 
 async function fetchWeeklyJams(username: string, token: string): Promise<AdapterResult> {

--- a/src/db/queries/recording-artist-cache.ts
+++ b/src/db/queries/recording-artist-cache.ts
@@ -1,0 +1,27 @@
+import { inArray } from 'drizzle-orm'
+import type { Database } from '@/db'
+import { recordingArtistCache } from '@/db/schema'
+
+export type CachedRecordingArtist = typeof recordingArtistCache.$inferSelect
+
+export async function getCachedRecordingArtists(
+  db: Database,
+  recordingMbids: string[],
+): Promise<CachedRecordingArtist[]> {
+  if (recordingMbids.length === 0) return []
+  return db
+    .select()
+    .from(recordingArtistCache)
+    .where(inArray(recordingArtistCache.recordingMbid, recordingMbids))
+}
+
+export async function insertCachedRecordingArtists(
+  db: Database,
+  entries: Array<{ recordingMbid: string; artistMbid: string; artistName: string }>,
+): Promise<void> {
+  if (entries.length === 0) return
+  await db
+    .insert(recordingArtistCache)
+    .values(entries)
+    .onConflictDoNothing({ target: recordingArtistCache.recordingMbid })
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -563,3 +563,10 @@ export const librarySyncState = pgTable(
     naturalKey: uniqueIndex('library_sync_state_natural_key_idx').on(table.userId, table.source),
   }),
 )
+
+export const recordingArtistCache = pgTable('recording_artist_cache', {
+  recordingMbid: uuid('recording_mbid').primaryKey(),
+  artistMbid: uuid('artist_mbid').notNull(),
+  artistName: text('artist_name').notNull(),
+  cachedAt: timestamp('cached_at', { withTimezone: true }).defaultNow().notNull(),
+})

--- a/src/web/components/discovery-mode-form.tsx
+++ b/src/web/components/discovery-mode-form.tsx
@@ -31,6 +31,7 @@ function serializeValue(field: DiscoveryConfigField, value: unknown): DiscoveryM
 function getDefaultValue(field: DiscoveryConfigField): boolean | string {
   if (field.type === 'toggle') return false
   if (field.type === 'select') return field.options?.[0]?.value ?? ''
+  if (field.type === 'tags') return JSON.stringify([{ tag: '', weight: 1 }])
   return ''
 }
 
@@ -49,6 +50,21 @@ function normalizeValue(field: DiscoveryConfigField, value: boolean | string): u
       .split(',')
       .map((item) => item.trim())
       .filter(Boolean)
+  }
+  if (field.type === 'tags') {
+    try {
+      const arr = JSON.parse(String(value))
+      if (Array.isArray(arr))
+        return arr.filter(
+          (r: unknown) =>
+            typeof r === 'object' &&
+            r !== null &&
+            'tag' in r &&
+            typeof (r as Record<string, unknown>).tag === 'string' &&
+            ((r as Record<string, unknown>).tag as string).trim(),
+        )
+    } catch {}
+    return []
   }
   return String(value).trim()
 }
@@ -93,6 +109,107 @@ function buildSubmission(
       fallbackPolicy: mode.availability.fallbackUsed ? 'allow-fallback' : 'strict',
     } satisfies DiscoveryModeSubscriptionConfig,
   }
+}
+
+function TagBuilderField({
+  value,
+  onChange,
+  inputId,
+  helpId,
+}: {
+  value: string
+  onChange: (val: string) => void
+  inputId: string
+  helpId?: string
+}) {
+  type TagRow = { id: number; tag: string; weight: number }
+
+  let counter = 0
+  function nextId() {
+    counter += 1
+    return counter
+  }
+
+  function parse(raw: string): TagRow[] {
+    try {
+      const arr = JSON.parse(raw)
+      if (Array.isArray(arr) && arr.length > 0)
+        return arr.map((r: { tag?: string; weight?: number }) => ({
+          id: nextId(),
+          tag: typeof r.tag === 'string' ? r.tag : '',
+          weight: typeof r.weight === 'number' ? r.weight : 1,
+        }))
+    } catch {}
+    return [{ id: nextId(), tag: '', weight: 1 }]
+  }
+
+  function serialize(rows: TagRow[]): string {
+    return JSON.stringify(rows.map(({ tag, weight }) => ({ tag, weight })))
+  }
+
+  const rows = parse(value)
+  const showWeights = rows.length > 1 || (rows.length === 1 && rows[0]?.weight !== 1)
+
+  function updateRow(id: number, updates: Partial<TagRow>) {
+    const next = rows.map((r) => (r.id === id ? { ...r, ...updates } : r))
+    onChange(serialize(next))
+  }
+
+  function addRow() {
+    if (rows.length >= 10) return
+    onChange(serialize([...rows, { id: nextId(), tag: '', weight: 1 }]))
+  }
+
+  function removeRow(id: number) {
+    if (rows.length <= 1) return
+    onChange(serialize(rows.filter((r) => r.id !== id)))
+  }
+
+  return (
+    <div id={inputId} aria-describedby={helpId} className="space-y-2">
+      {rows.map((row) => (
+        <div key={row.id} className="flex items-center gap-2">
+          <input
+            type="text"
+            value={row.tag}
+            placeholder="e.g. trip hop"
+            onChange={(e) => updateRow(row.id, { tag: e.target.value })}
+            className="flex-1 rounded-md border border-border bg-surface px-3 py-2 text-sm text-text placeholder:text-muted focus:border-accent focus:outline-none"
+          />
+          {showWeights && (
+            <input
+              type="number"
+              min={1}
+              max={10}
+              value={row.weight}
+              onChange={(e) =>
+                updateRow(row.id, {
+                  weight: Math.max(1, Math.min(10, Number(e.target.value) || 1)),
+                })
+              }
+              className="w-16 rounded-md border border-border bg-surface px-2 py-2 text-sm text-text focus:border-accent focus:outline-none"
+              title="Weight"
+            />
+          )}
+          {rows.length > 1 && (
+            <button
+              type="button"
+              onClick={() => removeRow(row.id)}
+              className="rounded-md px-2 py-2 text-sm text-muted hover:text-reject"
+              title="Remove tag"
+            >
+              x
+            </button>
+          )}
+        </div>
+      ))}
+      {rows.length < 10 && (
+        <button type="button" onClick={addRow} className="text-sm text-accent hover:underline">
+          + Add tag
+        </button>
+      )}
+    </div>
+  )
 }
 
 function DiscoveryModeFields({
@@ -149,6 +266,13 @@ function DiscoveryModeFields({
                   setValues((prev) => ({ ...prev, [field.key]: event.target.checked }))
                 }
                 className="h-4 w-4 rounded border-border"
+              />
+            ) : field.type === 'tags' ? (
+              <TagBuilderField
+                value={String(value)}
+                onChange={(val) => setValues((prev) => ({ ...prev, [field.key]: val }))}
+                inputId={inputId}
+                helpId={helpId}
               />
             ) : (
               <input

--- a/tests/core/clients/listenbrainz-tag-radio.test.ts
+++ b/tests/core/clients/listenbrainz-tag-radio.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createListenBrainzClient } from '@/core/clients/listenbrainz'
+
+const mockGet = vi.fn()
+
+vi.mock('@/core/clients/http', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/clients/http')>()
+  return {
+    ...actual,
+    createHttpClient: vi.fn(() => ({
+      get: mockGet,
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    })),
+  }
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getTagRadio(tags, options)', () => {
+  it('sends single tag without parens or weight', async () => {
+    mockGet.mockResolvedValueOnce([])
+    const client = createListenBrainzClient('testuser', 'my-token')
+    await client.getTagRadio([{ tag: 'jazz', weight: 1 }])
+    expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('tag=jazz'))
+    // No parens for single tag
+    expect(mockGet).not.toHaveBeenCalledWith(expect.stringContaining('(jazz)'))
+  })
+
+  it('assembles multi-tag expression with weights', async () => {
+    mockGet.mockResolvedValueOnce([])
+    const client = createListenBrainzClient('testuser', 'my-token')
+    await client.getTagRadio([
+      { tag: 'trip hop', weight: 2 },
+      { tag: 'ambient', weight: 1 },
+    ])
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringContaining('tag=%28trip+hop%29%3A2%3A%28ambient%29%3A1'),
+    )
+  })
+
+  it('passes count, pop_begin, pop_end as query params', async () => {
+    mockGet.mockResolvedValueOnce([])
+    const client = createListenBrainzClient('testuser', 'my-token')
+    await client.getTagRadio([{ tag: 'rock', weight: 1 }], { count: 10, popBegin: 20, popEnd: 80 })
+    const url = mockGet.mock.calls[0]?.[0] as string
+    expect(url).toContain('count=10')
+    expect(url).toContain('pop_begin=20')
+    expect(url).toContain('pop_end=80')
+  })
+
+  it('defaults count=25, pop_begin=0, pop_end=100', async () => {
+    mockGet.mockResolvedValueOnce([])
+    const client = createListenBrainzClient('testuser', 'my-token')
+    await client.getTagRadio([{ tag: 'rock', weight: 1 }])
+    const url = mockGet.mock.calls[0]?.[0] as string
+    expect(url).toContain('count=25')
+    expect(url).toContain('pop_begin=0')
+    expect(url).toContain('pop_end=100')
+  })
+
+  it('maps LB response to TagRadioRecording[]', async () => {
+    mockGet.mockResolvedValueOnce([
+      { recording_mbid: 'rec-1', percent: 100, source: 'artist', tag_count: 9 },
+      { recording_mbid: 'rec-2', percent: 45.5, source: 'release-group', tag_count: 3 },
+    ])
+    const client = createListenBrainzClient('testuser', 'my-token')
+    const result = await client.getTagRadio([{ tag: 'jazz', weight: 1 }])
+    expect(result).toEqual([
+      { recordingMbid: 'rec-1', percent: 100, source: 'artist', tagCount: 9 },
+      { recordingMbid: 'rec-2', percent: 45.5, source: 'release-group', tagCount: 3 },
+    ])
+  })
+
+  it('returns empty array for empty LB response', async () => {
+    mockGet.mockResolvedValueOnce([])
+    const client = createListenBrainzClient('testuser', 'my-token')
+    const result = await client.getTagRadio([{ tag: 'obscure', weight: 1 }])
+    expect(result).toEqual([])
+  })
+})

--- a/tests/core/clients/musicbrainz-lookup-recording.test.ts
+++ b/tests/core/clients/musicbrainz-lookup-recording.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMusicBrainzClient } from '@/core/clients/musicbrainz'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+vi.mock('p-queue', () => {
+  const mockAdd = vi.fn((fn: () => unknown) => fn())
+  const MockPQueue = vi.fn().mockImplementation(function (this: { add: typeof mockAdd }) {
+    this.add = mockAdd
+  })
+  return { default: MockPQueue }
+})
+
+function makeJsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('lookupRecording(mbid)', () => {
+  it('fetches /recording/{mbid} with artist-credits inc', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJsonResponse({
+        id: 'rec-mbid',
+        title: 'Wandering Star',
+        'artist-credit': [
+          {
+            artist: {
+              id: 'artist-mbid-1',
+              name: 'Portishead',
+            },
+          },
+        ],
+      }),
+    )
+
+    const client = createMusicBrainzClient()
+    const result = await client.lookupRecording('rec-mbid')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/recording/rec-mbid'),
+      expect.anything(),
+    )
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('inc=artist-credits'),
+      expect.anything(),
+    )
+    expect(result).toEqual({
+      recordingMbid: 'rec-mbid',
+      artistMbid: 'artist-mbid-1',
+      artistName: 'Portishead',
+    })
+  })
+
+  it('returns null on 404', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('Not Found', { status: 404 }))
+
+    const client = createMusicBrainzClient()
+    const result = await client.lookupRecording('missing-mbid')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when artist-credit array is empty', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJsonResponse({
+        id: 'rec-mbid',
+        title: 'Untitled',
+        'artist-credit': [],
+      }),
+    )
+
+    const client = createMusicBrainzClient()
+    const result = await client.lookupRecording('rec-mbid')
+    expect(result).toBeNull()
+  })
+
+  it('uses the first artist credit when multiple exist', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeJsonResponse({
+        id: 'rec-mbid',
+        title: 'Collab Track',
+        'artist-credit': [
+          { artist: { id: 'primary-mbid', name: 'Primary Artist' } },
+          { artist: { id: 'feat-mbid', name: 'Featured Artist' } },
+        ],
+      }),
+    )
+
+    const client = createMusicBrainzClient()
+    const result = await client.lookupRecording('rec-mbid')
+    expect(result).toEqual({
+      recordingMbid: 'rec-mbid',
+      artistMbid: 'primary-mbid',
+      artistName: 'Primary Artist',
+    })
+  })
+
+  it('throws on non-404 errors', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('Server Error', { status: 500 }))
+
+    const client = createMusicBrainzClient()
+    await expect(client.lookupRecording('bad-mbid')).rejects.toThrow(/500/)
+  })
+})

--- a/tests/core/clients/tag-radio-resolver.test.ts
+++ b/tests/core/clients/tag-radio-resolver.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('p-queue', () => {
+  const mockAdd = vi.fn((fn: () => unknown) => fn())
+  const MockPQueue = vi.fn().mockImplementation(function (this: { add: typeof mockAdd }) {
+    this.add = mockAdd
+  })
+  return { default: MockPQueue }
+})
+
+// Mock DB queries
+const mockGetCached = vi.fn()
+const mockInsertCached = vi.fn()
+
+vi.mock('@/db/queries/recording-artist-cache', () => ({
+  getCachedRecordingArtists: (...args: unknown[]) => mockGetCached(...args),
+  insertCachedRecordingArtists: (...args: unknown[]) => mockInsertCached(...args),
+}))
+
+import type { TagRadioRecording } from '@/core/clients/listenbrainz'
+import { resolveTagRadioRecordings } from '@/core/clients/tag-radio-resolver'
+
+const mockLookupRecording = vi.fn()
+const mockMbClient = { lookupRecording: mockLookupRecording } as any
+const mockDb = {} as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetCached.mockResolvedValue([])
+  mockInsertCached.mockResolvedValue(undefined)
+})
+
+describe('resolveTagRadioRecordings', () => {
+  it('resolves recordings to artists via MB lookups on cache miss', async () => {
+    const recordings: TagRadioRecording[] = [
+      { recordingMbid: 'rec-1', percent: 100, source: 'artist', tagCount: 5 },
+      { recordingMbid: 'rec-2', percent: 60, source: 'artist', tagCount: 3 },
+    ]
+
+    mockLookupRecording
+      .mockResolvedValueOnce({
+        recordingMbid: 'rec-1',
+        artistMbid: 'artist-A',
+        artistName: 'Artist A',
+      })
+      .mockResolvedValueOnce({
+        recordingMbid: 'rec-2',
+        artistMbid: 'artist-B',
+        artistName: 'Artist B',
+      })
+
+    const result = await resolveTagRadioRecordings(recordings, mockMbClient, mockDb)
+
+    expect(result).toEqual([
+      { artistMbid: 'artist-A', artistName: 'Artist A', score: 1.0 },
+      { artistMbid: 'artist-B', artistName: 'Artist B', score: 0.6 },
+    ])
+    expect(mockInsertCached).toHaveBeenCalledOnce()
+  })
+
+  it('uses cache hits and skips MB lookups for cached recordings', async () => {
+    mockGetCached.mockResolvedValue([
+      {
+        recordingMbid: 'rec-1',
+        artistMbid: 'artist-A',
+        artistName: 'Artist A',
+        cachedAt: new Date(),
+      },
+    ])
+
+    const recordings: TagRadioRecording[] = [
+      { recordingMbid: 'rec-1', percent: 80, source: 'artist', tagCount: 5 },
+      { recordingMbid: 'rec-2', percent: 50, source: 'artist', tagCount: 3 },
+    ]
+
+    mockLookupRecording.mockResolvedValueOnce({
+      recordingMbid: 'rec-2',
+      artistMbid: 'artist-B',
+      artistName: 'Artist B',
+    })
+
+    const result = await resolveTagRadioRecordings(recordings, mockMbClient, mockDb)
+
+    // Only 1 MB lookup (rec-2), rec-1 was cached
+    expect(mockLookupRecording).toHaveBeenCalledTimes(1)
+    expect(mockLookupRecording).toHaveBeenCalledWith('rec-2')
+    expect(result).toHaveLength(2)
+  })
+
+  it('groups multiple recordings by artist and takes max percent', async () => {
+    const recordings: TagRadioRecording[] = [
+      { recordingMbid: 'rec-1', percent: 40, source: 'artist', tagCount: 5 },
+      { recordingMbid: 'rec-2', percent: 90, source: 'artist', tagCount: 3 },
+      { recordingMbid: 'rec-3', percent: 70, source: 'artist', tagCount: 4 },
+    ]
+
+    // rec-1 and rec-2 both belong to Artist A, rec-3 belongs to Artist B
+    mockLookupRecording
+      .mockResolvedValueOnce({
+        recordingMbid: 'rec-1',
+        artistMbid: 'artist-A',
+        artistName: 'Artist A',
+      })
+      .mockResolvedValueOnce({
+        recordingMbid: 'rec-2',
+        artistMbid: 'artist-A',
+        artistName: 'Artist A',
+      })
+      .mockResolvedValueOnce({
+        recordingMbid: 'rec-3',
+        artistMbid: 'artist-B',
+        artistName: 'Artist B',
+      })
+
+    const result = await resolveTagRadioRecordings(recordings, mockMbClient, mockDb)
+
+    expect(result).toEqual([
+      { artistMbid: 'artist-A', artistName: 'Artist A', score: 0.9 }, // max(40, 90) / 100
+      { artistMbid: 'artist-B', artistName: 'Artist B', score: 0.7 },
+    ])
+  })
+
+  it('drops recordings that return null from MB (404)', async () => {
+    const recordings: TagRadioRecording[] = [
+      { recordingMbid: 'rec-1', percent: 100, source: 'artist', tagCount: 5 },
+      { recordingMbid: 'rec-gone', percent: 80, source: 'artist', tagCount: 3 },
+    ]
+
+    mockLookupRecording
+      .mockResolvedValueOnce({
+        recordingMbid: 'rec-1',
+        artistMbid: 'artist-A',
+        artistName: 'Artist A',
+      })
+      .mockResolvedValueOnce(null) // 404
+
+    const result = await resolveTagRadioRecordings(recordings, mockMbClient, mockDb)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.artistMbid).toBe('artist-A')
+  })
+
+  it('returns empty array for empty input', async () => {
+    const result = await resolveTagRadioRecordings([], mockMbClient, mockDb)
+    expect(result).toEqual([])
+  })
+
+  it('sorts results by score descending', async () => {
+    const recordings: TagRadioRecording[] = [
+      { recordingMbid: 'rec-1', percent: 30, source: 'artist', tagCount: 5 },
+      { recordingMbid: 'rec-2', percent: 90, source: 'artist', tagCount: 3 },
+      { recordingMbid: 'rec-3', percent: 60, source: 'artist', tagCount: 4 },
+    ]
+
+    mockLookupRecording
+      .mockResolvedValueOnce({ recordingMbid: 'rec-1', artistMbid: 'artist-A', artistName: 'A' })
+      .mockResolvedValueOnce({ recordingMbid: 'rec-2', artistMbid: 'artist-B', artistName: 'B' })
+      .mockResolvedValueOnce({ recordingMbid: 'rec-3', artistMbid: 'artist-C', artistName: 'C' })
+
+    const result = await resolveTagRadioRecordings(recordings, mockMbClient, mockDb)
+
+    expect(result[0]?.score).toBe(0.9)
+    expect(result[1]?.score).toBe(0.6)
+    expect(result[2]?.score).toBe(0.3)
+  })
+})

--- a/tests/core/clients/tag-radio-resolver.test.ts
+++ b/tests/core/clients/tag-radio-resolver.test.ts
@@ -1,14 +1,6 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('p-queue', () => {
-  const mockAdd = vi.fn((fn: () => unknown) => fn())
-  const MockPQueue = vi.fn().mockImplementation(function (this: { add: typeof mockAdd }) {
-    this.add = mockAdd
-  })
-  return { default: MockPQueue }
-})
-
 // Mock DB queries
 const mockGetCached = vi.fn()
 const mockInsertCached = vi.fn()

--- a/tests/core/discovery-modes/lb-tag-radio.test.ts
+++ b/tests/core/discovery-modes/lb-tag-radio.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the LB client
+const mockGetTagRadio = vi.fn()
+vi.mock('@/core/clients/listenbrainz', () => ({
+  createListenBrainzClient: vi.fn(() => ({
+    getTagRadio: mockGetTagRadio,
+  })),
+}))
+
+// Mock the resolver
+const mockResolve = vi.fn()
+vi.mock('@/core/clients/tag-radio-resolver', () => ({
+  resolveTagRadioRecordings: (...args: unknown[]) => mockResolve(...args),
+}))
+
+// Mock runtime helpers
+vi.mock('@/core/discovery-modes/modes/runtime', () => ({
+  getDiscoveryModeConnections: vi.fn().mockResolvedValue({
+    listenbrainzUsername: 'testuser',
+    listenbrainzToken: 'test-token',
+  }),
+  getNormalizedLimit: vi.fn((_req: unknown, fallback: number) => fallback),
+  normalizeDiscoveryName: vi.fn((name: string) => name.toLowerCase()),
+}))
+
+// Mock db and MB client
+vi.mock('@/db', () => ({ db: {} }))
+vi.mock('@/core/clients/musicbrainz', () => ({
+  createMusicBrainzClient: vi.fn(() => ({
+    lookupRecording: vi.fn(),
+  })),
+}))
+
+import { createListenBrainzTagRadioMode } from '@/core/discovery-modes/modes/listenbrainz'
+import type { DiscoveryModeRequest } from '@/core/discovery-modes/request'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function makeRequest(settings: Record<string, unknown>): DiscoveryModeRequest {
+  return {
+    modeId: 'lb-tag-radio',
+    userId: 1,
+    settingsMode: 'easy',
+    rawUserSettings: settings,
+    normalizedSettings: settings,
+    providerContext: { providerPath: ['listenbrainz'] },
+    fallbackPolicy: 'strict',
+    sources: [],
+  } as unknown as DiscoveryModeRequest
+}
+
+describe('lb-tag-radio discovery mode', () => {
+  it('calls getTagRadio with parsed tags and resolves to artist candidates', async () => {
+    mockGetTagRadio.mockResolvedValueOnce([
+      { recordingMbid: 'rec-1', percent: 100, source: 'artist', tagCount: 5 },
+    ])
+    mockResolve.mockResolvedValueOnce([
+      { artistMbid: 'artist-A', artistName: 'Artist A', score: 1.0 },
+    ])
+
+    const mode = createListenBrainzTagRadioMode()
+    const result = await mode.executor(
+      makeRequest({
+        tags: [{ tag: 'jazz', weight: 1 }],
+      }),
+    )
+
+    expect(mockGetTagRadio).toHaveBeenCalledWith([{ tag: 'jazz', weight: 1 }], {
+      count: 25,
+      popBegin: 0,
+      popEnd: 100,
+    })
+    expect(result.candidates).toEqual([
+      {
+        candidateType: 'artist',
+        name: 'Artist A',
+        mbid: 'artist-A',
+        provenanceProvider: 'listenbrainz:tag-radio',
+        confidenceHint: 1.0,
+        fallbackUsed: false,
+      },
+    ])
+  })
+
+  it('uses rawTagExpression when provided (overrides builder)', async () => {
+    mockGetTagRadio.mockResolvedValueOnce([])
+    mockResolve.mockResolvedValueOnce([])
+
+    const mode = createListenBrainzTagRadioMode()
+    await mode.executor(
+      makeRequest({
+        tags: [{ tag: 'jazz', weight: 1 }],
+        rawTagExpression: '(rock):3:(blues):1',
+      }),
+    )
+
+    // The raw expression should be parsed and sent
+    expect(mockGetTagRadio).toHaveBeenCalledWith(
+      [
+        { tag: 'rock', weight: 3 },
+        { tag: 'blues', weight: 1 },
+      ],
+      expect.any(Object),
+    )
+  })
+
+  it('passes count, popBegin, popEnd from advanced settings', async () => {
+    mockGetTagRadio.mockResolvedValueOnce([])
+    mockResolve.mockResolvedValueOnce([])
+
+    const mode = createListenBrainzTagRadioMode()
+    await mode.executor(
+      makeRequest({
+        tags: [{ tag: 'jazz', weight: 1 }],
+        count: 50,
+        popBegin: 20,
+        popEnd: 80,
+      }),
+    )
+
+    expect(mockGetTagRadio).toHaveBeenCalledWith(expect.any(Array), {
+      count: 50,
+      popBegin: 20,
+      popEnd: 80,
+    })
+  })
+
+  it('returns empty candidates when resolver returns empty', async () => {
+    mockGetTagRadio.mockResolvedValueOnce([])
+    mockResolve.mockResolvedValueOnce([])
+
+    const mode = createListenBrainzTagRadioMode()
+    const result = await mode.executor(
+      makeRequest({
+        tags: [{ tag: 'obscure', weight: 1 }],
+      }),
+    )
+
+    expect(result.candidates).toEqual([])
+  })
+
+  it('throws when no tags are provided', async () => {
+    const mode = createListenBrainzTagRadioMode()
+    await expect(mode.executor(makeRequest({ tags: [] }))).rejects.toThrow(/at least one tag/i)
+  })
+
+  it('has correct mode definition properties', () => {
+    const mode = createListenBrainzTagRadioMode()
+    expect(mode.id).toBe('lb-tag-radio')
+    expect(mode.label).toBe('Tag Radio')
+    expect(mode.availability).toBe('strict')
+    expect(mode.easyFields.some((f) => f.key === 'tags')).toBe(true)
+    expect(mode.advancedFields.some((f) => f.key === 'rawTagExpression')).toBe(true)
+    expect(mode.advancedFields.some((f) => f.key === 'count')).toBe(true)
+  })
+})

--- a/tests/core/discovery-modes/listenbrainz-radio.test.ts
+++ b/tests/core/discovery-modes/listenbrainz-radio.test.ts
@@ -26,6 +26,7 @@ const mockClient = {
   getSimilarArtists: vi.fn(),
   getListenCount: vi.fn(),
   getListeningActivity: vi.fn(),
+  getTagRadio: vi.fn(),
   testConnection: vi.fn(),
 }
 

--- a/tests/core/plugins/listenbrainz.test.ts
+++ b/tests/core/plugins/listenbrainz.test.ts
@@ -28,6 +28,7 @@ describe('createListenBrainzSource()', () => {
       getUserRadio: vi.fn().mockResolvedValue([]),
       getSimilarUsers: vi.fn().mockResolvedValue([]),
       getTopArtistsForUser: vi.fn().mockResolvedValue([]),
+      getTagRadio: vi.fn().mockResolvedValue([]),
     }
     vi.mocked(createListenBrainzClient).mockReturnValue(client)
     return client

--- a/tests/core/subscriptions/listenbrainz.test.ts
+++ b/tests/core/subscriptions/listenbrainz.test.ts
@@ -16,6 +16,7 @@ const mockClient = {
   getUserRadio: vi.fn(),
   getListenCount: vi.fn(),
   getListeningActivity: vi.fn(),
+  getTagRadio: vi.fn(),
   testConnection: vi.fn(),
 }
 


### PR DESCRIPTION
## Summary

- Add `lb-tag-radio` discovery mode that discovers artists by genre/style tags via ListenBrainz's tag radio endpoint
- Add `tag-radio` feed type to the ListenBrainz subscription adapter for recurring tag-based discovery
- Add `recording_artist_cache` table for persistent MusicBrainz recording-to-artist resolution
- Add `tags` field type to the discovery mode form with a tag builder UI (multi-row, per-tag weights)
- Extend both the ListenBrainz and MusicBrainz clients with `getTagRadio()` and `lookupRecording()` methods

## Architecture

LB's `/1/lb-radio/tags` returns bare recording MBIDs. A new `resolveTagRadioRecordings()` helper resolves those to artists via MusicBrainz lookups, backed by a `recording_artist_cache` Postgres table. Results are grouped by artist with max-percent scoring. Both the discovery mode and subscription adapter share this resolution layer.

## Test plan

- [ ] 23 new tests across 4 test files (LB client, MB client, resolver, discovery mode)
- [ ] Full test suite passes (1676 tests)
- [ ] Typecheck clean
- [ ] Lint clean
- [ ] Tag Radio appears in discovery mode dropdown
- [ ] Tag builder renders with add/remove rows and weight controls
- [ ] Tag Radio appears in ListenBrainz subscription feed type dropdown