### PR TITLE
fix: batch large library sync inserts

### DIFF
--- a/src/core/library/store.ts
+++ b/src/core/library/store.ts
@@ -11,6 +11,9 @@ import type { ReconciledAlbum } from './album-reconciler'
 import type { ReconciledArtist, ReconcilerOverride } from './reconciler'
 
 type Db = import('@/db').Database
+type ChunkInsertExecutor = Pick<Db, 'insert'>
+
+const SQLITE_MAX_HOST_PARAMETERS = 32_766
 
 export type LibrarySyncStateRow = {
   userId: number | null
@@ -143,6 +146,27 @@ export function emptyLibrarySyncCounts(): LibrarySyncCounts {
 }
 
 export function createLibrarySyncStore(database: Db): LibrarySyncStore {
+  async function insertRowsInChunks<TRow extends Record<string, unknown>>(
+    executor: ChunkInsertExecutor,
+    table: typeof libraryArtists | typeof libraryAlbums,
+    rows: TRow[],
+  ): Promise<void> {
+    if (rows.length === 0) return
+
+    let columnsPerRow = 1
+    for (const row of rows) {
+      columnsPerRow = Math.max(columnsPerRow, Object.keys(row).length)
+    }
+
+    // Keep bulk inserts under SQLite's host-parameter ceiling so the same
+    // sync path remains safe across supported and future database backends.
+    const chunkSize = Math.max(1, Math.floor(SQLITE_MAX_HOST_PARAMETERS / columnsPerRow))
+
+    for (let index = 0; index < rows.length; index += chunkSize) {
+      await executor.insert(table).values(rows.slice(index, index + chunkSize) as never)
+    }
+  }
+
   function makeUserClause(userId: number | null) {
     return userId === null ? isNull(libraryArtists.userId) : eq(libraryArtists.userId, userId)
   }
@@ -225,7 +249,9 @@ export function createLibrarySyncStore(database: Db): LibrarySyncStore {
         await tx.delete(libraryAlbums).where(and(albumUserClause, eq(libraryAlbums.source, source)))
 
         if (artists.length > 0) {
-          await tx.insert(libraryArtists).values(
+          await insertRowsInChunks(
+            tx,
+            libraryArtists,
             artists.map((a) => ({
               userId,
               source,
@@ -241,7 +267,9 @@ export function createLibrarySyncStore(database: Db): LibrarySyncStore {
         }
 
         if (albums.length > 0) {
-          await tx.insert(libraryAlbums).values(
+          await insertRowsInChunks(
+            tx,
+            libraryAlbums,
             albums.map((album) => ({
               userId,
               source,
@@ -272,7 +300,9 @@ export function createLibrarySyncStore(database: Db): LibrarySyncStore {
         await tx.delete(libraryArtists).where(and(userClause, eq(libraryArtists.source, source)))
 
         if (artists.length === 0) return
-        await tx.insert(libraryArtists).values(
+        await insertRowsInChunks(
+          tx,
+          libraryArtists,
           artists.map((a) => ({
             userId,
             source,
@@ -298,7 +328,9 @@ export function createLibrarySyncStore(database: Db): LibrarySyncStore {
 
         if (albums.length === 0) return
 
-        await tx.insert(libraryAlbums).values(
+        await insertRowsInChunks(
+          tx,
+          libraryAlbums,
           albums.map((album) => ({
             userId,
             source,

--- a/tests/core/library/store-chunking.test.ts
+++ b/tests/core/library/store-chunking.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest'
+import { createLibrarySyncStore } from '@/core/library/store'
+import { libraryAlbums, libraryArtists } from '@/db/schema'
+
+const SQLITE_MAX_HOST_PARAMETERS = 32_766
+const ARTIST_INSERT_COLUMNS = 9
+const ALBUM_INSERT_COLUMNS = 12
+
+type InsertCall = {
+  table: unknown
+  rows: unknown[]
+}
+
+type MockTx = {
+  delete: ReturnType<typeof vi.fn>
+  insert: ReturnType<typeof vi.fn>
+}
+
+function makeDb() {
+  const insertCalls: InsertCall[] = []
+  const where = vi.fn().mockResolvedValue(undefined)
+  const del = vi.fn().mockReturnValue({ where })
+  const insert = vi.fn((table: unknown) => ({
+    values: vi.fn(async (rows: unknown[]) => {
+      insertCalls.push({ table, rows })
+      return []
+    }),
+  }))
+  const tx: MockTx = { delete: del, insert }
+  const transaction = vi.fn(async (callback: (tx: MockTx) => Promise<unknown>) => callback(tx))
+
+  return {
+    transaction,
+    _mocks: {
+      del,
+      insert,
+      insertCalls,
+      where,
+    },
+  }
+}
+
+function makeArtist(index: number) {
+  return {
+    sourceArtistId: `artist-${index}`,
+    name: `Artist ${index}`,
+    nameNormalized: `artist ${index}`,
+    mbid: null,
+    matchMethod: null,
+    matchConfidence: null,
+    genres: [],
+    unreconciledReason: 'no_candidate' as const,
+  }
+}
+
+function makeAlbum(index: number) {
+  return {
+    sourceAlbumId: `album-${index}`,
+    sourceArtistId: `artist-${index}`,
+    title: `Album ${index}`,
+    titleNormalized: `album ${index}`,
+    albumMbid: null,
+    artistMbid: 'a74b1b7f-71a5-4011-9441-d0b5e4122711',
+    releaseYear: 2000,
+    primaryType: 'Album' as const,
+    matchMethod: null,
+    matchConfidence: null,
+  }
+}
+
+describe('LibrarySyncStore chunked inserts', () => {
+  it('splits oversized album writes into sqlite-safe chunks', async () => {
+    const db = makeDb()
+    const store = createLibrarySyncStore(db as never)
+    const albums = Array.from({ length: 3_000 }, (_, index) => makeAlbum(index))
+
+    await store.replaceLibraryAlbums(1, 'plex', albums)
+
+    const albumCalls = db._mocks.insertCalls.filter((call) => call.table === libraryAlbums)
+    expect(albumCalls.length).toBeGreaterThan(1)
+    expect(albumCalls.reduce((total, call) => total + call.rows.length, 0)).toBe(albums.length)
+    expect(
+      albumCalls.every(
+        (call) => call.rows.length * ALBUM_INSERT_COLUMNS <= SQLITE_MAX_HOST_PARAMETERS,
+      ),
+    ).toBe(true)
+  })
+
+  it('chunks artist and album snapshot writes independently inside one transaction', async () => {
+    const db = makeDb()
+    const store = createLibrarySyncStore(db as never)
+    const artists = Array.from({ length: 4_000 }, (_, index) => makeArtist(index))
+    const albums = Array.from({ length: 3_000 }, (_, index) => makeAlbum(index))
+
+    await store.replaceLibrarySnapshot(1, 'plex', artists, albums)
+
+    const artistCalls = db._mocks.insertCalls.filter((call) => call.table === libraryArtists)
+    const albumCalls = db._mocks.insertCalls.filter((call) => call.table === libraryAlbums)
+
+    expect(db.transaction).toHaveBeenCalledOnce()
+    expect(artistCalls.length).toBeGreaterThan(1)
+    expect(albumCalls.length).toBeGreaterThan(1)
+    expect(artistCalls.reduce((total, call) => total + call.rows.length, 0)).toBe(artists.length)
+    expect(albumCalls.reduce((total, call) => total + call.rows.length, 0)).toBe(albums.length)
+    expect(
+      artistCalls.every(
+        (call) => call.rows.length * ARTIST_INSERT_COLUMNS <= SQLITE_MAX_HOST_PARAMETERS,
+      ),
+    ).toBe(true)
+    expect(
+      albumCalls.every(
+        (call) => call.rows.length * ALBUM_INSERT_COLUMNS <= SQLITE_MAX_HOST_PARAMETERS,
+      ),
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- chunk library sync inserts for both artists and albums instead of sending one oversized statement
- size chunks against SQLite's host-parameter limit so the sync path stays portable across backends
- add a regression test that fails on the old single-statement behavior and verifies chunked writes

## Test Plan
- bun run lint
- bun run typecheck
- bun run test
- bun run test:api-routes
- bun run build
- bun run test:e2e
