### PR TITLE
chore: finish repo audit sweep and prep 0.26.7

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     needs: build
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
@@ -72,7 +72,7 @@ jobs:
     needs: api-route-test
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -43,7 +43,7 @@ body:
       placeholder: |
         - OS: Ubuntu 24.04
         - Browser: Firefox 126
-        - Digarr: 0.24.2
+        - Digarr: 0.26.7
         - Deploy: Docker Compose
     validations:
       required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     needs: build
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
@@ -85,7 +85,7 @@ jobs:
     needs: api-route-test
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable user-facing changes are documented here.
 
 ## Unreleased
 
+## v0.26.7 - 2026-04-14
+
+### Fixed
+
+- Legacy shared-token auth can no longer write user locale, password, or preference settings that are meant for session-authenticated users only
+- Docker, Helm, raw Kubernetes, CI, and issue-template defaults were audited and brought back in line with the current release surface
+
+### Changed
+
+- Top-level docs and roadmap docs were tightened to reduce duplicated release detail and point readers at the changelog for per-release history
+- Dev helper scripts were simplified and cleaned up for more predictable local setup and teardown behavior
+
 ## v0.26.6 - 2026-04-14
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,6 @@ bun run dev          # backend on :3000
 bun run dev:web      # frontend on :5173 (proxies /api to :3000)
 ```
 
----
-
 ## Code style
 
 Digarr uses [Biome](https://biomejs.dev/) for linting and formatting.
@@ -54,9 +52,7 @@ bun run lint        # check
 bun run lint:fix    # auto-fix
 ```
 
-TypeScript strict mode is enforced. No `any` -- use `unknown`, generics, or proper types.
-
----
+TypeScript strict mode is enforced. No `any`; use `unknown`, generics, or proper types.
 
 ## Testing
 
@@ -75,8 +71,6 @@ Tests live in `tests/`. Keep them close to the code they cover. E2E coverage liv
 
 For route, workflow, or UI changes, run `bun run test:e2e` before opening a PR. CI also runs the smoke and browser suites, but the expectation is that branch diffs affecting those paths get a local pass first.
 
----
-
 ## Submitting a PR
 
 1. Create a branch from `main`: `git checkout -b feat/my-thing`
@@ -85,8 +79,6 @@ For route, workflow, or UI changes, run `bun run test:e2e` before opening a PR. 
 4. Run `bun run test:e2e` if your change affects routes, workflows, or UI behavior
 5. Open a PR against `main` and fill in the template
 6. A maintainer will review; be ready to iterate
-
----
 
 ## Commit style
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Tests](https://img.shields.io/badge/tests-vitest%20%2B%20playwright-brightgreen)](https://github.com/iuliandita/digarr/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/tag/iuliandita/digarr?label=release)](https://github.com/iuliandita/digarr/releases)
 
-**Music discovery for your *arr stack.** Connect your listening sources, pick an AI provider, and Digarr turns that into a taste profile, a recommendation pipeline, and a queue you can actually work through. You can approve artists into Lidarr or playlist targets, run mood searches in plain English, launch targeted discovery modes, import Spotify Liked Songs to get started faster, schedule recurring discovery, generate playlists, browse your library by genre, and switch the UI and AI-assisted discovery output across 15 shipped languages. It is self-hosted, so the data stays with you.
+**Music discovery for your *arr stack.** Connect your listening sources, pick an AI provider, and Digarr builds a taste profile, runs a recommendation pipeline, and gives you a queue you can actually review. Approve artists into Lidarr or playlist targets, run mood searches in plain English, launch focused discovery modes, import Spotify Liked Songs to get started faster, schedule recurring discovery, generate playlists, browse by genre, and use the UI and AI-assisted discovery output across 15 shipped languages. It is self-hosted, so the data stays with you.
 
 > [!WARNING]
 > **Beta software, working toward v1.0.** You can use it today, but expect rough edges. Releases can land quickly, sometimes several in a day, so check the [releases page](https://github.com/iuliandita/digarr/releases) and [CHANGELOG.md](CHANGELOG.md) before updating. If you run into something broken, [open an issue](https://github.com/iuliandita/digarr/issues) or send over a feature idea.
@@ -23,12 +23,8 @@
 
 [More screenshots](docs/SCREENSHOTS.md)
 
----
-
 > [!NOTE]
 > **Built with AI.** A human sets the roadmap, designs the architecture, and reviews the output; most code and tests are AI-generated.
-
----
 
 ## What Makes Digarr Different
 
@@ -69,8 +65,6 @@ In addition to approval-driven queueing, Digarr now runs a background `slskd` wo
 ### Cross-Platform Search
 Search across Spotify, Deezer, MusicBrainz, TIDAL, and Bandcamp in one pass. Digarr merges the results, deduplicates them, and lets you launch Quick Discover from any match.
 
----
-
 ## Features
 
 - **8 data sources:** ListenBrainz, Last.fm, Spotify (OAuth), Deezer (OAuth), Plex, Jellyfin, Emby, and Discogs
@@ -109,8 +103,6 @@ Connect external services to unlock discovery feeds, library sync, playlist expo
 | Emby | - | - | Artists, Albums | Yes | - |
 | AI Provider | Mood Discover | - | - | - | - |
 
----
-
 ## Quick Start
 
 ```sh
@@ -128,8 +120,6 @@ For zero-touch boot, set `DIGARR_INITIAL_USERNAME`, `DIGARR_INITIAL_PASSWORD`, `
 
 For local development, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
----
-
 ## How It Works
 
 Digarr runs a 7-stage recommendation pipeline:
@@ -144,8 +134,6 @@ Digarr runs a 7-stage recommendation pipeline:
 
 You can run the pipeline on a schedule, by hand, through subscriptions for targeted discovery, or from Discover -> Discovery Modes for focused manual runs on `/discover/modes`.
 
----
-
 ## Requirements
 
 | Service | Required | Purpose |
@@ -155,13 +143,9 @@ You can run the pipeline on a schedule, by hand, through subscriptions for targe
 | **AI Provider** | Yes | Anthropic, OpenAI, Gemini, Ollama, or any compatible endpoint |
 | **PostgreSQL** | Yes | Data storage (included in Docker Compose) |
 
----
-
 ## Configuration
 
 Most day-to-day configuration lives in the web UI after initial setup. That includes connections, scoring weights, schedules, preferences, and the saved interface language. If you connect Spotify, Settings > Connections includes a one-click `Import Liked Songs` action to seed recommendations for a faster first scan. Settings also includes dedicated `Job History` and `System Health` tabs for operational visibility, while Library Health now keeps the latest scan snapshot, shows when it last synced, auto-rescans on the configured library-sync interval, and still exposes a manual `Sync Now` action. Env-var auto-setup needs initial admin credentials plus an AI provider and model. Listening sources, Lidarr, and Emby can be added later in the UI or supplied during setup. `slskd` targets are added later in Settings > Targets and can be linked to a specific Lidarr target there so a single approval can add the artist to Lidarr first and then queue the matched Soulseek release. See [`.env.example`](.env.example) for local development fallbacks and [`deploy/docker/.env.example`](deploy/docker/.env.example) for Compose deployments.
-
----
 
 ## Backup & Restore
 
@@ -186,8 +170,6 @@ Admin tools available under Settings > Administration > Data Hygiene:
 - **AI Reasoning Audit:** detect and fix AI hallucinations
 - **Purge Sessions:** clean out expired login sessions
 
----
-
 ## Deployment
 
 | Method | Path | Notes |
@@ -198,8 +180,6 @@ Admin tools available under Settings > Administration > Data Hygiene:
 | Unraid | [`deploy/unraid/`](deploy/unraid/) | Community Applications template. Requires external PostgreSQL. |
 | Synology NAS | [`docs/guides/synology.md`](docs/guides/synology.md) | DSM 7.1+ (Docker/Container Manager). SSH or GUI. |
 | Docker Desktop | [`docs/guides/docker-desktop.md`](docs/guides/docker-desktop.md) | macOS and Windows (WSL 2). |
-
----
 
 ## Friends
 
@@ -216,19 +196,13 @@ Other self-hosted music discovery projects:
 | [Explo](https://github.com/LumePart/Explo) | Discover Weekly for self-hosted. ListenBrainz recs to your media server. |
 | [MusicMoveArr Datasets](https://github.com/MusicMoveArr/Datasets) | MB/Spotify/Deezer/Tidal datasets used by Digarr for genre enrichment. |
 
----
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
----
-
 ## License
 
 MIT. See [LICENSE](LICENSE).
-
----
 
 ## Star History
 

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -5,11 +5,11 @@
 
 services:
   app:
-    image: docker.io/iuliandita/digarr:0.24
+    image: docker.io/iuliandita/digarr:0.26
     # Pin to a patch version for full stability:
-    # image: docker.io/iuliandita/digarr:0.24.2
+    # image: docker.io/iuliandita/digarr:0.26.7
     # Alpine variant (smaller image, musl libc):
-    # image: docker.io/iuliandita/digarr:0.24.2-alpine
+    # image: docker.io/iuliandita/digarr:0.26.7-alpine
     env_file:
       - path: .env
         required: false
@@ -32,6 +32,8 @@ services:
       start_period: 15s
       retries: 3
     read_only: true
+    volumes:
+      - backups:/app/backups
     tmpfs:
       - /tmp
     security_opt:
@@ -90,3 +92,4 @@ services:
 
 volumes:
   pgdata:
+  backups:

--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.24.2
-appVersion: "0.24.2"
+version: 0.26.7
+appVersion: "0.26.7"

--- a/deploy/helm/digarr/templates/_helpers.tpl
+++ b/deploy/helm/digarr/templates/_helpers.tpl
@@ -69,3 +69,14 @@ PostgreSQL hostname -- bundled service or external host.
 {{- .Values.database.host }}
 {{- end }}
 {{- end }}
+
+{{/*
+App image reference -- prefer digest when provided.
+*/}}
+{{- define "digarr.image" -}}
+{{- if .Values.image.digest }}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest }}
+{{- else }}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/digarr/templates/deployment.yaml
+++ b/deploy/helm/digarr/templates/deployment.yaml
@@ -14,18 +14,15 @@ spec:
       labels:
         {{- include "digarr.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: false
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ include "digarr.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: 3000
@@ -39,22 +36,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "digarr.databaseSecretName" . }}
                   key: DATABASE_URL
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 3
-            failureThreshold: 3
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/deploy/helm/digarr/templates/networkpolicy.yaml
+++ b/deploy/helm/digarr/templates/networkpolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "digarr.fullname" . }}
+  labels:
+    {{- include "digarr.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "digarr.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
+{{- end }}

--- a/deploy/helm/digarr/templates/postgresql.yaml
+++ b/deploy/helm/digarr/templates/postgresql.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "digarr.labels" . | nindent 4 }}
     app.kubernetes.io/component: database
 spec:
-  type: ClusterIP
+  clusterIP: None
   ports:
     - port: 5432
       targetPort: postgresql
@@ -38,11 +38,15 @@ spec:
         {{- include "digarr.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: database
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: postgresql
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
           securityContext:
             runAsNonRoot: true
             runAsUser: 999
@@ -68,16 +72,22 @@ spec:
             - name: data
               mountPath: /var/lib/postgresql/data
           {{- end }}
-          livenessProbe:
+          startupProbe:
             exec:
               command: ["pg_isready", "-U", {{ .Values.postgresql.auth.username | quote }}]
+            failureThreshold: 30
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            tcpSocket:
+              port: postgresql
             initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 5
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", {{ .Values.postgresql.auth.username | quote }}]
-            initialDelaySeconds: 5
+            initialDelaySeconds: 3
             periodSeconds: 10
             timeoutSeconds: 3
           resources:

--- a/deploy/helm/digarr/values.schema.json
+++ b/deploy/helm/digarr/values.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string", "minLength": 1 },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      },
+      "required": ["repository", "tag", "pullPolicy"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "minLength": 1 },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      },
+      "required": ["type", "port"]
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      },
+      "required": ["enabled"]
+    },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "username": { "type": "string", "minLength": 1 },
+            "password": { "type": "string" },
+            "database": { "type": "string", "minLength": 1 }
+          },
+          "required": ["username", "database"]
+        }
+      },
+      "required": ["enabled", "auth"]
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "host": { "type": "string" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "name": { "type": "string", "minLength": 1 },
+        "user": { "type": "string", "minLength": 1 },
+        "password": { "type": "string" },
+        "existingSecret": { "type": "string" }
+      },
+      "required": ["port", "name", "user", "password", "existingSecret"]
+    }
+  },
+  "required": ["image", "service", "networkPolicy", "postgresql", "database"],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "postgresql": {
+            "properties": {
+              "enabled": { "const": false }
+            },
+            "required": ["enabled"]
+          }
+        }
+      },
+      "then": {
+        "anyOf": [
+          {
+            "properties": {
+              "database": {
+                "properties": {
+                  "existingSecret": { "minLength": 1 }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "database": {
+                "properties": {
+                  "host": { "minLength": 1 },
+                  "password": { "minLength": 1 }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,12 +2,34 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.24.2"
-  pullPolicy: IfNotPresent
+  tag: "0.26.7"
+  # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
+  pullPolicy: Always
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 service:
   type: ClusterIP
   port: 3000
+
+networkPolicy:
+  enabled: true
 
 ingress:
   enabled: false
@@ -27,17 +49,40 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+    ephemeral-storage: 256Mi
   limits:
     cpu: 500m
     memory: 512Mi
-
-securityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
+    ephemeral-storage: 1Gi
 
 env:
   PORT: "3000"
   LOG_LEVEL: info
+
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 30
+  periodSeconds: 5
+  timeoutSeconds: 3
+
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
 
 # ---------------------------------------------------------------------------
 # Database
@@ -58,6 +103,7 @@ postgresql:
   image:
     repository: postgres
     tag: "17-alpine"
+    pullPolicy: Always
   auth:
     username: digarr
     # password: ""  # REQUIRED -- helm install will fail without this
@@ -70,9 +116,11 @@ postgresql:
     requests:
       cpu: 50m
       memory: 64Mi
+      ephemeral-storage: 256Mi
     limits:
       cpu: 250m
       memory: 256Mi
+      ephemeral-storage: 1Gi
 
 # External database -- used when postgresql.enabled is false
 database:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -21,19 +21,28 @@ spec:
       labels:
         app: digarr
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: digarr
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
-          image: ghcr.io/iuliandita/digarr:0.24.2
-          imagePullPolicy: IfNotPresent
+          # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
+          image: ghcr.io/iuliandita/digarr:0.26.7
+          imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 3000
@@ -49,9 +58,15 @@ spec:
                 secretKeyRef:
                   name: digarr-db # name of your Secret
                   key: DATABASE_URL
-          livenessProbe:
+          startupProbe:
             httpGet:
               path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            tcpSocket:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 30
@@ -61,7 +76,7 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 5
+            initialDelaySeconds: 3
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
@@ -74,9 +89,11 @@ spec:
             requests:
               cpu: 100m
               memory: 128Mi
+              ephemeral-storage: 256Mi
             limits:
               cpu: 500m
               memory: 512Mi
+              ephemeral-storage: 1Gi
       volumes:
         - name: tmp
           emptyDir: {}

--- a/deploy/k8s/networkpolicy.yaml
+++ b/deploy/k8s/networkpolicy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: digarr
+  namespace: digarr
+  labels:
+    app: digarr
+spec:
+  podSelector:
+    matchLabels:
+      app: digarr
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-   <Repository>docker.io/iuliandita/digarr:0.24.2</Repository>
-   <Tag>0.24.2</Tag>
-   <TagDescription>v0.24.2 stable release</TagDescription>
-  </Branch>
+   <Repository>docker.io/iuliandita/digarr:0.26.7</Repository>
+   <Tag>0.26.7</Tag>
+   <TagDescription>v0.26.7 stable release</TagDescription>
   <Network>bridge</Network>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,7 +21,7 @@ Admin-only endpoints return 403 for non-admin users.
 | PATCH | `/api/auth/me/locale` | Yes | Update the saved user locale. Session auth only. |
 | POST | `/api/auth/change-password` | Yes | Change password. Invalidates all sessions. Rate limited: 5/min |
 | GET | `/api/auth/me/preferences` | Yes | Get merged user preferences |
-| PATCH | `/api/auth/me/preferences` | Yes | Update user preferences (partial merge) |
+| PATCH | `/api/auth/me/preferences` | Yes | Update user preferences (partial merge). Session auth only. |
 
 **PATCH /api/auth/me/locale** body:
 ```json
@@ -32,6 +32,8 @@ Notes:
 - `preferredLocale` may be a supported locale string or `null`
 - Supported locales: `en`, `es`, `fr`, `de`, `pt-BR`, `it`, `nl`, `ro`, `pl`, `tr`, `uk`, `ru`, `ja`, `ko`, `zh-CN`
 - Legacy token auth is rejected with `403`; this route requires a session-authenticated user
+- `POST /api/auth/change-password` also rejects legacy token auth with `403`; password changes require a session-authenticated user
+- `PATCH /api/auth/me/preferences` also rejects legacy token auth with `403`; preference writes require a session-authenticated user
 - `GET /api/auth/status` returns `required: true` as soon as setup is complete, even if no users exist yet, so the frontend can force registration/login instead of treating the app as public
 
 ### OIDC / OAuth

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Updated: 2026-04-14 | Current: v0.26.6
+> Updated: 2026-04-14 | Current: v0.26.7
 >
 > Priorities change with feedback. This is current intent, not a promise.
 
@@ -36,8 +36,6 @@ Committed direction, roughly in priority order.
 
 ### Discovery
 
-- ~~Deezer favorites import~~ shipped in v0.22.0 (OAuth connect + favorites, followed, Flow, playlists)
-- ~~Deeper ListenBrainz integration (radio, similar-users coverage)~~ shipped in v0.23.0; ~~tag radio~~ shipped in v0.24.0 (with recording-artist cache for MB resolution)
 - Label-catalog discovery mode implementation
 - Artist-relationship discovery mode implementation
 
@@ -49,7 +47,7 @@ Committed direction, roughly in priority order.
 
 ## Exploring
 
-Ideas we're considering. Feedback welcome -- open an issue or discussion if any of these matter to you.
+Ideas we're considering. If any of these matter to you, open an issue or discussion.
 
 ### Discovery
 
@@ -77,6 +75,7 @@ Good ideas with no timeline yet.
 - Taste DNA / shareable profile
 - Audition playlists ("try before you add")
 - Interactive API docs (Swagger/Scalar UI)
+
 ## Experiments
 
 Low confidence. Would build only with real demand.
@@ -94,51 +93,16 @@ Low confidence. Would build only with real demand.
 - Native desktop client (Linux/Mac/Windows) -- PWA install already covers most of this
 - Native mobile apps (Android/iOS) -- PWA is already installable; native value is mostly reliable push notifications
 
-## Recently Shipped
+## Shipped Highlights
 
-### v0.24.0 -- v0.24.2
+For release-by-release detail, see [CHANGELOG.md](../CHANGELOG.md).
+Release reminder: after publishing a new app image, update the pinned digests in `deploy/k8s/deployment.yaml` and `deploy/helm/digarr/values.yaml`.
 
-- Tag Radio discovery mode via ListenBrainz radio (multiple tags, per-tag weights, raw LB syntax, popularity filtering)
-- Tag Radio subscription feed for recurring tag-based discovery
-- Recording-artist cache for MusicBrainz recording-to-artist lookups
-- Full i18n coverage: all remaining hardcoded English strings translated across 15 locales
-
-### v0.26.0
-
-- Discovery Modes moved to a dedicated page under the Discover menu so the main Discover view stays focused on recommendation review
-
-### v0.26.1
-
-- Shipped ListenBrainz radio modes now show as available, while placeholder modes stay blocked with explicit reasons
-- Manual discovery-mode runs now preflight Artist Radio seeds, return a `jobId` immediately, and surface quick failures instead of silently stalling behind a success toast
-
-### v0.26.2
-
-- Setup completion now hands cleanly into required registration or login instead of leaving a zero-user auth gap
-- Settings no longer report missing secrets as saved integrations, now show Deezer and Emby icons, and the docs/CI checks were tightened to match the current multilingual surface
-
-### v0.26.3
-
-### v0.26.4 -- v0.26.6
-
-- Finished the remaining localization sweep, tightened translation quality checks, and kept the shipped locale set aligned across the app
-- Large library syncs now batch database inserts to stay under backend parameter limits
-- Backup restore now repairs serial sequences after replaying explicit ids, and user identity fields now enforce unique non-null email and OIDC subject values
-- Linked `slskd` background sync now handles Lidarr's paginated wanted-release responses without crashing on each tick
-
-- Library Health now persists scan snapshots, shows last sync timing, auto-rescans on the configured interval, and keeps a manual sync action
-- Settings now gives Job History and System Health dedicated tabs, expands target controls to match the newer admin style, and removes the oversized dashboard health block
-- Fresh databases now skip pre-migration auto-backups until the app tables exist, avoiding noisy first-boot warnings
-
-### v0.26.4
-
-- Shared forms, dialogs, admin surfaces, and server-side validation errors now respect the selected locale instead of falling back to hardcoded English
-- Locale catalogs now pass stricter quality checks for untranslated English fallbacks and restored native accents or diacritics where they belong
-
-### v0.26.5
-
-- Large library syncs now batch artist and album inserts instead of sending one oversized statement that can exceed database parameter limits
-- The batch sizing targets SQLite-safe parameter ceilings so the same sync path stays portable across database backends
+- Discovery modes now live on their own page, ship ListenBrainz radio coverage plus Release Radar and Similar Artist Web, and can be saved as subscriptions
+- Multilingual support is fully shipped across 15 locales, including locale-aware AI output and stricter translation-quality checks
+- Library operations now cover Lidarr, Plex, Jellyfin, Emby, and `slskd`, with artist and album sync, reconciliation review, persistent Library Health snapshots, and better sync visibility
+- Operations and safety now include backup/restore, pre-flight migration checks, auto-backups, job history, stuck-task detection, and browser-test release gates
+- Recent integration work added Deezer OAuth feeds, Emby support, linked `slskd` targets, and broader playlist export coverage
 
 ### v0.25.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.26.6",
+  "version": "0.26.7",
   "type": "module",
   "private": true,
   "scripts": {

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONTAINER_NAME="digarr-pg"
-DB_USER="digarr"
-DB_PASS="digarr"
-DB_NAME="digarr"
-DB_PORT="5432"
-DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@localhost:${DB_PORT}/${DB_NAME}"
+readonly CONTAINER_NAME="digarr-pg"
+readonly DB_USER="digarr"
+readonly DB_PASS="digarr"
+readonly DB_NAME="digarr"
+readonly DB_PORT="5432"
+readonly DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@localhost:${DB_PORT}/${DB_NAME}"
 
-red()   { printf '\033[0;31m%s\033[0m\n' "$*"; }
+red() { printf '\033[0;31m%s\033[0m\n' "$*"; }
 green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
-blue()  { printf '\033[0;34m%s\033[0m\n' "$*"; }
+blue() { printf '\033[0;34m%s\033[0m\n' "$*"; }
 
-cd "$(git rev-parse --show-toplevel)"
+ensure_postgres_container() {
+  if docker inspect "$CONTAINER_NAME" &>/dev/null; then
+    if [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" == "true" ]]; then
+      green "postgres already running ($CONTAINER_NAME)"
+      return
+    fi
 
-# -- postgres ----------------------------------------------------------------
-
-if docker inspect "$CONTAINER_NAME" &>/dev/null; then
-  if [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" = "true" ]; then
-    green "postgres already running ($CONTAINER_NAME)"
-  else
     blue "starting existing postgres container..."
     docker start "$CONTAINER_NAME"
+    return
   fi
-else
+
   blue "creating postgres container..."
   docker run -d --name "$CONTAINER_NAME" \
     -e POSTGRES_USER="$DB_USER" \
@@ -31,50 +31,66 @@ else
     -e POSTGRES_DB="$DB_NAME" \
     -p "${DB_PORT}:5432" \
     postgres:17-alpine
-fi
+}
 
-blue "waiting for postgres to accept connections..."
-for i in $(seq 1 30); do
-  if pg_isready -h localhost -p "$DB_PORT" -U "$DB_USER" &>/dev/null; then
-    green "postgres ready"
-    break
+wait_for_postgres() {
+  blue "waiting for postgres to accept connections..."
+
+  for attempt in {1..30}; do
+    if pg_isready -h localhost -p "$DB_PORT" -U "$DB_USER" &>/dev/null; then
+      green "postgres ready"
+      return
+    fi
+
+    if [[ "$attempt" -eq 30 ]]; then
+      red "postgres did not start in time"
+      exit 1
+    fi
+
+    sleep 1
+  done
+}
+
+ensure_env_file() {
+  if [[ ! -f .env ]]; then
+    blue "creating .env from .env.example..."
+    cp .env.example .env
+    return
   fi
-  if [ "$i" -eq 30 ]; then
-    red "postgres did not start in time"
-    exit 1
-  fi
-  sleep 1
-done
 
-# -- .env --------------------------------------------------------------------
-
-if [ ! -f .env ]; then
-  blue "creating .env from .env.example..."
-  cp .env.example .env
-else
   green ".env already exists"
-fi
+}
 
-# -- deps --------------------------------------------------------------------
+ensure_dependencies() {
+  if [[ ! -d node_modules ]]; then
+    blue "installing dependencies..."
+    bun install
+    return
+  fi
 
-if [ ! -d node_modules ]; then
-  blue "installing dependencies..."
-  bun install
-else
   green "node_modules exists (run 'bun install' manually if stale)"
-fi
+}
 
-# -- migrations --------------------------------------------------------------
+print_next_steps() {
+  printf '\nstart the dev servers in two terminals:\n\n'
+  printf '  terminal 1 (backend):  bun run dev\n'
+  printf '  terminal 2 (frontend): bun run dev:web\n\n'
+  printf 'then open http://localhost:5173\n\n'
+}
 
-blue "running database migrations..."
-DATABASE_URL="$DATABASE_URL" bun run db:migrate
+main() {
+  cd "$(git rev-parse --show-toplevel)"
 
-green "setup complete"
-echo ""
-echo "start the dev servers in two terminals:"
-echo ""
-echo "  terminal 1 (backend):  bun run dev"
-echo "  terminal 2 (frontend): bun run dev:web"
-echo ""
-echo "then open http://localhost:5173"
-echo ""
+  ensure_postgres_container
+  wait_for_postgres
+  ensure_env_file
+  ensure_dependencies
+
+  blue "running database migrations..."
+  DATABASE_URL="$DATABASE_URL" bun run db:migrate
+
+  green "setup complete"
+  print_next_steps
+}
+
+main "$@"

--- a/scripts/dev-teardown.sh
+++ b/scripts/dev-teardown.sh
@@ -1,20 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONTAINER_NAME="digarr-pg"
+readonly CONTAINER_NAME="digarr-pg"
 
-red()   { printf '\033[0;31m%s\033[0m\n' "$*"; }
 green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
 
-if docker inspect "$CONTAINER_NAME" &>/dev/null; then
-  echo "stopping and removing $CONTAINER_NAME..."
-  docker rm -f "$CONTAINER_NAME"
-  green "postgres container removed"
-else
-  green "no container to remove"
-fi
+main() {
+  if docker inspect "$CONTAINER_NAME" &>/dev/null; then
+    printf 'stopping and removing %s...\n' "$CONTAINER_NAME"
+    docker rm -f "$CONTAINER_NAME"
+    green "postgres container removed"
+  else
+    green "no container to remove"
+  fi
 
-echo ""
-echo "data was in a docker volume. to also wipe the data:"
-echo "  docker volume rm \$(docker volume ls -q | grep digarr)"
-echo ""
+  printf '\ndata was in a docker volume. to also wipe the data:\n'
+  printf "  docker volume rm \$(docker volume ls -q | grep digarr)\n\n"
+}
+
+main "$@"

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -49,6 +49,20 @@ export function authRoutes(deps: AppDependencies) {
       }),
     )
 
+  function requireSessionUser(c: Context<HonoEnv>) {
+    const userId = c.get('userId')
+    if (!userId) {
+      return { ok: false as const, response: c.json({ error: 'Not authenticated' }, 401) }
+    }
+    if (c.get('legacyTokenAuth')) {
+      return {
+        ok: false as const,
+        response: c.json({ error: 'Session authentication required' }, 403),
+      }
+    }
+    return { ok: true as const, userId }
+  }
+
   // Register a new user. First user becomes admin.
   router.post('/api/auth/register', async (c) => {
     const messages = getRequestMessages(c)
@@ -146,11 +160,8 @@ export function authRoutes(deps: AppDependencies) {
   })
 
   router.patch('/api/auth/me/locale', async (c) => {
-    const userId = c.get('userId')
-    if (!userId) return c.json({ error: 'Not authenticated' }, 401)
-    if (c.get('legacyTokenAuth')) {
-      return c.json({ error: 'Session authentication required' }, 403)
-    }
+    const auth = requireSessionUser(c)
+    if (!auth.ok) return auth.response
 
     const body = await c.req.json()
     if (!body || typeof body !== 'object' || Array.isArray(body)) {
@@ -162,7 +173,7 @@ export function authRoutes(deps: AppDependencies) {
       return c.json({ error: 'preferredLocale must be a string or null' }, 400)
     }
 
-    const user = await deps.getUserById(userId)
+    const user = await deps.getUserById(auth.userId)
     if (!user) return c.json({ error: 'User not found' }, 404)
 
     const preferredLocale = rawPreferredLocale === null ? null : normalizeLocale(rawPreferredLocale)
@@ -171,16 +182,14 @@ export function authRoutes(deps: AppDependencies) {
       return c.json({ error: 'Unsupported locale' }, 400)
     }
 
-    await deps.updateUserPreferredLocale(userId, preferredLocale)
+    await deps.updateUserPreferredLocale(auth.userId, preferredLocale)
     return c.json({ success: true, preferredLocale })
   })
 
   // Change password for the current session user (requires session auth, not legacy token)
   router.post('/api/auth/change-password', async (c) => {
-    const userId = c.get('userId')
-    if (!userId) {
-      return c.json({ error: 'Password change requires a user account' }, 403)
-    }
+    const auth = requireSessionUser(c)
+    if (!auth.ok) return auth.response
 
     const body = await c.req.json()
     const { currentPassword, newPassword } = body as {
@@ -195,7 +204,7 @@ export function authRoutes(deps: AppDependencies) {
       return c.json({ error: 'New password must be at least 8 characters' }, 400)
     }
 
-    const user = await deps.getUserById(userId)
+    const user = await deps.getUserById(auth.userId)
     if (!user) {
       return c.json({ error: 'User not found' }, 404)
     }
@@ -207,12 +216,12 @@ export function authRoutes(deps: AppDependencies) {
     }
 
     const newHash = hashPassword(newPassword)
-    await deps.updatePassword(userId, newHash)
+    await deps.updatePassword(auth.userId, newHash)
 
     // Invalidate all sessions for this user, then create a fresh one
-    await clearUserSessions(userId)
+    await clearUserSessions(auth.userId)
     const newToken = generateSessionToken()
-    await createSession(userId, newToken)
+    await createSession(auth.userId, newToken)
 
     return c.json({ ok: true, token: newToken })
   })
@@ -237,10 +246,10 @@ export function authRoutes(deps: AppDependencies) {
 
   // Update the authenticated user's preferences (partial merge)
   router.patch('/api/auth/me/preferences', async (c) => {
-    const userId = c.get('userId')
-    if (!userId) return c.json({ error: 'Not authenticated' }, 401)
+    const auth = requireSessionUser(c)
+    if (!auth.ok) return auth.response
     const body = await c.req.json()
-    const user = await deps.getUserById(userId)
+    const user = await deps.getUserById(auth.userId)
     if (!user) return c.json({ error: 'User not found' }, 404)
     // Filter to allowed preference keys only
     const filtered: Record<string, unknown> = {}
@@ -283,7 +292,7 @@ export function authRoutes(deps: AppDependencies) {
     // Merge incoming with existing to preserve fields not being updated
     const current = (user.preferences ?? {}) as Record<string, unknown>
     const updated = { ...current, ...filtered }
-    await updateUserPreferences(deps.db, userId, updated as Preferences)
+    await updateUserPreferences(deps.db, auth.userId, updated as Preferences)
     return c.json({ success: true })
   })
 

--- a/tests/server/routes/auth.test.ts
+++ b/tests/server/routes/auth.test.ts
@@ -681,6 +681,97 @@ describe('PATCH /api/auth/me/locale', () => {
   })
 })
 
+describe('POST /api/auth/change-password', () => {
+  it('changes the password for a session-authenticated user', async () => {
+    const storedHash = hashPassword('oldpassword123')
+    const updatePassword = vi.fn(async () => {})
+    const app = createApp(
+      makeDeps({
+        updatePassword,
+        getUserCount: vi.fn(async () => 1),
+        getUserByUsername: vi.fn(async () => ({
+          id: 1,
+          username: 'testuser',
+          passwordHash: storedHash,
+          isAdmin: false,
+        })),
+      }),
+    )
+
+    await createSession(1, 'session-token')
+    const res = await app.request('/api/auth/change-password', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer session-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        currentPassword: 'oldpassword123',
+        newPassword: 'newpassword123',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.token).toEqual(expect.any(String))
+    expect(body.token).not.toBe('session-token')
+    expect(updatePassword).toHaveBeenCalledOnce()
+    expect(updatePassword).toHaveBeenCalledWith(1, expect.any(String))
+  })
+
+  it('rejects legacy read-only token auth', async () => {
+    const updatePassword = vi.fn(async () => {})
+    const app = new Hono<HonoEnv>()
+    app.use('*', async (c, next) => {
+      c.set('userId', 1)
+      c.set('legacyTokenAuth', true)
+      await next()
+    })
+    app.route('/', authRoutes(makeDeps({ updatePassword })))
+
+    const res = await app.request('/api/auth/change-password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        currentPassword: 'oldpassword123',
+        newPassword: 'newpassword123',
+      }),
+    })
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'Session authentication required' })
+    expect(updatePassword).not.toHaveBeenCalled()
+  })
+})
+
+describe('PATCH /api/auth/me/preferences', () => {
+  it('rejects legacy read-only token auth', async () => {
+    const app = new Hono<HonoEnv>()
+    app.use('*', async (c, next) => {
+      c.set('userId', 1)
+      c.set('legacyTokenAuth', true)
+      await next()
+    })
+    app.route('/', authRoutes(makeDeps()))
+
+    const res = await app.request('/api/auth/me/preferences', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        scoreThreshold: 0.8,
+      }),
+    })
+
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toEqual({ error: 'Session authentication required' })
+  })
+})
+
 describe('GET /api/auth/status', () => {
   it('reports hasUsers: false when no users exist', async () => {
     const app = createApp(makeDeps({ getUserCount: vi.fn(async () => 0) }))


### PR DESCRIPTION
## Summary
- finish the repo audit sweep across docs, scripts, deploy configs, API auth, CI, and release metadata
- tighten session-only auth for locale, password, and preference writes
- harden Helm/raw K8s examples, refresh CI defaults, and prep release metadata for 0.26.7

## Verification
- bun run lint
- bun run typecheck
- bun run test
- shellcheck scripts/dev-setup.sh scripts/dev-teardown.sh
- DB_PASS=testpass docker compose -f deploy/docker/docker-compose.yml config
- helm lint deploy/helm/digarr --set postgresql.auth.password=testpass
- python XML parse for deploy/unraid/digarr.xml