### PR TITLE
feat(ci): SHA-pin runner images + cosign keyless signing (v0.27.8)

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   lint-typecheck-test:
     runs-on: docker
     container:
-      image: oven/bun:1.3.11
+      image: oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7
     steps:
       - name: Install git
         run: apt-get update -qq && apt-get install -y -qq git > /dev/null
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: docker
     container:
-      image: oven/bun:1.3.11
+      image: oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7
     needs: lint-typecheck-test
     steps:
       - name: Install git
@@ -39,11 +39,11 @@ jobs:
   api-route-test:
     runs-on: docker
     container:
-      image: oven/bun:1.3.11
+      image: oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7
     needs: build
     services:
       postgres:
-        image: postgres:17-alpine
+        image: postgres:17-alpine@sha256:6f30057d31f5861b66f3545d4821f987aacf1dd920765f0acadea0c58ff975b1
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
@@ -68,11 +68,11 @@ jobs:
   browser-test:
     runs-on: docker
     container:
-      image: oven/bun:1.3.11
+      image: oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7
     needs: api-route-test
     services:
       postgres:
-        image: postgres:17-alpine
+        image: postgres:17-alpine@sha256:6f30057d31f5861b66f3545d4821f987aacf1dd920765f0acadea0c58ff975b1
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test

--- a/.forgejo/workflows/release.yml
+++ b/.forgejo/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   quality-gate:
     runs-on: docker
     container:
-      image: oven/bun:1.3.11
+      image: oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7
     steps:
       - name: Install git
         run: apt-get update -qq && apt-get install -y -qq git > /dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,15 +37,16 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write # cosign keyless signing via Sigstore OIDC
     strategy:
       matrix:
         include:
           - variant: debian
-            runtime-image: "oven/bun:1.3.11-slim"
+            runtime-image: "oven/bun:1.3.11-slim@sha256:478281fdd196871c7e51ba6a820b7803a8ae97042ec86cdbc2e1c6b6626442d9"
             suffix: ""
             latest: "auto"
           - variant: alpine
-            runtime-image: "oven/bun:1.3.11-alpine"
+            runtime-image: "oven/bun:1.3.11-alpine@sha256:7ed9f74c326d1c260abe247ac423ccbf5ac92af62bb442d515d1f92f21e8ea9b"
             suffix: "-alpine"
             latest: "false"
     steps:
@@ -56,6 +57,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Log in to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
@@ -93,6 +97,7 @@ jobs:
             type=raw,value=alpine,enable=${{ matrix.variant == 'alpine' }},suffix=
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: .
@@ -103,6 +108,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             RUNTIME_IMAGE=${{ matrix.runtime-image }}
+
+      - name: Sign images (cosign keyless)
+        env:
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKER_IMAGE: docker.io/iuliandita/digarr
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${GHCR_IMAGE}@${DIGEST}"
+          cosign sign --yes "${DOCKER_IMAGE}@${DIGEST}"
 
       - name: Generate SBOM (container)
         if: matrix.variant == 'debian'
@@ -119,6 +133,16 @@ jobs:
           path: .
           artifact-name: sbom-source.spdx.json
           output-file: sbom-source.spdx.json
+
+      - name: Attest SBOM (container) via cosign
+        if: matrix.variant == 'debian'
+        env:
+          GHCR_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DOCKER_IMAGE: docker.io/iuliandita/digarr
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest --yes --type spdxjson --predicate sbom-container.spdx.json "${GHCR_IMAGE}@${DIGEST}"
+          cosign attest --yes --type spdxjson --predicate sbom-container.spdx.json "${DOCKER_IMAGE}@${DIGEST}"
 
       - name: Ensure release exists and upload SBOMs
         if: matrix.variant == 'debian'

--- a/README.md
+++ b/README.md
@@ -181,6 +181,29 @@ Admin tools available under Settings > Administration > Data Hygiene:
 | Synology NAS | [`docs/guides/synology.md`](docs/guides/synology.md) | DSM 7.1+ (Docker/Container Manager). SSH or GUI. |
 | Docker Desktop | [`docs/guides/docker-desktop.md`](docs/guides/docker-desktop.md) | macOS and Windows (WSL 2). |
 
+### Verifying image signatures
+
+Since v0.27.8, every release image is signed with [cosign](https://github.com/sigstore/cosign) using GitHub OIDC (no long-lived keys). Signatures are stored alongside the image at both `ghcr.io/iuliandita/digarr` and `docker.io/iuliandita/digarr`. The generated SBOM is attached as a signed SPDX attestation bound to the same image digest.
+
+Install cosign and verify a pulled image before running it:
+
+```sh
+# Replace <TAG> with the version you pulled, e.g. 0.27.8
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/iuliandita/digarr/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  ghcr.io/iuliandita/digarr:<TAG>
+
+# Verify the signed SBOM
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp '^https://github\.com/iuliandita/digarr/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  ghcr.io/iuliandita/digarr:<TAG>
+```
+
+A successful verify proves the image was built by this repo's `release.yml` workflow on a tagged push. Any tampering or registry compromise after publication would fail verification.
+
 ## Friends
 
 Other self-hosted music discovery projects:

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 
 # Global ARG -- must be before any FROM to use in FROM instructions
-ARG RUNTIME_IMAGE=oven/bun:1.3.11-slim
+ARG RUNTIME_IMAGE=oven/bun:1.3.11-slim@sha256:478281fdd196871c7e51ba6a820b7803a8ae97042ec86cdbc2e1c6b6626442d9
 
 # Build stage -- always Debian for consistent toolchain
-FROM oven/bun:1.3.11 AS builder
+FROM oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7 AS builder
 WORKDIR /app
 COPY package.json bun.lock* ./
 RUN bun install --frozen-lockfile

--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.27.7
-appVersion: "0.27.7"
+version: 0.27.8
+appVersion: "0.27.8"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.27.7"
+  tag: "0.27.8"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
   digest: "sha256:0161a61cae342413d62bd70ac2fcb00f9125db4f0c887a29204362404fb6b8c8"
   pullPolicy: Always

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.27.7",
+  "version": "0.27.8",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Batch 7 of the 0.27.x hardening sweep. Closes the mutable-tag exposure on both CI paths and adds verifiable image provenance without any key management.

## Summary

- **SHA-pin all runner/base images** (SEV-009 fix):
  - ``.forgejo/workflows/ci.yml``: 4 × ``oven/bun:1.3.11`` + 2 × ``postgres:17-alpine`` pinned by ``@sha256`` digest.
  - ``.forgejo/workflows/release.yml``: ``oven/bun:1.3.11`` quality-gate runner pinned.
  - ``deploy/docker/Dockerfile``: builder FROM + default ``RUNTIME_IMAGE`` ARG pinned.
  - ``.github/workflows/release.yml`` matrix: both bun-slim and bun-alpine variants pinned.
- **Cosign keyless signing** in ``.github/workflows/release.yml``:
  - Installs ``sigstore/cosign-installer@v4.1.1`` (SHA-pinned).
  - Adds ``id-token: write`` for Sigstore OIDC.
  - Signs the pushed image at both ``ghcr.io`` and ``docker.io`` by immutable digest via OIDC (no private key, no secret rotation).
  - ``cosign attest`` binds the existing SPDX SBOM to the image digest.
- **README.md**: verification recipe with ``cosign verify`` and ``cosign verify-attestation`` showing the ``certificate-identity-regexp`` + ``certificate-oidc-issuer`` flags that pin the signer to this repo's ``release.yml``.

## Why keyless

``ROADMAP.md`` had cosign under Parked, pending a decision between GitHub OIDC keyless vs self-managed keys. Keyless resolves the decision: the signing identity IS the workflow run - no keys to store, rotate, or lose. Provenance is cryptographically bound to ``github.com/iuliandita/digarr/.github/workflows/release.yml@refs/tags/v<tag>``.

## What is NOT in this batch

- SLSA provenance generator (separate effort).
- Forgejo-side signing (needs Forgejo OIDC research).
- Admission-time signature verification at the K8s side (future batch).
- Existing pre-v0.27.8 images remain unsigned by design.

## Test plan

- [x] ``actionlint`` clean on ``.github/workflows/release.yml``
- [x] YAML parse clean on all three workflows
- [x] ``bun run lint``, ``bun run typecheck``, ``bun run i18n:check`` clean
- [ ] CI green (lint/typecheck/test/api/browser on both GitHub and Forgejo)
- [ ] Release workflow exercises the new cosign steps on the ``v0.27.8`` tag push