### PR TITLE
feat(k8s): batch 6 - ServiceAccount + PDB + PSS restricted (v0.27.7)

### DIFF
--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.27.6
-appVersion: "0.27.6"
+version: 0.27.7
+appVersion: "0.27.7"

--- a/deploy/helm/digarr/templates/NOTES.txt
+++ b/deploy/helm/digarr/templates/NOTES.txt
@@ -1,5 +1,14 @@
 Digarr has been deployed!
 
+For defense-in-depth, label the namespace with Pod Security Standards so
+future pod specs that weaken the securityContext are rejected at admission:
+
+  kubectl label namespace {{ .Release.Namespace }} \
+    pod-security.kubernetes.io/enforce=restricted \
+    pod-security.kubernetes.io/enforce-version=latest \
+    pod-security.kubernetes.io/audit=restricted \
+    pod-security.kubernetes.io/warn=restricted --overwrite
+
 1. Get the application URL:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}

--- a/deploy/helm/digarr/templates/_helpers.tpl
+++ b/deploy/helm/digarr/templates/_helpers.tpl
@@ -71,6 +71,17 @@ PostgreSQL hostname -- bundled service or external host.
 {{- end }}
 
 {{/*
+ServiceAccount name -- uses override if supplied, otherwise derives from fullname.
+*/}}
+{{- define "digarr.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "digarr.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 App image reference -- prefer digest when provided.
 */}}
 {{- define "digarr.image" -}}

--- a/deploy/helm/digarr/templates/deployment.yaml
+++ b/deploy/helm/digarr/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         {{- include "digarr.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "digarr.serviceAccountName" . }}
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/deploy/helm/digarr/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/digarr/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (int .Values.replicaCount) 1) -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "digarr.fullname" . }}
+  labels:
+    {{- include "digarr.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "digarr.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/digarr/templates/postgresql.yaml
+++ b/deploy/helm/digarr/templates/postgresql.yaml
@@ -40,6 +40,7 @@ spec:
     spec:
       automountServiceAccountToken: false
       securityContext:
+        runAsNonRoot: true
         fsGroup: 999
         seccompProfile:
           type: RuntimeDefault
@@ -51,6 +52,9 @@ spec:
             runAsNonRoot: true
             runAsUser: 999
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - name: postgresql
               containerPort: 5432

--- a/deploy/helm/digarr/templates/serviceaccount.yaml
+++ b/deploy/helm/digarr/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "digarr.serviceAccountName" . }}
+  labels:
+    {{- include "digarr.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/digarr/values.schema.json
+++ b/deploy/helm/digarr/values.schema.json
@@ -18,6 +18,16 @@
       },
       "required": ["repository", "tag", "pullPolicy"]
     },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "automountServiceAccountToken": { "type": "boolean" },
+        "annotations": { "type": "object" }
+      },
+      "required": ["create", "automountServiceAccountToken"]
+    },
     "service": {
       "type": "object",
       "properties": {
@@ -30,6 +40,25 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" }
+      },
+      "required": ["enabled"]
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+%$" }
+          ]
+        },
+        "maxUnavailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+%$" }
+          ]
+        }
       },
       "required": ["enabled"]
     },
@@ -62,7 +91,15 @@
       "required": ["port", "name", "user", "password", "existingSecret"]
     }
   },
-  "required": ["image", "service", "networkPolicy", "postgresql", "database"],
+  "required": [
+    "image",
+    "serviceAccount",
+    "service",
+    "networkPolicy",
+    "podDisruptionBudget",
+    "postgresql",
+    "database"
+  ],
   "allOf": [
     {
       "if": {

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.27.6"
+  tag: "0.27.7"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
   digest: "sha256:be46740aa026f901ae9dbd2c0ff1337a96d28ddf2fe077ced8384602ae22ef9b"
   pullPolicy: Always
@@ -25,12 +25,31 @@ containerSecurityContext:
     drop:
       - ALL
 
+serviceAccount:
+  # Create a dedicated ServiceAccount with token automount disabled.
+  # Set create=false and supply serviceAccount.name to reuse an existing one
+  # (for example, one with IRSA / Workload Identity annotations).
+  create: true
+  name: ""
+  automountServiceAccountToken: false
+  annotations: {}
+
 service:
   type: ClusterIP
   port: 3000
 
 networkPolicy:
   enabled: true
+
+# PodDisruptionBudget protects the app from voluntary evictions during
+# node drains. Disabled by default because the chart ships replicaCount=1 --
+# a PDB with minAvailable=1 at replicas=1 blocks every drain. The template
+# also gates on replicaCount > 1, so flipping enabled=true without scaling
+# up is a no-op.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1  # alternative to minAvailable
 
 ingress:
   enabled: false

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         app: digarr
     spec:
+      serviceAccountName: digarr
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,14 @@
+# Digarr Namespace
+# Pod Security Standards labels fail-close any pod that does not satisfy
+# the "restricted" profile. If someone weakens the pod securityContext by
+# mistake, the API server rejects the admission.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: digarr
+  labels:
+    app: digarr
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/deploy/k8s/poddisruptionbudget.yaml
+++ b/deploy/k8s/poddisruptionbudget.yaml
@@ -1,0 +1,20 @@
+# Digarr PodDisruptionBudget
+# Only meaningful once replicas >= 2. A PDB with minAvailable=1 at replicas=1
+# blocks every voluntary disruption (node drains, cluster upgrades) because
+# the scheduler cannot guarantee 1 available pod while the single replica is
+# being evicted.
+#
+# Uncomment and apply once you scale the Deployment to 2+ replicas.
+# ---
+# apiVersion: policy/v1
+# kind: PodDisruptionBudget
+# metadata:
+#   name: digarr
+#   namespace: digarr
+#   labels:
+#     app: digarr
+# spec:
+#   minAvailable: 1
+#   selector:
+#     matchLabels:
+#       app: digarr

--- a/deploy/k8s/serviceaccount.yaml
+++ b/deploy/k8s/serviceaccount.yaml
@@ -1,0 +1,12 @@
+# Digarr ServiceAccount
+# Dedicated SA with token automount disabled. Defense-in-depth: the pod spec
+# also sets automountServiceAccountToken=false, but an SA-level default keeps
+# future pod specs safe if anyone forgets the pod-level flag.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: digarr
+  namespace: digarr   # match your namespace
+  labels:
+    app: digarr
+automountServiceAccountToken: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.27.6",
+  "version": "0.27.7",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Batch 6 of the 0.27.x hardening sweep. No runtime behavior change for the app.

## Summary

- **Dedicated ServiceAccount** on both Helm chart and raw manifests. SA has `automountServiceAccountToken: false` (defense-in-depth on top of the existing pod-level flag). New `serviceAccount.*` values let operators swap in a pre-existing SA for IRSA / Workload Identity.
- **PodDisruptionBudget** template in the Helm chart, gated on `podDisruptionBudget.enabled && replicaCount > 1` so the default (replicas=1) behavior is unchanged. Commented example in `deploy/k8s/poddisruptionbudget.yaml`.
- **Pod Security Standards labels**: new `deploy/k8s/namespace.yaml` with `enforce=restricted`. Helm `NOTES.txt` emits the equivalent `kubectl label` command.
- **Postgres StatefulSet** container securityContext now drops `ALL` capabilities and sets pod-level `runAsNonRoot: true` explicitly so the bundled Postgres passes PSS restricted.
- `values.schema.json` updated with required `serviceAccount` + `podDisruptionBudget` blocks.

## Out of scope (already shipped)

- Image digest pinning: already in `_helpers.tpl` (`digarr.image` prefers digest over tag) and `values.yaml`.
- Helm/raw NetworkPolicy drift: already in parity.

## Test plan

- [x] ``helm lint deploy/helm/digarr --set postgresql.auth.password=test`` clean
- [x] ``helm template`` renders correctly with default values, ``serviceAccount.create=false`` + custom name, and ``podDisruptionBudget.enabled=true`` at replicas=3
- [x] ``helm template ... --set podDisruptionBudget.enabled=true`` at replicas=1 renders no PDB (expected)
- [x] ``kubectl apply --dry-run=client`` on both Helm render and raw manifests
- [x] ``bun run lint``, ``bun run typecheck``, ``bun run i18n:check`` clean
- [x] ``bun run test`` 1804 pass (scrypt flake passed this run)
- [ ] CI green