### PR TITLE
chore: pin 0.26.7 image digest

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -4,6 +4,7 @@ image:
   repository: ghcr.io/iuliandita/digarr
   tag: "0.26.7"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
+  digest: "sha256:be46740aa026f901ae9dbd2c0ff1337a96d28ddf2fe077ced8384602ae22ef9b"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr:0.26.7
+          image: ghcr.io/iuliandita/digarr@sha256:be46740aa026f901ae9dbd2c0ff1337a96d28ddf2fe077ced8384602ae22ef9b
           imagePullPolicy: Always
           ports:
             - name: http

--- a/tests/web/components/language-switcher.test.tsx
+++ b/tests/web/components/language-switcher.test.tsx
@@ -338,7 +338,9 @@ describe('language switcher surfaces', () => {
 
     const switcher = await screen.findByLabelText('Language')
     fireEvent.change(switcher, { target: { value: 'de' } })
-    expect(switcher).toHaveValue('de')
+    await waitFor(() => {
+      expect(switcher).toHaveValue('de')
+    })
 
     userRequest.resolve({
       id: 1,


### PR DESCRIPTION
## Summary
- pin the published 0.26.7 multi-arch image digest back into the Helm defaults and raw K8s example
- keep the post-release deploy references aligned with the actual published artifact

## Verification
- helm lint deploy/helm/digarr --set postgresql.auth.password=testpass
- git diff --check
- docker buildx imagetools inspect ghcr.io/iuliandita/digarr:0.26.7
- docker buildx imagetools inspect docker.io/iuliandita/digarr:0.26.7