### PR TITLE
fix(pipeline): pass librarySync into manual pipeline runs (#105)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -35,16 +35,53 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: environment
+  - type: input
+    id: digarr-version
     attributes:
-      label: Environment
-      description: OS, browser, Digarr version, deployment method
-      placeholder: |
-        - OS: Ubuntu 24.04
-        - Browser: Firefox 126
-        - Digarr: 0.26.7
-        - Deploy: Docker Compose
+      label: Digarr version
+      description: Visible in the footer of the web UI, or `package.json`.
+      placeholder: "e.g. 0.27.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment method
+      options:
+        - Docker Compose
+        - Docker (plain)
+        - Helm (Kubernetes)
+        - Kubernetes (raw manifests)
+        - Bun (from source)
+        - Other / custom
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Host OS
+      description: OS and version of the machine running Digarr (or the K8s node).
+      placeholder: "e.g. Ubuntu 24.04, Debian 12, CachyOS rolling, Talos 1.8"
+    validations:
+      required: true
+
+  - type: input
+    id: postgres-version
+    attributes:
+      label: Postgres version
+      description: Run `SELECT version();` or check your image tag.
+      placeholder: "e.g. 16.4, 17.2"
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Only if the bug is in the web UI. Skip for backend-only issues.
+      placeholder: "e.g. Firefox 126, Chrome 138, Safari 17"
     validations:
       required: false
 

--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.27.2
-appVersion: "0.27.2"
+version: 0.27.3
+appVersion: "0.27.3"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.27.2"
+  tag: "0.27.3"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
   digest: "sha256:be46740aa026f901ae9dbd2c0ff1337a96d28ddf2fe077ced8384602ae22ef9b"
   pullPolicy: Always

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.27.2",
+  "version": "0.27.3",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -107,6 +107,7 @@ export function pipelineRoutes(deps: AppDependencies) {
         providerRegistry: deps.providerRegistry,
         userConnections,
         autoApproveDeps,
+        librarySync: deps.librarySync,
         jobRecorder: deps.jobRecorder,
         trigger: 'manual',
         responseLocale,

--- a/tests/server/routes/pipeline.test.ts
+++ b/tests/server/routes/pipeline.test.ts
@@ -267,6 +267,15 @@ describe('POST /api/pipeline/run', () => {
       }),
     )
   })
+
+  it('passes librarySync into the orchestrator (regression: GH #105)', async () => {
+    const orchestrator = makeMockOrchestrator(false) as unknown as AppDependencies['orchestrator']
+    const librarySync = { syncForUser: vi.fn() } as unknown as AppDependencies['librarySync']
+    const app = createApp(makeDeps({ orchestrator, librarySync }))
+    const res = await authedRequest(app, '/api/pipeline/run', { method: 'POST' })
+    expect(res.status).toBe(202)
+    expect(orchestrator.run).toHaveBeenCalledWith(expect.objectContaining({ librarySync }))
+  })
 })
 
 describe('GET /api/pipeline/status', () => {


### PR DESCRIPTION
Fixes #105.

## Summary

Manual scans were failing for every user with:

> Pipeline orchestrator requires librarySync, userId, and library StoreDb methods

``POST /api/pipeline/run`` built the orchestrator deps without passing ``librarySync``, and the ``as unknown as PipelineDeps`` cast hid the missing field at compile time. The scheduled-run path and discovery-mode path both pass it correctly - only the manual trigger was broken.

## Changes

- ``src/server/routes/pipeline.ts``: pass ``librarySync: deps.librarySync`` through to ``orchestrator.run()``.
- ``tests/server/routes/pipeline.test.ts``: regression test asserting the field is present. Fails on ``main`` without the fix.
- ``.github/ISSUE_TEMPLATE/bug.yml``: split the single ``Environment`` textarea into required structured inputs (digarr version, deployment method, host OS, postgres version) plus an optional browser field. Issue #105 came in with ``_No response_`` for environment - this makes future reports actionable.
- ``package.json`` / ``Chart.yaml`` / ``values.yaml``: bump to 0.27.3.

## Test plan

- [x] ``bun run typecheck`` clean
- [x] ``bun run lint`` clean
- [x] ``bun run test`` - 1804/1804 pass (the previously flaky ``change-password`` test is now passing too under lower concurrency)
- [ ] CI green
- [ ] Post-merge: manual scan from UI succeeds end-to-end