### PR TITLE
feat(i18n): batch 6 - finish component coverage + library-sync messages (v0.27.6)

### DIFF
--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.27.5
-appVersion: "0.27.5"
+version: 0.27.6
+appVersion: "0.27.6"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.27.5"
+  tag: "0.27.6"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
   digest: "sha256:be46740aa026f901ae9dbd2c0ff1337a96d28ddf2fe077ced8384602ae22ef9b"
   pullPolicy: Always

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.27.5",
+  "version": "0.27.6",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/core/i18n/messages/de.ts
+++ b/src/core/i18n/messages/de.ts
@@ -1164,4 +1164,10 @@ export const de = {
   'pipeline.message.resolvingArtist': '{0} wird aufgelöst...',
   'pipeline.message.searchingArtist': '{0} wird gesucht...',
   'pipeline.message.resolutionComplete': 'Auflösung abgeschlossen',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Bibliothekskatalog wird aufgebaut',
+  'firstSyncBanner.body':
+    'Digarr gleicht deine Bibliothek mit MusicBrainz ab. Das MusicBrainz-Rate-Limit erlaubt etwa 60 Künstler pro Minute, eine Bibliothek mit 5.000 Künstlern braucht also rund 80 Minuten für die vollständige Synchronisierung. Das geschieht nur einmal -- spätere Synchronisierungen nutzen den lokalen Cache und sind in Sekunden fertig.',
+  'librarySync.message.syncingSource': '{0} wird synchronisiert...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/en.ts
+++ b/src/core/i18n/messages/en.ts
@@ -1321,4 +1321,12 @@ export const en = {
   'pipeline.message.resolvingArtist': 'Resolving {0}...',
   'pipeline.message.searchingArtist': 'Searching {0}...',
   'pipeline.message.resolutionComplete': 'Resolution complete',
+
+  // Library first-sync banner
+  'firstSyncBanner.title': 'Building your library catalog',
+  'firstSyncBanner.body':
+    'Digarr is matching your library against MusicBrainz. The MusicBrainz rate limit allows roughly 60 artists per minute, so a 5,000-artist library takes around 80 minutes to fully reconcile. This only happens once -- subsequent syncs use the local cache and complete in seconds.',
+
+  // Library sync progress messages
+  'librarySync.message.syncingSource': 'Syncing {0}...',
 } as const

--- a/src/core/i18n/messages/es.ts
+++ b/src/core/i18n/messages/es.ts
@@ -1157,4 +1157,10 @@ export const es = {
   'pipeline.message.resolvingArtist': 'Resolviendo {0}...',
   'pipeline.message.searchingArtist': 'Buscando {0}...',
   'pipeline.message.resolutionComplete': 'Resolución completa',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Construyendo el catálogo de tu biblioteca',
+  'firstSyncBanner.body':
+    'Digarr está comparando tu biblioteca con MusicBrainz. El límite de tasa de MusicBrainz permite aproximadamente 60 artistas por minuto, por lo que una biblioteca de 5.000 artistas tarda cerca de 80 minutos en reconciliarse por completo. Esto solo sucede una vez -- las sincronizaciones posteriores usan la caché local y terminan en segundos.',
+  'librarySync.message.syncingSource': 'Sincronizando {0}...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/fr.ts
+++ b/src/core/i18n/messages/fr.ts
@@ -1157,4 +1157,10 @@ export const fr = {
   'pipeline.message.resolvingArtist': 'Résolution de {0}...',
   'pipeline.message.searchingArtist': 'Recherche de {0}...',
   'pipeline.message.resolutionComplete': 'Résolution terminée',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Construction du catalogue de votre bibliothèque',
+  'firstSyncBanner.body':
+    "Digarr fait correspondre votre bibliothèque à MusicBrainz. La limite de débit de MusicBrainz autorise environ 60 artistes par minute, une bibliothèque de 5 000 artistes prend donc environ 80 minutes pour être entièrement réconciliée. Cela ne se produit qu'une seule fois -- les synchronisations suivantes utilisent le cache local et se terminent en quelques secondes.",
+  'librarySync.message.syncingSource': 'Synchronisation de {0}...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/it.ts
+++ b/src/core/i18n/messages/it.ts
@@ -1175,4 +1175,10 @@ export const it = {
   'pipeline.message.resolvingArtist': 'Risoluzione di {0}...',
   'pipeline.message.searchingArtist': 'Ricerca di {0}...',
   'pipeline.message.resolutionComplete': 'Risoluzione completa',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Costruzione del catalogo della libreria',
+  'firstSyncBanner.body':
+    'Digarr sta confrontando la tua libreria con MusicBrainz. Il limite di richieste di MusicBrainz consente circa 60 artisti al minuto, quindi una libreria di 5.000 artisti impiega circa 80 minuti per la riconciliazione completa. Questo accade una sola volta -- le sincronizzazioni successive usano la cache locale e si completano in pochi secondi.',
+  'librarySync.message.syncingSource': 'Sincronizzazione di {0}...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/ja.ts
+++ b/src/core/i18n/messages/ja.ts
@@ -1150,4 +1150,10 @@ export const ja = {
   'pipeline.message.resolvingArtist': '{0} を解決中...',
   'pipeline.message.searchingArtist': '{0} を検索中...',
   'pipeline.message.resolutionComplete': '解決が完了しました',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'ライブラリのカタログを構築中',
+  'firstSyncBanner.body':
+    'Digarrはライブラリを MusicBrainz と照合しています。MusicBrainz のレート制限は1分あたり約60名のアーティストまでなので、5,000名のライブラリの完全な照合には約80分かかります。これは初回のみで、以降の同期はローカルキャッシュを使って数秒で完了します。',
+  'librarySync.message.syncingSource': '{0} を同期中...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/ko.ts
+++ b/src/core/i18n/messages/ko.ts
@@ -1138,4 +1138,10 @@ export const ko = {
   'pipeline.message.resolvingArtist': '{0} 해결 중...',
   'pipeline.message.searchingArtist': '{0} 검색 중...',
   'pipeline.message.resolutionComplete': '해결 완료',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': '라이브러리 카탈로그 구축 중',
+  'firstSyncBanner.body':
+    'Digarr가 라이브러리를 MusicBrainz와 매칭하고 있습니다. MusicBrainz의 속도 제한은 분당 약 60명의 아티스트를 허용하므로 5,000명 규모의 라이브러리를 완전히 정합하는 데 약 80분이 걸립니다. 이 작업은 한 번만 수행되며 -- 이후 동기화는 로컬 캐시를 사용해 몇 초 만에 완료됩니다.',
+  'librarySync.message.syncingSource': '{0} 동기화 중...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/nl.ts
+++ b/src/core/i18n/messages/nl.ts
@@ -1153,4 +1153,10 @@ export const nl = {
   'pipeline.message.resolvingArtist': '{0} wordt opgehaald...',
   'pipeline.message.searchingArtist': 'Zoeken naar {0}...',
   'pipeline.message.resolutionComplete': 'Resolutie voltooid',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Je bibliotheekcatalogus wordt opgebouwd',
+  'firstSyncBanner.body':
+    'Digarr matcht je bibliotheek met MusicBrainz. De MusicBrainz-snelheidslimiet staat ongeveer 60 artiesten per minuut toe, dus een bibliotheek van 5.000 artiesten doet er ongeveer 80 minuten over om volledig te worden verwerkt. Dit gebeurt maar één keer -- volgende synchronisaties gebruiken de lokale cache en zijn binnen seconden klaar.',
+  'librarySync.message.syncingSource': '{0} wordt gesynchroniseerd...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/pl.ts
+++ b/src/core/i18n/messages/pl.ts
@@ -1151,4 +1151,10 @@ export const pl = {
   'pipeline.message.resolvingArtist': 'Rozwiązywanie {0}...',
   'pipeline.message.searchingArtist': 'Wyszukiwanie {0}...',
   'pipeline.message.resolutionComplete': 'Rozwiązywanie zakończone',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Budowanie katalogu biblioteki',
+  'firstSyncBanner.body':
+    'Digarr dopasowuje twoją bibliotekę do MusicBrainz. Limit zapytań MusicBrainz pozwala na około 60 artystów na minutę, więc biblioteka licząca 5000 artystów potrzebuje około 80 minut do pełnego uzgodnienia. Dzieje się to tylko raz -- kolejne synchronizacje korzystają z lokalnej pamięci podręcznej i kończą się w kilka sekund.',
+  'librarySync.message.syncingSource': 'Synchronizacja {0}...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/pt-BR.ts
+++ b/src/core/i18n/messages/pt-BR.ts
@@ -1159,4 +1159,10 @@ export const ptBR = {
   'pipeline.message.resolvingArtist': 'Resolvendo {0}...',
   'pipeline.message.searchingArtist': 'Pesquisando {0}...',
   'pipeline.message.resolutionComplete': 'Resolução concluída',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Construindo o catálogo da sua biblioteca',
+  'firstSyncBanner.body':
+    'Digarr está comparando sua biblioteca com o MusicBrainz. O limite de taxa do MusicBrainz permite cerca de 60 artistas por minuto, então uma biblioteca de 5.000 artistas leva cerca de 80 minutos para ser totalmente reconciliada. Isso acontece apenas uma vez -- as sincronizações seguintes usam o cache local e terminam em segundos.',
+  'librarySync.message.syncingSource': 'Sincronizando {0}...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/ro.ts
+++ b/src/core/i18n/messages/ro.ts
@@ -1159,4 +1159,10 @@ export const ro = {
   'pipeline.message.resolvingArtist': 'Se rezolvă {0}...',
   'pipeline.message.searchingArtist': 'Se caută {0}...',
   'pipeline.message.resolutionComplete': 'Rezolvare completă',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Se construiește catalogul bibliotecii tale',
+  'firstSyncBanner.body':
+    'Digarr potrivește biblioteca ta cu MusicBrainz. Limita de rată MusicBrainz permite aproximativ 60 de artiști pe minut, deci o bibliotecă de 5.000 de artiști durează aproximativ 80 de minute pentru reconciliere completă. Acest proces are loc o singură dată -- sincronizările ulterioare folosesc memoria cache locală și se finalizează în câteva secunde.',
+  'librarySync.message.syncingSource': 'Se sincronizează {0}...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/ru.ts
+++ b/src/core/i18n/messages/ru.ts
@@ -1163,4 +1163,10 @@ export const ru = {
   'pipeline.message.resolvingArtist': 'Сопоставление {0}...',
   'pipeline.message.searchingArtist': 'Поиск {0}...',
   'pipeline.message.resolutionComplete': 'Сопоставление завершено',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Создание каталога вашей библиотеки',
+  'firstSyncBanner.body':
+    'Digarr сопоставляет вашу библиотеку с MusicBrainz. Лимит запросов MusicBrainz позволяет обрабатывать около 60 исполнителей в минуту, поэтому полное сопоставление библиотеки из 5 000 исполнителей занимает около 80 минут. Это происходит только один раз -- последующие синхронизации используют локальный кэш и завершаются за секунды.',
+  'librarySync.message.syncingSource': 'Синхронизация {0}...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/tr.ts
+++ b/src/core/i18n/messages/tr.ts
@@ -1151,4 +1151,10 @@ export const tr = {
   'pipeline.message.resolvingArtist': '{0} çözülüyor...',
   'pipeline.message.searchingArtist': '{0} aranıyor...',
   'pipeline.message.resolutionComplete': 'Çözüm tamamlandı',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Kitaplık kataloğun oluşturuluyor',
+  'firstSyncBanner.body':
+    'Digarr, kitaplığını MusicBrainz ile eşleştiriyor. MusicBrainz hız sınırı dakikada yaklaşık 60 sanatçıya izin verir, bu nedenle 5.000 sanatçılık bir kitaplığın tam olarak eşitlenmesi yaklaşık 80 dakika sürer. Bu sadece bir kez gerçekleşir -- sonraki eşitlemeler yerel önbelleği kullanır ve saniyeler içinde tamamlanır.',
+  'librarySync.message.syncingSource': '{0} eşitleniyor...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/uk.ts
+++ b/src/core/i18n/messages/uk.ts
@@ -1155,4 +1155,10 @@ export const uk = {
   'pipeline.message.resolvingArtist': 'Зіставлення {0}...',
   'pipeline.message.searchingArtist': 'Пошук {0}...',
   'pipeline.message.resolutionComplete': 'Зіставлення завершено',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': 'Створення каталогу вашої бібліотеки',
+  'firstSyncBanner.body':
+    'Digarr зіставляє вашу бібліотеку з MusicBrainz. Ліміт запитів MusicBrainz дозволяє приблизно 60 виконавців на хвилину, тому повне зіставлення бібліотеки з 5 000 виконавців займає близько 80 хвилин. Це відбувається лише один раз -- наступні синхронізації використовують локальний кеш і завершуються за кілька секунд.',
+  'librarySync.message.syncingSource': 'Синхронізація {0}...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -1086,4 +1086,10 @@ export const zhCN = {
   'pipeline.message.resolvingArtist': '正在解析 {0}...',
   'pipeline.message.searchingArtist': '正在搜索 {0}...',
   'pipeline.message.resolutionComplete': '解析完成',
+
+  // Batch 6: first-sync banner + library sync messages
+  'firstSyncBanner.title': '正在构建您的库目录',
+  'firstSyncBanner.body':
+    'Digarr 正在将您的库与 MusicBrainz 进行匹配。MusicBrainz 的速率限制约为每分钟 60 位艺术家,因此 5,000 位艺术家的库大约需要 80 分钟才能完全协调完成。这只发生一次 -- 后续同步使用本地缓存,几秒内即可完成。',
+  'librarySync.message.syncingSource': '正在同步 {0}...',
 } satisfies Partial<MessageCatalog>

--- a/src/core/library/sync.ts
+++ b/src/core/library/sync.ts
@@ -43,6 +43,7 @@ export type SyncSummary = {
 export type SyncOptions = {
   force?: boolean
   onProgress?: (msg: string) => void
+  t?: import('@/core/i18n/translator').Translator
 }
 
 export type SyncOrchestratorDeps = {
@@ -106,7 +107,11 @@ export function createSyncOrchestrator(deps: SyncOrchestratorDeps) {
         lastSyncError: null,
       })
 
-      options?.onProgress?.(`Syncing ${source.name}...`)
+      options?.onProgress?.(
+        options?.t
+          ? options.t('librarySync.message.syncingSource', source.name)
+          : `Syncing ${source.name}...`,
+      )
       const rawArtists = await source.listArtists()
 
       const overrides = userId != null ? await deps.store.getAllOverrides(userId) : new Map()

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -67,7 +67,11 @@ export interface PipelineDeps {
   librarySync: {
     syncForUser: (
       userId: number,
-      options?: { force?: boolean; onProgress?: (msg: string) => void },
+      options?: {
+        force?: boolean
+        onProgress?: (msg: string) => void
+        t?: import('@/core/i18n/translator').Translator
+      },
     ) => Promise<unknown>
   }
 }
@@ -229,6 +233,7 @@ export class PipelineOrchestrator extends EventEmitter {
       } else {
         await deps.librarySync.syncForUser(userIdForSync, {
           onProgress: (msg) => this.emit('progress', { stage: 'collect', message: msg }),
+          t,
         })
       }
 

--- a/src/web/components/admin/upgrade-section.tsx
+++ b/src/web/components/admin/upgrade-section.tsx
@@ -12,7 +12,7 @@ export function UpgradeSection() {
     queryFn: getPendingMigrations,
   })
 
-  if (!data) return <p className="text-sm text-muted">Loading...</p>
+  if (!data) return <p className="text-sm text-muted">{t('common.loading')}</p>
 
   return (
     <div className="space-y-3 pt-2">

--- a/src/web/components/album-picker.tsx
+++ b/src/web/components/album-picker.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 import { getAlbums } from '../lib/api'
+import { useI18n } from '../lib/i18n'
 import { ArtistThumb } from './artist-thumb'
 import { Button } from './ui/button'
 
@@ -42,6 +43,7 @@ export function AlbumPicker({
   onConfirm,
   onCancel,
 }: Props) {
+  const { t } = useI18n()
   const albumsQuery = useQuery({
     queryKey: ['albums', artistMbid],
     queryFn: () => getAlbums(artistMbid),
@@ -104,7 +106,7 @@ export function AlbumPicker({
             type="button"
             onClick={onCancel}
             className="text-muted hover:text-text transition-colors p-1"
-            aria-label="Close"
+            aria-label={t('common.close')}
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -136,7 +138,9 @@ export function AlbumPicker({
           )}
 
           {albumsQuery.isSuccess && sortedAlbums.length === 0 && (
-            <p className="text-sm text-muted text-center py-8">No release groups found</p>
+            <p className="text-sm text-muted text-center py-8">
+              {t('albumPicker.noReleaseGroups')}
+            </p>
           )}
 
           {albumsQuery.isSuccess && sortedAlbums.length > 0 && (

--- a/src/web/components/bottom-nav.tsx
+++ b/src/web/components/bottom-nav.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom'
+import { useI18n } from '../lib/i18n'
 import { cn } from '../lib/utils'
 
 // Icons (inline SVG -- consistent with existing component style)
@@ -99,10 +100,11 @@ const NAV_ITEMS = [
  * Fixed to bottom of screen, above any content via z-index.
  */
 export function BottomNav() {
+  const { t } = useI18n()
   return (
     <nav
       className="md:hidden fixed bottom-0 left-0 right-0 z-40 bg-bg border-t border-border"
-      aria-label="Mobile navigation"
+      aria-label={t('app.mobileNav')}
     >
       <div className="flex items-center justify-around h-14 px-2">
         {NAV_ITEMS.map(({ to, label, Icon, exact }) => (

--- a/src/web/components/genre-grid.tsx
+++ b/src/web/components/genre-grid.tsx
@@ -1,4 +1,5 @@
 import type { GenreInfo } from '../../core/genre/types'
+import { useI18n } from '../lib/i18n'
 import { GenreCard } from './genre-card'
 import { Skeleton } from './ui/skeleton'
 
@@ -25,6 +26,7 @@ function GenreSkeletonGrid() {
 }
 
 export function GenreGrid({ genres, loading = false }: GenreGridProps) {
+  const { t } = useI18n()
   if (loading) {
     return <GenreSkeletonGrid />
   }
@@ -32,7 +34,7 @@ export function GenreGrid({ genres, loading = false }: GenreGridProps) {
   if (genres.length === 0) {
     return (
       <div className="py-12 text-center">
-        <p className="text-muted text-sm">No genres found.</p>
+        <p className="text-muted text-sm">{t('genres.noneFound')}</p>
       </div>
     )
   }

--- a/src/web/components/hint.tsx
+++ b/src/web/components/hint.tsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react'
 import { useHints } from '../hooks/use-hints'
+import { useI18n } from '../lib/i18n'
 
 type HintProps = {
   id: string
@@ -10,6 +11,7 @@ type HintProps = {
 
 export function Hint({ id, type = 'inline', children, className = '' }: HintProps) {
   const { isHintDismissed, dismissHint } = useHints()
+  const { t } = useI18n()
 
   if (isHintDismissed(id)) return null
 
@@ -22,7 +24,7 @@ export function Hint({ id, type = 'inline', children, className = '' }: HintProp
         <button
           type="button"
           onClick={() => dismissHint(id)}
-          aria-label="Dismiss hint"
+          aria-label={t('hint.dismissHint')}
           className="shrink-0 text-muted hover:text-text transition-colors"
         >
           <X size={13} aria-hidden="true" />
@@ -40,7 +42,7 @@ export function Hint({ id, type = 'inline', children, className = '' }: HintProp
         <button
           type="button"
           onClick={() => dismissHint(id)}
-          aria-label="Dismiss hint"
+          aria-label={t('hint.dismissHint')}
           className="shrink-0 text-muted hover:text-text transition-colors"
         >
           <X size={13} aria-hidden="true" />
@@ -58,7 +60,7 @@ export function Hint({ id, type = 'inline', children, className = '' }: HintProp
           onClick={() => dismissHint(id)}
           className="text-xs text-muted hover:text-text transition-colors underline underline-offset-2"
         >
-          Dismiss
+          {t('common.dismiss')}
         </button>
       </div>
     )
@@ -73,7 +75,7 @@ export function Hint({ id, type = 'inline', children, className = '' }: HintProp
       <button
         type="button"
         onClick={() => dismissHint(id)}
-        aria-label="Dismiss hint"
+        aria-label={t('hint.dismissHint')}
         className="shrink-0 text-muted hover:text-text transition-colors"
       >
         <X size={13} aria-hidden="true" />

--- a/src/web/components/library-first-sync-banner.tsx
+++ b/src/web/components/library-first-sync-banner.tsx
@@ -2,10 +2,12 @@ import { useQuery } from '@tanstack/react-query'
 import { X } from 'lucide-react'
 import { useState } from 'react'
 import { getLibrarySources } from '../lib/api'
+import { useI18n } from '../lib/i18n'
 
 const STORAGE_KEY = 'digarr.firstSyncBannerDismissed'
 
 export function LibraryFirstSyncBanner() {
+  const { t } = useI18n()
   const [dismissed, setDismissed] = useState(() => {
     if (typeof window === 'undefined') return false
     return window.localStorage.getItem(STORAGE_KEY) === '1'
@@ -40,18 +42,13 @@ export function LibraryFirstSyncBanner() {
         type="button"
         onClick={dismiss}
         className="absolute top-3 right-3 text-muted hover:opacity-70 transition-opacity"
-        aria-label="Dismiss"
+        aria-label={t('common.dismiss')}
       >
         <X size={14} />
       </button>
       <div className="pr-6 space-y-1">
-        <div className="text-sm font-semibold text-text">Building your library catalog</div>
-        <div className="text-sm text-muted">
-          Digarr is matching your library against MusicBrainz. The MusicBrainz rate limit allows
-          roughly 60 artists per minute, so a 5,000-artist library takes around 80 minutes to fully
-          reconcile. This only happens once -- subsequent syncs use the local cache and complete in
-          seconds.
-        </div>
+        <div className="text-sm font-semibold text-text">{t('firstSyncBanner.title')}</div>
+        <div className="text-sm text-muted">{t('firstSyncBanner.body')}</div>
       </div>
     </div>
   )

--- a/src/web/components/mood-prompt-bar.tsx
+++ b/src/web/components/mood-prompt-bar.tsx
@@ -40,12 +40,12 @@ export function MoodPromptBar({
     setQueued((prev) => new Set([...prev, artistName]))
     try {
       await quickDiscover(artistName)
-      toast.success(`Added "${artistName}" and discovering similar artists`)
+      toast.success(t('discover.moodAddedSuccess').replace('{0}', artistName))
       // Seed artist is stored async on the backend -- poll for it to appear
       setTimeout(onQueued, 2000)
       setTimeout(onQueued, 5000)
     } catch {
-      toast.error(`Failed to add "${artistName}"`)
+      toast.error(t('discover.moodAddFailed').replace('{0}', artistName))
       setQueued((prev) => {
         const next = new Set(prev)
         next.delete(artistName)

--- a/src/web/components/preview-player.tsx
+++ b/src/web/components/preview-player.tsx
@@ -1,5 +1,6 @@
 import { Music, X } from 'lucide-react'
 import type { PreviewSource } from '@/web/hooks/use-preview'
+import { useI18n } from '../lib/i18n'
 
 const SOURCE_LABELS: Record<PreviewSource['type'], string> = {
   'spotify-embed': 'Spotify',
@@ -21,6 +22,7 @@ type Props = {
  * bottom-0. Only renders when a preview is active (loading or playing).
  */
 export function PreviewPlayer({ playing, artistName, source, loading, onStop }: Props) {
+  const { t } = useI18n()
   if (!playing && !loading) return null
 
   const sourceLabel = source ? SOURCE_LABELS[source.type] : null
@@ -29,7 +31,7 @@ export function PreviewPlayer({ playing, artistName, source, loading, onStop }: 
   return (
     <section
       className="fixed bottom-14 md:bottom-0 left-0 right-0 z-50 bg-surface border-t border-border shadow-lg"
-      aria-label="Preview player"
+      aria-label={t('preview.playerRegion')}
     >
       <div className="max-w-3xl mx-auto px-4 py-2">
         <div className="flex items-center gap-3">
@@ -37,13 +39,15 @@ export function PreviewPlayer({ playing, artistName, source, loading, onStop }: 
 
           <div className="flex-1 min-w-0">
             {loading && !artistName ? (
-              <span className="text-sm text-muted">Loading preview...</span>
+              <span className="text-sm text-muted">{t('preview.loadingPreview')}</span>
             ) : (
               <div className="flex items-center gap-2 min-w-0">
                 {artistName && (
                   <span className="text-sm text-text font-medium truncate">{artistName}</span>
                 )}
-                {loading && <span className="text-xs text-muted shrink-0">Loading...</span>}
+                {loading && (
+                  <span className="text-xs text-muted shrink-0">{t('common.loading')}</span>
+                )}
                 {!loading && sourceLabel && (
                   <span className="text-xs text-muted uppercase shrink-0">{sourceLabel}</span>
                 )}
@@ -55,10 +59,10 @@ export function PreviewPlayer({ playing, artistName, source, loading, onStop }: 
             type="button"
             onClick={onStop}
             className="shrink-0 flex items-center gap-1 px-2 py-1 rounded text-sm text-muted hover:text-text hover:bg-bg/50 transition-colors"
-            aria-label="Close preview"
+            aria-label={t('preview.closePreview')}
           >
             <X size={14} aria-hidden="true" />
-            <span className="hidden sm:inline">Close</span>
+            <span className="hidden sm:inline">{t('common.close')}</span>
           </button>
         </div>
 

--- a/src/web/components/streaming-links.tsx
+++ b/src/web/components/streaming-links.tsx
@@ -1,4 +1,5 @@
 import { isHttpUrl } from '@/core/validation'
+import { useI18n } from '../lib/i18n'
 
 type StreamingLinksProps = {
   streamingUrls: Record<string, string> | null
@@ -78,6 +79,7 @@ function extractSpotifyId(url: string): { type: string; id: string } | null {
 }
 
 function SpotifyEmbed({ url }: SpotifyEmbedProps) {
+  const { t } = useI18n()
   const parsed = extractSpotifyId(url)
   if (!parsed) return null
   const embedUrl = `https://open.spotify.com/embed/${parsed.type}/${parsed.id}?utm_source=generator`
@@ -89,7 +91,7 @@ function SpotifyEmbed({ url }: SpotifyEmbedProps) {
       allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
       loading="lazy"
       className="rounded border border-border mt-2"
-      title="Spotify preview"
+      title={t('streaming.spotifyEmbedTitle')}
     />
   )
 }
@@ -101,6 +103,7 @@ export function StreamingLinks({
   onPlay,
   isPlaying = false,
 }: StreamingLinksProps) {
+  const { t } = useI18n()
   const urls = streamingUrls ?? {}
 
   // Build the list of links: prefer direct URL, fall back to search URL for known services
@@ -140,7 +143,7 @@ export function StreamingLinks({
             onClick={onPlay}
             className="inline-flex items-center justify-center px-1.5 py-0.5 rounded text-micro font-bold border border-green-500/40 text-green-500 bg-surface/50 hover:opacity-80 transition-opacity"
           >
-            {isPlaying ? 'STOP' : 'PLAY'}
+            {isPlaying ? t('streaming.stopShort') : t('streaming.playShort')}
           </button>
         )}
         {links.map(({ key, label, url, color }) => (

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -1204,7 +1204,7 @@ export function DiscoverPage() {
           </button>
           <button
             type="button"
-            aria-label="Dismiss"
+            aria-label={t('common.dismiss')}
             onClick={() => {
               if (undoTimerRef.current) clearTimeout(undoTimerRef.current)
               setUndoEntry(null)


### PR DESCRIPTION
Follows up on #107. Closes the small-component i18n gaps from the original batch-5 audit and threads the orchestrator's translator one level deeper into the library sync.

## Components updated

- ``preview-player.tsx`` (player region, close, loading)
- ``streaming-links.tsx`` (PLAY/STOP, Spotify embed iframe title)
- ``mood-prompt-bar.tsx`` (success / failure toasts)
- ``album-picker.tsx`` (close + empty state)
- ``genre-grid.tsx`` (empty state)
- ``hint.tsx`` (3 aria-labels + dismiss button)
- ``library-first-sync-banner.tsx`` (dismiss + the title and body that explain MusicBrainz rate limits - those were not in the original audit but were obvious once the file was open)
- ``bottom-nav.tsx`` (aria-label)
- ``discover.tsx`` (undo-toast dismiss)
- ``admin/upgrade-section.tsx`` (loading fallback)

## Library sync

The librarySync ``onProgress`` callback bubbles \`\`Syncing {source}...\`\` up through the orchestrator's SSE stream. Added an optional ``t`` to ``SyncOptions``, threaded the orchestrator's translator through, kept a graceful English fallback when no translator is provided.

## New keys

3 new (firstSyncBanner.title, firstSyncBanner.body, librarySync.message.syncingSource) plus translations to all 14 locales. Catalog parity restored.

## Test plan

- [x] ``bun run typecheck`` clean
- [x] ``bun run lint`` clean
- [x] ``bun run i18n:check`` validates 15 locales
- [x] ``bun run test`` 1803/1804 (auth scrypt flake, unchanged by this PR - passes in isolation)
- [ ] CI green