### PR TITLE
ci(security): pin trivy binary to 0.69.3

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,6 +52,8 @@ jobs:
           format: sarif
           output: trivy-fs.sarif
           exit-code: "1"
+          # Pin binary version; v0.69.4-v0.69.6 contained credential-stealing malware (CVE-2026-33634)
+          trivy-version: "0.69.3"
       - uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         if: always()
         with:
@@ -89,6 +91,8 @@ jobs:
           severity: HIGH,CRITICAL
           format: sarif
           output: trivy-image.sarif
+          # Pin binary version; v0.69.4-v0.69.6 contained credential-stealing malware (CVE-2026-33634)
+          trivy-version: "0.69.3"
       - uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         if: always()
         with:


### PR DESCRIPTION
## Summary

- Pin `trivy-version: "0.69.3"` on both `trivy-fs` and `trivy-image` scan steps in `.github/workflows/security.yml`
- `aquasecurity/trivy-action@v0.35.0` otherwise resolves the latest trivy binary at runtime; it was not pinned

## Why now

The Mar 19-23 2026 window had compromised trivy releases (v0.69.4-v0.69.6) containing credential-stealing malware (CVE-2026-33634). `security.yml` ran ~100 times during that window. Pinning eliminates the recurrence risk.

## Operator action

Rotate `DOCKERHUB_TOKEN` and any other secrets exposed to `security.yml` runs during Mar 19-23 as a precaution. The `trivy-image` job is the only one that uses `DOCKERHUB_TOKEN`; `trivy-fs`, `audit`, and `codeql` jobs only have the default `GITHUB_TOKEN`.

## Test plan

- [x] `bun run lint` clean
- [ ] CI workflow runs successfully with pinned version