### PR TITLE
fix(pipeline): isolate source failures, atomic store, chunked bulk upserts

### DIFF
--- a/src/core/ops/backup.ts
+++ b/src/core/ops/backup.ts
@@ -265,34 +265,31 @@ export async function restoreBackup(
   const tablesRestored: Record<string, number> = {}
   const warnings: string[] = []
 
-  // Wrap in a transaction so partial failures roll back cleanly
-  try {
-    // Backward compatibility: map old subscriptionRuns to jobRuns format
-    const backupData = backup.data as unknown as Record<string, unknown[]>
-    if (backupData.subscriptionRuns?.length && !backup.data.jobRuns?.length) {
-      backup.data.jobRuns = backupData.subscriptionRuns as Record<string, unknown>[]
+  // Backward compatibility: map old subscriptionRuns to jobRuns format
+  const backupData = backup.data as unknown as Record<string, unknown[]>
+  if (backupData.subscriptionRuns?.length && !backup.data.jobRuns?.length) {
+    backup.data.jobRuns = backupData.subscriptionRuns as Record<string, unknown>[]
+  }
+
+  // Wrap in a transaction so partial failures roll back cleanly.
+  // Let errors bubble up to the caller so HTTP returns 500, not 200 with
+  // an empty tablesRestored map and a warning the UI may miss.
+  await db.transaction(async (tx) => {
+    const includedSpecs = RESTORE_ORDER.filter((spec) => Array.isArray(backup.data[spec.key]))
+
+    for (const spec of [...includedSpecs].reverse()) {
+      await spec.clear(tx)
     }
 
-    await db.transaction(async (tx) => {
-      const includedSpecs = RESTORE_ORDER.filter((spec) => Array.isArray(backup.data[spec.key]))
+    for (const spec of RESTORE_ORDER) {
+      const rows = backup.data[spec.key]
+      if (!Array.isArray(rows) || rows.length === 0) continue
 
-      for (const spec of [...includedSpecs].reverse()) {
-        await spec.clear(tx)
-      }
-
-      for (const spec of RESTORE_ORDER) {
-        const rows = backup.data[spec.key]
-        if (!Array.isArray(rows) || rows.length === 0) continue
-
-        await spec.restore(tx, rows)
-        await spec.resetSequence(tx)
-        tablesRestored[spec.key] = rows.length
-      }
-    })
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    warnings.push(`Restore failed (rolled back): ${msg}`)
-  }
+      await spec.restore(tx, rows)
+      await spec.resetSequence(tx)
+      tablesRestored[spec.key] = rows.length
+    }
+  })
 
   return {
     tablesRestored,

--- a/src/core/pipeline/analyze.ts
+++ b/src/core/pipeline/analyze.ts
@@ -2,24 +2,33 @@ import type { DiscoverySource, ListeningActivityEntry, TopArtistEntry } from '@/
 import type { TasteProfile } from '@/core/types'
 
 export async function analyze(sources: DiscoverySource[]): Promise<TasteProfile> {
+  // One failing source must not crash the whole pipeline run.
+  const results = await Promise.allSettled(
+    sources.map(async (source) => ({
+      id: source.id,
+      artists: await source.getTopArtists(),
+      activity: source.getListeningActivity ? await source.getListeningActivity() : [],
+    })),
+  )
+
   const allArtists: TopArtistEntry[] = []
   let activityData: ListeningActivityEntry[] = []
 
-  // Collect top artists and (optionally) listening activity from all sources
-  await Promise.all(
-    sources.map(async (source) => {
-      const artists = await source.getTopArtists()
-      for (const a of artists) allArtists.push(a)
-
-      if (source.getListeningActivity) {
-        const activity = await source.getListeningActivity()
-        // Merge activity data -- first source with activity wins
-        if (activityData.length === 0) {
-          activityData = activity
-        }
-      }
-    }),
-  )
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i]
+    if (r?.status !== 'fulfilled') {
+      const sourceId = sources[i]?.id ?? 'unknown'
+      const reason = r && r.status === 'rejected' ? r.reason : 'unknown'
+      const msg = reason instanceof Error ? reason.message : String(reason)
+      console.warn(`[analyze] source ${sourceId} failed: ${msg}`)
+      continue
+    }
+    for (const a of r.value.artists) allArtists.push(a)
+    // Deterministic: first fulfilled source with activity wins.
+    if (activityData.length === 0 && r.value.activity.length > 0) {
+      activityData = r.value.activity
+    }
+  }
 
   // Deduplicate by name (case-insensitive), keep highest play count
   const byName = new Map<string, TopArtistEntry>()

--- a/src/core/pipeline/store.ts
+++ b/src/core/pipeline/store.ts
@@ -68,6 +68,15 @@ export interface StoreDb {
   >
 
   userHasAnySyncState?: (userId: number) => Promise<boolean>
+
+  // Optional atomic variant: wraps upsertArtist + insertRecommendation in a
+  // single DB transaction so a crash between the two cannot leave an artist
+  // row without a matching recommendation. Prod wiring provides this; test
+  // mocks keep the two separate methods.
+  upsertArtistAndRecommendation?: (
+    artist: Parameters<StoreDb['upsertArtist']>[0],
+    rec: Omit<Parameters<StoreDb['insertRecommendation']>[0], 'artistId'>,
+  ) => Promise<void>
 }
 
 export type StoreOptions = {
@@ -93,33 +102,37 @@ export async function store(
   let failed = 0
 
   for (const artist of artists) {
+    const artistData = {
+      mbid: artist.mbid,
+      name: artist.name,
+      disambiguation: artist.disambiguation,
+      tags: artist.tags,
+      genres: artist.genres,
+      imageUrl: artist.imageUrl,
+      logoUrl: artist.logoUrl,
+      imageFailed: artist.imageFailed,
+      streamingUrls: artist.streamingUrls,
+      beginYear: artist.beginYear,
+      endYear: artist.endYear,
+    }
+    const recData = {
+      batchId: batch.id,
+      score: artist.score,
+      sources: artist.sourceScores,
+      aiReasoning: artist.aiReasoning,
+      status: 'pending',
+      userId: options.userId,
+      recommendedReleaseGroupId: artist.suggestedAlbum?.releaseGroupId,
+      recommendedReleaseGroupTitle: artist.suggestedAlbum?.title,
+    }
+
     try {
-      const upserted = await db.upsertArtist({
-        mbid: artist.mbid,
-        name: artist.name,
-        disambiguation: artist.disambiguation,
-        tags: artist.tags,
-        genres: artist.genres,
-        imageUrl: artist.imageUrl,
-        logoUrl: artist.logoUrl,
-        imageFailed: artist.imageFailed,
-        streamingUrls: artist.streamingUrls,
-        beginYear: artist.beginYear,
-        endYear: artist.endYear,
-      })
-
-      await db.insertRecommendation({
-        artistId: upserted.id,
-        batchId: batch.id,
-        score: artist.score,
-        sources: artist.sourceScores,
-        aiReasoning: artist.aiReasoning,
-        status: 'pending',
-        userId: options.userId,
-        recommendedReleaseGroupId: artist.suggestedAlbum?.releaseGroupId,
-        recommendedReleaseGroupTitle: artist.suggestedAlbum?.title,
-      })
-
+      if (db.upsertArtistAndRecommendation) {
+        await db.upsertArtistAndRecommendation(artistData, recData)
+      } else {
+        const upserted = await db.upsertArtist(artistData)
+        await db.insertRecommendation({ ...recData, artistId: upserted.id })
+      }
       added++
     } catch (err: unknown) {
       failed++

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -20,3 +20,8 @@ const pool = new pg.Pool({
 export const db = drizzle(pool, { schema })
 export { pool }
 export type Database = typeof db
+
+// A db handle that can be either the top-level Database or an in-flight
+// transaction. Query helpers that participate in caller-provided transactions
+// should accept this type.
+export type DbOrTx = Database | Parameters<Parameters<Database['transaction']>[0]>[0]

--- a/src/db/queries/artist-metadata.ts
+++ b/src/db/queries/artist-metadata.ts
@@ -30,29 +30,37 @@ export async function lookupByName(db: Database, name: string): Promise<ArtistMe
   return row ?? null
 }
 
+// Postgres bind-parameter limit is 65535. artist_metadata inserts 5 cols per row
+// (name, nameNormalized, spotifyGenres, spotifyPopularity, deezerFans), so keep
+// chunks well under floor(65535/5)=13107. 5000 leaves headroom.
+const BULK_UPSERT_CHUNK = 5000
+
 export async function bulkUpsert(db: Database, rows: ArtistMetadataInsert[]): Promise<number> {
   if (rows.length === 0) return 0
-  await db
-    .insert(artistMetadata)
-    .values(
-      rows.map((row) => ({
-        name: row.name,
-        nameNormalized: row.nameNormalized,
-        spotifyGenres: row.spotifyGenres ?? null,
-        spotifyPopularity: row.spotifyPopularity ?? null,
-        deezerFans: row.deezerFans ?? null,
-      })),
-    )
-    .onConflictDoUpdate({
-      target: artistMetadata.nameNormalized,
-      set: {
-        name: sql`excluded.name`,
-        spotifyGenres: sql`excluded.spotify_genres`,
-        spotifyPopularity: sql`excluded.spotify_popularity`,
-        deezerFans: sql`excluded.deezer_fans`,
-        cachedAt: sql`now()`,
-      },
-    })
+  for (let i = 0; i < rows.length; i += BULK_UPSERT_CHUNK) {
+    const chunk = rows.slice(i, i + BULK_UPSERT_CHUNK)
+    await db
+      .insert(artistMetadata)
+      .values(
+        chunk.map((row) => ({
+          name: row.name,
+          nameNormalized: row.nameNormalized,
+          spotifyGenres: row.spotifyGenres ?? null,
+          spotifyPopularity: row.spotifyPopularity ?? null,
+          deezerFans: row.deezerFans ?? null,
+        })),
+      )
+      .onConflictDoUpdate({
+        target: artistMetadata.nameNormalized,
+        set: {
+          name: sql`excluded.name`,
+          spotifyGenres: sql`excluded.spotify_genres`,
+          spotifyPopularity: sql`excluded.spotify_popularity`,
+          deezerFans: sql`excluded.deezer_fans`,
+          cachedAt: sql`now()`,
+        },
+      })
+  }
   return rows.length
 }
 

--- a/src/db/queries/artists.ts
+++ b/src/db/queries/artists.ts
@@ -1,5 +1,5 @@
 import { eq, sql } from 'drizzle-orm'
-import type { Database } from '@/db'
+import type { Database, DbOrTx } from '@/db'
 import { artists, genres } from '@/db/schema'
 
 export type ArtistRow = typeof artists.$inferSelect
@@ -18,7 +18,7 @@ export type ArtistInsert = {
   endYear?: number | null
 }
 
-export async function upsertArtist(db: Database, artist: ArtistInsert): Promise<ArtistRow> {
+export async function upsertArtist(db: DbOrTx, artist: ArtistInsert): Promise<ArtistRow> {
   const { imageFailed, ...artistData } = artist
 
   const imageFailedAtInsert = imageFailed ? new Date() : artist.imageUrl ? null : undefined

--- a/src/db/queries/recommendations.ts
+++ b/src/db/queries/recommendations.ts
@@ -1,5 +1,5 @@
 import { and, count, desc, eq, gte, inArray, sql } from 'drizzle-orm'
-import type { Database } from '@/db'
+import type { Database, DbOrTx } from '@/db'
 import { artistMetadata, artists, recommendationBatches, recommendations } from '@/db/schema'
 
 type RecommendationRow = typeof recommendations.$inferSelect
@@ -314,7 +314,7 @@ export async function getGenreArtists(
 }
 
 export async function insertRecommendation(
-  db: Database,
+  db: DbOrTx,
   data: {
     artistId: number
     batchId: number

--- a/src/db/queries/recording-artist-cache.ts
+++ b/src/db/queries/recording-artist-cache.ts
@@ -15,13 +15,19 @@ export async function getCachedRecordingArtists(
     .where(inArray(recordingArtistCache.recordingMbid, recordingMbids))
 }
 
+// Postgres bind-parameter limit is 65535; 3 cols per row -> floor(65535/3)=21845.
+// 5000 is safe headroom and also limits transaction size.
+const CACHE_INSERT_CHUNK = 5000
+
 export async function insertCachedRecordingArtists(
   db: Database,
   entries: Array<{ recordingMbid: string; artistMbid: string; artistName: string }>,
 ): Promise<void> {
   if (entries.length === 0) return
-  await db
-    .insert(recordingArtistCache)
-    .values(entries)
-    .onConflictDoNothing({ target: recordingArtistCache.recordingMbid })
+  for (let i = 0; i < entries.length; i += CACHE_INSERT_CHUNK) {
+    await db
+      .insert(recordingArtistCache)
+      .values(entries.slice(i, i + CACHE_INSERT_CHUNK))
+      .onConflictDoNothing({ target: recordingArtistCache.recordingMbid })
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,13 @@ const storeDb: StoreDb = {
     return { id: row.id }
   },
   insertRecommendation: (data) => insertRecommendation(db, data),
+  // Atomic pair: prevents orphaned artist rows when the followup insert fails
+  upsertArtistAndRecommendation: async (artistData, recData) => {
+    await db.transaction(async (tx) => {
+      const row = await upsertArtist(tx, artistData)
+      await insertRecommendation(tx, { ...recData, artistId: row.id })
+    })
+  },
   getRejectedMbids: (cooldownDays) => getRejectedArtistMbids(db, cooldownDays),
   getFeedbackHistory: () => getGenreFeedbackHistory(db),
   lookupArtistMetadata: (name) => lookupByName(db, name),

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -77,7 +77,13 @@ export function adminRoutes(deps: AdminDeps) {
       return c.json({ error: 'Invalid backup file structure' }, 400)
     }
 
-    const result = await restoreBackup(deps.db, backup, { force })
+    let result: Awaited<ReturnType<typeof restoreBackup>>
+    try {
+      result = await restoreBackup(deps.db, backup, { force })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return c.json({ error: `Restore failed (rolled back): ${msg}` }, 500)
+    }
 
     if (result.encryptionMismatch && !force) {
       return c.json(

--- a/src/server/routes/batches.ts
+++ b/src/server/routes/batches.ts
@@ -11,6 +11,7 @@ export function batchRoutes(deps: AppDependencies) {
 
   router.get('/api/batches/:id', async (c) => {
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid batch ID' }, 400)
     const batch = await deps.getBatch(id)
     if (!batch) {
       return c.json({ error: 'Batch not found' }, 404)

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -276,6 +276,7 @@ export function recommendationRoutes(deps: AppDependencies) {
 
   router.get('/api/recommendations/:id', async (c) => {
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid recommendation ID' }, 400)
     const rec = await deps.getRecommendation(id)
     if (!rec) return c.json({ error: 'Recommendation not found' }, 404)
     const userId = c.get('userId')
@@ -285,6 +286,7 @@ export function recommendationRoutes(deps: AppDependencies) {
 
   router.patch('/api/recommendations/:id', async (c) => {
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid recommendation ID' }, 400)
     const body = await c.req.json()
     const {
       status,

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -714,6 +714,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
     }
 
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid subscription ID' }, 400)
     const existing = await deps.subscriptionQueries.getSubscription(id)
     if (!existing) {
       return c.json({ error: 'Subscription not found' }, 404)
@@ -780,6 +781,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
     }
 
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid subscription ID' }, 400)
     const existing = await deps.subscriptionQueries.getSubscription(id)
     if (!existing) {
       return c.json({ error: 'Subscription not found' }, 404)
@@ -800,6 +802,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
     }
 
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid subscription ID' }, 400)
     const existing = await deps.subscriptionQueries.getSubscription(id)
     if (!existing) {
       return c.json({ error: 'Subscription not found' }, 404)
@@ -841,6 +844,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
     }
 
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid subscription ID' }, 400)
     const existing = await deps.subscriptionQueries.getSubscription(id)
     if (!existing) {
       return c.json({ error: 'Subscription not found' }, 404)

--- a/src/server/routes/targets.ts
+++ b/src/server/routes/targets.ts
@@ -100,6 +100,7 @@ export function targetRoutes(deps: TargetDeps) {
       return c.json({ error: 'Admin access required' }, 403)
 
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid target ID' }, 400)
     const target = await deps.targetQueries.getTarget(id)
     if (!target || target.userId !== userId) {
       return c.json({ error: 'Target not found' }, 404)
@@ -130,6 +131,7 @@ export function targetRoutes(deps: TargetDeps) {
       return c.json({ error: 'Admin access required' }, 403)
 
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid target ID' }, 400)
     const target = await deps.targetQueries.getTarget(id)
     if (!target || target.userId !== userId) {
       return c.json({ error: 'Target not found' }, 404)
@@ -144,6 +146,7 @@ export function targetRoutes(deps: TargetDeps) {
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
     const id = Number(c.req.param('id'))
+    if (!Number.isFinite(id)) return c.json({ error: 'Invalid target ID' }, 400)
     const target = await deps.targetQueries.getTarget(id)
     if (!target || target.userId !== userId) {
       return c.json({ error: 'Target not found' }, 404)


### PR DESCRIPTION
## Summary

Six data-safety fixes that together address the critical findings from the deep audit.

- **`analyze.ts`**: `Promise.all` → `Promise.allSettled` over listening sources. A single flaky Last.fm/ListenBrainz/Spotify call no longer aborts the entire pipeline run. Activity merge is now deterministic (first fulfilled source wins).
- **Pipeline `store`**: adds optional `upsertArtistAndRecommendation` to `StoreDb`. Prod wiring implements it as a single DB transaction so a crash between artist upsert and recommendation insert cannot leave an orphaned artist row. Test mocks keep the two separate methods (fallback path preserved).
- **Backup restore**: drops the catch that swallowed errors into `warnings[]`. Errors now bubble to the admin route which returns HTTP 500 instead of 200 with empty `tablesRestored` - users can no longer miss a silent restore failure.
- **Bulk upserts**: chunk `artistMetadata.bulkUpsert` and `recordingArtistCache.insertCachedRecordingArtists` at 5000 rows. Previously the single INSERT VALUES crashed above ~9362 rows due to Postgres's 65535 bind-parameter ceiling.
- **NaN guards**: add `!Number.isFinite(id)` on `batches/:id`, `recommendations/:id` (2 handlers), `subscriptions/:id` (4 handlers), `targets/:id` (3 handlers). Matches the pattern already in place for `artists/:id`, `jobs/:id`, `users/:id`. Bad IDs return 400 instead of 500.
- **New `DbOrTx` type** in `src/db/index.ts` so query helpers can accept either `Database` or an in-flight Drizzle transaction. Used by `upsertArtist` and `insertRecommendation`.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` -- 1786 passed, 22 skipped, 0 failures
- [ ] CI full chain green