### PR TITLE
feat(api): Zod validation on critical write routes (v0.27.9)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,13 +7,16 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.88.0",
         "@hono/node-server": "^1.19.13",
+        "@hono/zod-validator": "^0.7.6",
         "croner": "^10.0.1",
         "drizzle-orm": "^0.45.2",
+        "drizzle-zod": "^0.8.3",
         "hono": "^4.12.12",
         "openai": "^6.31.0",
         "openid-client": "^6.8.2",
         "p-queue": "^9.1.0",
         "pg": "^8.20.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
@@ -183,6 +186,8 @@
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
+    "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -411,6 +416,8 @@
     "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
+    "drizzle-zod": ["drizzle-zod@0.8.3", "", { "peerDependencies": { "drizzle-orm": ">=0.36.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-66yVOuvGhKJnTdiqj1/Xaaz9/qzOdRJADpDa68enqS6g3t0kpNkwNYjUuaeXgZfO/UWuIM9HIhSlJ6C5ZraMww=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -783,6 +790,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.27.8
-appVersion: "0.27.8"
+version: 0.27.9
+appVersion: "0.27.9"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.27.8"
+  tag: "0.27.9"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
   digest: "sha256:7b7105d1c1e14ca8f532bdc1dd5391e331a7c30a8bdc00895d81055de0939d6e"
   pullPolicy: Always

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.27.8",
+  "version": "0.27.9",
   "type": "module",
   "private": true,
   "scripts": {
@@ -60,12 +60,15 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
     "@hono/node-server": "^1.19.13",
+    "@hono/zod-validator": "^0.7.6",
     "croner": "^10.0.1",
     "drizzle-orm": "^0.45.2",
+    "drizzle-zod": "^0.8.3",
     "hono": "^4.12.12",
     "openai": "^6.31.0",
     "openid-client": "^6.8.2",
     "p-queue": "^9.1.0",
-    "pg": "^8.20.0"
+    "pg": "^8.20.0",
+    "zod": "^4.3.6"
   }
 }

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -12,6 +12,7 @@ import {
 import type { BackupFile, OpsDb } from '@/core/ops/types'
 import { getPendingMigrations } from '@/core/ops/upgrade'
 import { mergePreferences, type Preferences } from '@/db/schema'
+import { backupFileSchema } from '@/server/schemas/admin'
 import type { HonoEnv } from '@/server/types'
 
 export interface AdminDeps {
@@ -51,12 +52,16 @@ export function adminRoutes(deps: AdminDeps) {
     })
   })
 
-  // POST /api/admin/restore -- upload and restore backup JSON
+  // POST /api/admin/restore -- upload and restore backup JSON.
+  // Dual-format (multipart + raw JSON) rules out zJson middleware; we parse
+  // then validate with the same schema in-handler. Zod catches prototype
+  // pollution, missing top-level keys, and non-array table payloads before
+  // restoreBackup touches the DB.
   router.post('/api/admin/restore', async (c) => {
     const force = c.req.query('force') === 'true'
     const contentType = c.req.header('content-type') ?? ''
 
-    let backup: BackupFile
+    let raw: unknown
     try {
       if (contentType.includes('multipart/form-data')) {
         const form = await c.req.formData()
@@ -65,17 +70,32 @@ export function adminRoutes(deps: AdminDeps) {
           return c.json({ error: 'No file provided' }, 400)
         }
         const text = await file.text()
-        backup = JSON.parse(text)
+        raw = JSON.parse(text)
       } else {
-        backup = await c.req.json<BackupFile>()
+        raw = await c.req.json()
       }
     } catch {
       return c.json({ error: 'Invalid backup file format' }, 400)
     }
 
-    if (!backup.version || !backup.data) {
-      return c.json({ error: 'Invalid backup file structure' }, 400)
+    const parsed = backupFileSchema.safeParse(raw)
+    if (!parsed.success) {
+      const first = parsed.error.issues[0]
+      const where = first?.path.length ? first.path.join('.') : 'root'
+      return c.json(
+        {
+          error: `Invalid backup file structure at ${where}: ${first?.message ?? 'unknown'}`,
+          code: 'validation_failed' as const,
+          details: parsed.error.issues.map((i) => ({
+            path: i.path,
+            code: i.code,
+            message: i.message,
+          })),
+        },
+        400,
+      )
     }
+    const backup: BackupFile = parsed.data as BackupFile
 
     let result: Awaited<ReturnType<typeof restoreBackup>>
     try {

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -12,6 +12,8 @@ import { updateUserPreferences } from '@/db/queries/users'
 import { mergePreferences, type Preferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
 import { resolveRequestLocale } from '@/server/locale'
+import { changePasswordSchema, registerSchema } from '@/server/schemas/auth'
+import { zJson } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 const ALLOWED_PREF_KEYS = new Set([
@@ -64,8 +66,7 @@ export function authRoutes(deps: AppDependencies) {
   }
 
   // Register a new user. First user becomes admin.
-  router.post('/api/auth/register', async (c) => {
-    const messages = getRequestMessages(c)
+  router.post('/api/auth/register', zJson(registerSchema), async (c) => {
     // Registration closed by default after first user. Set DIGARR_DISABLE_REGISTRATION=false to open.
     const userCount = await deps.getUserCount()
     if (userCount > 0 && envConfig.disableRegistration) {
@@ -78,18 +79,7 @@ export function authRoutes(deps: AppDependencies) {
       )
     }
 
-    const body = await c.req.json()
-    const { username, password } = body as { username?: string; password?: string }
-
-    if (!username || !password) {
-      return c.json({ error: messages['auth.credentialsRequired'] }, 400)
-    }
-    if (username.length < 2 || username.length > 50) {
-      return c.json({ error: 'Username must be 2-50 characters' }, 400)
-    }
-    if (password.length < 8) {
-      return c.json({ error: 'Password must be at least 8 characters' }, 400)
-    }
+    const { username, password } = c.req.valid('json')
 
     const existingUser = await deps.getUserByUsername(username)
     if (existingUser) {
@@ -107,11 +97,18 @@ export function authRoutes(deps: AppDependencies) {
     return c.json({ user, token }, 201)
   })
 
-  // Login with username + password
+  // Login with username + password.
+  // Keeps manual validation so the "credentials required" error stays
+  // i18n'd via the request-locale messages bundle -- login is the most
+  // user-visible error surface and the existing locales cover it.
   router.post('/api/auth/login', async (c) => {
     const messages = getRequestMessages(c)
-    const body = await c.req.json()
-    const { username, password } = body as { username?: string; password?: string }
+    const body = (await c.req.json().catch(() => null)) as {
+      username?: unknown
+      password?: unknown
+    } | null
+    const username = typeof body?.username === 'string' ? body.username : ''
+    const password = typeof body?.password === 'string' ? body.password : ''
 
     if (!username || !password) {
       return c.json({ error: messages['auth.credentialsRequired'] }, 400)
@@ -187,22 +184,11 @@ export function authRoutes(deps: AppDependencies) {
   })
 
   // Change password for the current session user (requires session auth, not legacy token)
-  router.post('/api/auth/change-password', async (c) => {
+  router.post('/api/auth/change-password', zJson(changePasswordSchema), async (c) => {
     const auth = requireSessionUser(c)
     if (!auth.ok) return auth.response
 
-    const body = await c.req.json()
-    const { currentPassword, newPassword } = body as {
-      currentPassword?: string
-      newPassword?: string
-    }
-
-    if (!currentPassword || !newPassword) {
-      return c.json({ error: 'Current password and new password are required' }, 400)
-    }
-    if (newPassword.length < 8) {
-      return c.json({ error: 'New password must be at least 8 characters' }, 400)
-    }
+    const { currentPassword, newPassword } = c.req.valid('json')
 
     const user = await deps.getUserById(auth.userId)
     if (!user) {

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -10,6 +10,8 @@ import type { Preferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
 import { resolveRequestMessages } from '@/server/locale'
 import { resolveAdmin } from '@/server/middleware/admin-guard'
+import { updateSettingsSchema } from '@/server/schemas/settings'
+import { zJson } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 const SECRET_FIELDS = [
@@ -185,18 +187,11 @@ export function settingsRoutes(deps: AppDependencies) {
 
   const ALL_MUTABLE_FIELDS = new Set([...GLOBAL_MUTABLE_FIELDS, ...USER_CONNECTION_FIELDS])
 
-  router.patch('/api/settings', async (c) => {
-    const body = await c.req.json()
+  router.patch('/api/settings', zJson(updateSettingsSchema), async (c) => {
+    const body = c.req.valid('json')
     const sanitized: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
-      if (key === 'librarySyncIntervalHours') {
-        if (!Number.isInteger(value) || (value as number) < 1 || (value as number) > 24) {
-          return c.json(
-            { error: 'librarySyncIntervalHours must be an integer between 1 and 24' },
-            400,
-          )
-        }
-      }
+      if (value === undefined) continue
       if (ALL_MUTABLE_FIELDS.has(key)) {
         sanitized[key] = value
       }

--- a/src/server/routes/targets.ts
+++ b/src/server/routes/targets.ts
@@ -1,11 +1,14 @@
 import { Hono } from 'hono'
-import { TARGET_TYPES } from '@/core/targets/types'
 import type { ServiceTestResult } from '@/core/types'
 import type { TargetInsert, TargetRow, TargetUpdate } from '@/db/queries/targets'
 import { resolveAdmin } from '@/server/middleware/admin-guard'
+import {
+  createTargetSchema,
+  targetIdParamSchema,
+  updateTargetSchema,
+} from '@/server/schemas/targets'
+import { zJson, zParam } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
-
-const VALID_TARGET_TYPES: ReadonlySet<string> = new Set(TARGET_TYPES)
 
 type TargetDeps = {
   targetQueries: {
@@ -41,7 +44,7 @@ export function targetRoutes(deps: TargetDeps) {
     )
   })
 
-  router.post('/api/targets', async (c) => {
+  router.post('/api/targets', zJson(createTargetSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
@@ -55,26 +58,7 @@ export function targetRoutes(deps: TargetDeps) {
     )
       return c.json({ error: 'Admin access required' }, 403)
 
-    const body = await c.req.json()
-    const { type, name, config } = body as {
-      type?: string
-      name?: string
-      config?: Record<string, unknown>
-    }
-
-    if (!type || !name || !config) {
-      return c.json({ error: 'type, name, and config are required' }, 400)
-    }
-    if (!VALID_TARGET_TYPES.has(type)) {
-      return c.json({ error: `Invalid target type: ${type}` }, 400)
-    }
-
-    // SSRF check for URL fields
-    if (typeof config.url === 'string') {
-      if (!config.url.startsWith('http://') && !config.url.startsWith('https://')) {
-        return c.json({ error: 'URL must start with http:// or https://' }, 400)
-      }
-    }
+    const { type, name, config } = c.req.valid('json')
 
     const result = await deps.targetQueries.createTarget({
       type,
@@ -85,7 +69,37 @@ export function targetRoutes(deps: TargetDeps) {
     return c.json(result, 201)
   })
 
-  router.patch('/api/targets/:id', async (c) => {
+  router.patch(
+    '/api/targets/:id',
+    zParam(targetIdParamSchema),
+    zJson(updateTargetSchema),
+    async (c) => {
+      const userId = c.get('userId')
+      if (!userId) return c.json({ error: 'Unauthorized' }, 401)
+
+      if (
+        !(await resolveAdmin(
+          userId,
+          deps.getUserById,
+          c.get('authSkipped'),
+          c.get('legacyTokenAuth'),
+        ))
+      )
+        return c.json({ error: 'Admin access required' }, 403)
+
+      const { id } = c.req.valid('param')
+      const target = await deps.targetQueries.getTarget(id)
+      if (!target || target.userId !== userId) {
+        return c.json({ error: 'Target not found' }, 404)
+      }
+
+      const allowed: TargetUpdate = c.req.valid('json')
+      await deps.targetQueries.updateTarget(id, allowed)
+      return c.json({ success: true })
+    },
+  )
+
+  router.delete('/api/targets/:id', zParam(targetIdParamSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
@@ -99,39 +113,7 @@ export function targetRoutes(deps: TargetDeps) {
     )
       return c.json({ error: 'Admin access required' }, 403)
 
-    const id = Number(c.req.param('id'))
-    if (!Number.isFinite(id)) return c.json({ error: 'Invalid target ID' }, 400)
-    const target = await deps.targetQueries.getTarget(id)
-    if (!target || target.userId !== userId) {
-      return c.json({ error: 'Target not found' }, 404)
-    }
-
-    const body = await c.req.json()
-    const allowed: TargetUpdate = {}
-    if (body.name !== undefined) allowed.name = body.name
-    if (body.config !== undefined) allowed.config = body.config
-    if (body.enabled !== undefined) allowed.enabled = body.enabled
-
-    await deps.targetQueries.updateTarget(id, allowed)
-    return c.json({ success: true })
-  })
-
-  router.delete('/api/targets/:id', async (c) => {
-    const userId = c.get('userId')
-    if (!userId) return c.json({ error: 'Unauthorized' }, 401)
-
-    if (
-      !(await resolveAdmin(
-        userId,
-        deps.getUserById,
-        c.get('authSkipped'),
-        c.get('legacyTokenAuth'),
-      ))
-    )
-      return c.json({ error: 'Admin access required' }, 403)
-
-    const id = Number(c.req.param('id'))
-    if (!Number.isFinite(id)) return c.json({ error: 'Invalid target ID' }, 400)
+    const { id } = c.req.valid('param')
     const target = await deps.targetQueries.getTarget(id)
     if (!target || target.userId !== userId) {
       return c.json({ error: 'Target not found' }, 404)
@@ -141,12 +123,11 @@ export function targetRoutes(deps: TargetDeps) {
     return c.body(null, 204)
   })
 
-  router.post('/api/targets/:id/test', async (c) => {
+  router.post('/api/targets/:id/test', zParam(targetIdParamSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    const id = Number(c.req.param('id'))
-    if (!Number.isFinite(id)) return c.json({ error: 'Invalid target ID' }, 400)
+    const { id } = c.req.valid('param')
     const target = await deps.targetQueries.getTarget(id)
     if (!target || target.userId !== userId) {
       return c.json({ error: 'Target not found' }, 404)

--- a/src/server/routes/users.ts
+++ b/src/server/routes/users.ts
@@ -2,6 +2,8 @@ import { type Context, Hono } from 'hono'
 import { hashPassword } from '@/core/auth'
 import type { AppDependencies } from '@/server'
 import { resolveAdmin } from '@/server/middleware/admin-guard'
+import { createUserSchema, updateUserSchema, userIdParamSchema } from '@/server/schemas/users'
+import { zJson, zParam } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 export function userRoutes(deps: AppDependencies) {
@@ -39,21 +41,11 @@ export function userRoutes(deps: AppDependencies) {
   })
 
   // POST /api/users -- create a new user (admin only)
-  router.post('/api/users', async (c) => {
+  router.post('/api/users', zJson(createUserSchema), async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
 
-    const body = (await c.req.json()) as Record<string, unknown>
-    const username = typeof body.username === 'string' ? body.username.trim() : ''
-    const password = typeof body.password === 'string' ? body.password : ''
-    const isAdmin = body.isAdmin === true
-
-    if (!username || username.length < 2 || username.length > 50) {
-      return c.json({ error: 'Username must be 2-50 characters' }, 400)
-    }
-    if (password.length < 8) {
-      return c.json({ error: 'Password must be at least 8 characters' }, 400)
-    }
+    const { username, password, isAdmin } = c.req.valid('json')
 
     const existing = await deps.getUserByUsername(username)
     if (existing) {
@@ -68,16 +60,14 @@ export function userRoutes(deps: AppDependencies) {
   // PATCH /api/users/:id -- update user (admin only)
   // Body: { isAdmin?: boolean }
   // Guards: can't remove own admin role, can't remove last admin
-  router.patch('/api/users/:id', async (c) => {
+  router.patch('/api/users/:id', zParam(userIdParamSchema), zJson(updateUserSchema), async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
     const caller = await deps.getUserById(auth.userId)
     if (!caller) return c.json({ error: 'Admin access required' }, 403)
 
-    const targetId = Number(c.req.param('id'))
-    if (!Number.isFinite(targetId)) return c.json({ error: 'Invalid user id' }, 400)
-
-    const body = (await c.req.json()) as Record<string, unknown>
+    const { id: targetId } = c.req.valid('param')
+    const body = c.req.valid('json')
 
     // Guard: admin cannot remove their own admin role
     if (body.isAdmin === false && caller.id === targetId) {
@@ -101,14 +91,13 @@ export function userRoutes(deps: AppDependencies) {
 
   // DELETE /api/users/:id -- delete user (admin only)
   // Guards: can't delete self, can't delete last admin
-  router.delete('/api/users/:id', async (c) => {
+  router.delete('/api/users/:id', zParam(userIdParamSchema), async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
     const caller = await deps.getUserById(auth.userId)
     if (!caller) return c.json({ error: 'Admin access required' }, 403)
 
-    const targetId = Number(c.req.param('id'))
-    if (!Number.isFinite(targetId)) return c.json({ error: 'Invalid user id' }, 400)
+    const { id: targetId } = c.req.valid('param')
 
     if (caller.id === targetId) {
       return c.json({ error: 'Cannot delete your own account' }, 400)

--- a/src/server/schemas/admin.ts
+++ b/src/server/schemas/admin.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+
+// Backup data table rows are shape-heterogeneous (22 tables, mixed schemas),
+// so each table is typed as an array of records. restoreBackup is the
+// authoritative filter for column-level validation; this schema catches
+// the prototype pollution surface (non-array `data.*`, wrong top-level
+// types) before restore logic runs.
+const tableArray = z.array(z.record(z.string(), z.unknown()))
+
+export const backupDataSchema = z
+  .object({
+    settings: tableArray,
+    users: tableArray,
+    oauthTokens: tableArray,
+    oidcTokens: tableArray,
+    targets: tableArray,
+    subscriptions: tableArray,
+    jobRuns: tableArray,
+    recommendationBatches: tableArray,
+    recommendations: tableArray,
+    playlists: tableArray,
+    playlistTracks: tableArray,
+    artists: tableArray.optional(),
+    genres: tableArray.optional(),
+    artistMetadata: tableArray.optional(),
+  })
+  .passthrough()
+
+export const backupFileSchema = z.object({
+  version: z.number().int().positive(),
+  appVersion: z.string().min(1),
+  createdAt: z.string().min(1),
+  encryptionKeyHash: z.string().nullable(),
+  includesCaches: z.boolean(),
+  data: backupDataSchema,
+})
+
+export type BackupFileInput = z.infer<typeof backupFileSchema>

--- a/src/server/schemas/auth.ts
+++ b/src/server/schemas/auth.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+export const usernameSchema = z
+  .string()
+  .trim()
+  .min(2, 'Username must be 2-50 characters')
+  .max(50, 'Username must be 2-50 characters')
+
+export const passwordSchema = z.string().min(8, 'Password must be at least 8 characters')
+
+export const registerSchema = z.object({
+  username: usernameSchema,
+  password: passwordSchema,
+})
+
+export const loginSchema = z.object({
+  username: z.string().min(1, 'Username is required'),
+  password: z.string().min(1, 'Password is required'),
+})
+
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required'),
+  newPassword: passwordSchema.refine(
+    (val) => val.length >= 8,
+    'New password must be at least 8 characters',
+  ),
+})
+
+export const updateLocaleSchema = z.object({
+  preferredLocale: z.string().nullable(),
+})

--- a/src/server/schemas/settings.ts
+++ b/src/server/schemas/settings.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod'
+
+// Inner preferences object. Enforces numeric ranges where they exist and
+// keeps other fields permissive enough that partial merges (the normal PATCH
+// pattern) still pass. Passthrough catches any legacy key still in flight --
+// the merge in handlers is the authoritative filter.
+const scoringWeightsSchema = z
+  .object({
+    consensus: z.number().min(0).max(1).optional(),
+    similarity: z.number().min(0).max(1).optional(),
+    genreOverlap: z.number().min(0).max(1).optional(),
+    aiConfidence: z.number().min(0).max(1).optional(),
+    feedbackBoost: z.number().min(0).max(1).optional(),
+    popularity: z.number().min(0).max(1).optional(),
+  })
+  .partial()
+
+const preferencesSchema = z
+  .object({
+    qualityProfileId: z.number().int().optional(),
+    metadataProfileId: z.number().int().optional(),
+    rootFolderId: z.number().int().optional(),
+    scheduleCron: z.string().optional(),
+    scoreThreshold: z.number().min(0).max(1).optional(),
+    scoringWeights: scoringWeightsSchema.optional(),
+    rejectionCooldownDays: z.number().int().min(0).optional(),
+    topArtistsLimit: z.number().int().min(1).optional(),
+    librarySeedRatio: z.number().min(0).max(1).optional(),
+    webhookUrl: z.string().optional(),
+    lidarrPublicUrl: z.string().optional(),
+    autoApproveEnabled: z.boolean().optional(),
+    autoApproveThreshold: z.number().min(0).max(1).optional(),
+    autoApproveMonitorOption: z.enum(['all', 'new', 'none']).optional(),
+    playlistSize: z.number().int().min(1).optional(),
+    playlistSchedule: z.string().optional(),
+    playlistEnabled: z.boolean().optional(),
+    dismissedHints: z.array(z.string()).optional(),
+    subscriptionMode: z.enum(['active', 'ai-only']).nullable().optional(),
+    fanartApiKey: z.string().optional(),
+    metadataFallbackUrl: z.string().optional(),
+  })
+  .passthrough()
+
+// PATCH body for /api/settings. Every field optional -- it's a partial update.
+// Unknown top-level keys are silently stripped (matches the existing allowlist
+// behavior). Per-field types prevent accidental string-where-number bugs from
+// the UI or curl.
+export const updateSettingsSchema = z.object({
+  // Lidarr (global, admin-only in handler)
+  lidarrUrl: z.string().optional(),
+  lidarrApiKey: z.string().optional(),
+  skipTlsVerify: z.boolean().optional(),
+  librarySyncIntervalHours: z.number().int().min(1).max(24).optional(),
+
+  // AI (global, admin-only)
+  aiProvider: z.string().optional(),
+  aiApiKey: z.string().optional(),
+  aiModel: z.string().optional(),
+  aiBaseUrl: z.string().optional(),
+
+  // Preferences (nested)
+  preferences: preferencesSchema.optional(),
+
+  // OIDC (global, admin-only)
+  oidcIssuerUrl: z.string().optional(),
+  oidcClientId: z.string().optional(),
+  oidcClientSecret: z.string().optional(),
+  oidcScopes: z.string().optional(),
+
+  // Per-user connection fields (persisted on users table; user-scoped)
+  listenbrainzUsername: z.string().nullable().optional(),
+  listenbrainzToken: z.string().nullable().optional(),
+  lastfmUsername: z.string().nullable().optional(),
+  lastfmApiKey: z.string().nullable().optional(),
+  plexUrl: z.string().nullable().optional(),
+  plexToken: z.string().nullable().optional(),
+  jellyfinUrl: z.string().nullable().optional(),
+  jellyfinApiKey: z.string().nullable().optional(),
+  jellyfinUserId: z.string().nullable().optional(),
+  embyUrl: z.string().nullable().optional(),
+  embyApiKey: z.string().nullable().optional(),
+  embyUserId: z.string().nullable().optional(),
+  discogsToken: z.string().nullable().optional(),
+  discogsUsername: z.string().nullable().optional(),
+})

--- a/src/server/schemas/targets.ts
+++ b/src/server/schemas/targets.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod'
+import { TARGET_TYPES } from '@/core/targets/types'
+
+// URL must be http(s). Private-IP / SSRF checks live in handlers and
+// outbound HTTP clients (publicIpOnly) -- schema just enforces the scheme.
+export const httpUrl = z
+  .string()
+  .trim()
+  .refine((v) => v.startsWith('http://') || v.startsWith('https://'), {
+    message: 'URL must start with http:// or https://',
+  })
+
+// Config is deliberately loose: each target type has its own shape managed by
+// the adapter. Pinning per-type config here would duplicate adapter-side
+// validation. We only insist on url being http(s) when present.
+export const targetConfigSchema = z
+  .object({
+    url: httpUrl.optional(),
+  })
+  .catchall(z.unknown())
+
+export const createTargetSchema = z.object({
+  type: z.enum(TARGET_TYPES),
+  name: z.string().trim().min(1).max(200),
+  config: targetConfigSchema,
+})
+
+// PATCH body: only explicitly-allowed fields. .strict() rejects unknown keys
+// so future silent expansion is caught in review.
+export const updateTargetSchema = z
+  .object({
+    name: z.string().trim().min(1).max(200).optional(),
+    config: targetConfigSchema.optional(),
+    enabled: z.boolean().optional(),
+  })
+  .strict()
+
+export const targetIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})

--- a/src/server/schemas/users.ts
+++ b/src/server/schemas/users.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import { passwordSchema, usernameSchema } from './auth'
+
+export const createUserSchema = z.object({
+  username: usernameSchema,
+  password: passwordSchema,
+  isAdmin: z.boolean().optional().default(false),
+})
+
+// PATCH body: only admin role is mutable here today. Keep shape strict so
+// future additions are a deliberate choice, not a silent expansion.
+export const updateUserSchema = z
+  .object({
+    isAdmin: z.boolean().optional(),
+  })
+  .strict()
+
+export const userIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})

--- a/src/server/schemas/validator.ts
+++ b/src/server/schemas/validator.ts
@@ -1,0 +1,46 @@
+import { zValidator as zv } from '@hono/zod-validator'
+import type { z } from 'zod'
+
+// Consistent 400 response shape for every Zod-validated route. Clients key on
+// `error` (stable machine code) and render per-field hints from `details`.
+// Zod's English messages travel through unchanged; UI may translate by path+code.
+type ValidationIssue = {
+  path: (string | number)[]
+  code: string
+  message: string
+}
+
+// @hono/zod-validator Hook generic has a 6-arg signature that narrows
+// ZodError<output<T>> per target. Using any on the error here keeps the hook
+// reusable across targets without losing runtime behavior or output typing
+// on the handler side (c.req.valid(...) stays inferred).
+type AnyResult =
+  | { success: true }
+  // biome-ignore lint/suspicious/noExplicitAny: see comment above AnyResult
+  | { success: false; error: any }
+
+// biome-ignore lint/suspicious/noExplicitAny: hook may run against any target
+const hook = (result: AnyResult, c: any) => {
+  if (result.success) return
+  const issues: ValidationIssue[] = (
+    result.error?.issues ?? ([] as Array<{ path: unknown[]; code: string; message: string }>)
+  ).map((i: { path: unknown[]; code: string; message: string }) => ({
+    path: i.path.map((p) => (typeof p === 'symbol' ? p.toString() : (p as string | number))),
+    code: i.code,
+    message: i.message,
+  }))
+  // `error` is a human-readable summary so existing clients that read `data.error`
+  // keep showing useful text. `code` is the stable machine identifier.
+  // `details` carries the full structured issue list for form-level UIs.
+  const first = issues[0]
+  const summary = first
+    ? first.path.length > 0
+      ? `${first.path.join('.')}: ${first.message}`
+      : first.message
+    : 'Invalid request'
+  return c.json({ error: summary, code: 'validation_failed' as const, details: issues }, 400)
+}
+
+export const zJson = <T extends z.ZodTypeAny>(schema: T) => zv('json', schema, hook)
+export const zQuery = <T extends z.ZodTypeAny>(schema: T) => zv('query', schema, hook)
+export const zParam = <T extends z.ZodTypeAny>(schema: T) => zv('param', schema, hook)

--- a/tests/server/routes/validation.test.ts
+++ b/tests/server/routes/validation.test.ts
@@ -1,0 +1,263 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearAllSessions, createSession } from '@/core/sessions'
+import { createTestApp } from '../../helpers/test-app'
+
+const adminUser = {
+  id: 1,
+  username: 'admin',
+  isAdmin: true,
+  preferences: null,
+  email: null,
+  oidcSubject: null,
+  authProvider: 'local' as const,
+  listenbrainzUsername: null,
+  listenbrainzToken: null,
+  lastfmUsername: null,
+  lastfmApiKey: null,
+  plexUrl: null,
+  plexToken: null,
+  jellyfinUrl: null,
+  jellyfinApiKey: null,
+  jellyfinUserId: null,
+  embyUrl: null,
+  embyApiKey: null,
+  embyUserId: null,
+  discogsToken: null,
+  discogsUsername: null,
+  createdAt: new Date(),
+}
+
+async function authedApp() {
+  const { app, deps } = createTestApp({
+    getUserById: vi.fn(async (id: number) => (id === 1 ? adminUser : null)),
+    getUserCount: vi.fn(async () => 1),
+    getUserByUsername: vi.fn(async () => null),
+  })
+  await clearAllSessions()
+  const token = 'test-session-token'
+  await createSession(adminUser.id, token)
+  return { app, deps, headers: { Authorization: `Bearer ${token}` } }
+}
+
+beforeEach(async () => {
+  await clearAllSessions()
+})
+
+describe('validation: shared error shape', () => {
+  it('returns error summary + code + details for a validation failure', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ username: 'a', password: 'short' }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('validation_failed')
+    expect(typeof body.error).toBe('string')
+    expect(Array.isArray(body.details)).toBe(true)
+    expect(body.details.length).toBeGreaterThan(0)
+    expect(body.details[0]).toHaveProperty('path')
+    expect(body.details[0]).toHaveProperty('code')
+    expect(body.details[0]).toHaveProperty('message')
+  })
+})
+
+describe('validation: auth.register', () => {
+  it('rejects missing username', async () => {
+    const { app } = await authedApp()
+    const res = await app.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'password123' }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('validation_failed')
+    expect(body.details.some((d: { path: string[] }) => d.path.includes('username'))).toBe(true)
+  })
+
+  it('rejects password shorter than 8 characters', async () => {
+    const { app } = await authedApp()
+    const res = await app.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'alice', password: '1234567' }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('validation_failed')
+    expect(body.details.some((d: { path: string[] }) => d.path.includes('password'))).toBe(true)
+  })
+
+  it('rejects username with wrong type', async () => {
+    const { app } = await authedApp()
+    const res = await app.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 42, password: 'password123' }),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('validation: users', () => {
+  it('rejects POST /api/users with non-boolean isAdmin', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ username: 'newuser', password: 'password123', isAdmin: 'yes' }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('validation_failed')
+  })
+
+  it('rejects PATCH /api/users/:id with unknown field', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/users/2', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ isAdmin: true, passwordHash: 'injected' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects PATCH /api/users/:id with non-numeric id param', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/users/not-a-number', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ isAdmin: true }),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('validation: targets', () => {
+  it('rejects POST /api/targets with invalid target type', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/targets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ type: 'made-up-type', name: 'x', config: {} }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('validation_failed')
+  })
+
+  it('rejects POST /api/targets with non-http URL in config', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/targets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        type: 'lidarr',
+        name: 'x',
+        config: { url: 'ftp://evil.example' },
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects POST /api/targets with empty name', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/targets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ type: 'lidarr', name: '', config: {} }),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('validation: settings PATCH', () => {
+  it('rejects librarySyncIntervalHours out of range', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ librarySyncIntervalHours: 99 }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('validation_failed')
+  })
+
+  it('rejects skipTlsVerify with wrong type', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ skipTlsVerify: 'true' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects scoringWeights.consensus out of [0, 1]', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        preferences: { scoringWeights: { consensus: 2.5 } },
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('validation: admin restore', () => {
+  it('rejects POST /api/admin/restore with missing data section', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/admin/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        version: 1,
+        appVersion: '0.27.9',
+        createdAt: '2026-04-14',
+        encryptionKeyHash: null,
+        includesCaches: false,
+        // data: {} missing entirely
+      }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('validation_failed')
+  })
+
+  it('rejects POST /api/admin/restore when a table is not an array', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/admin/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        version: 1,
+        appVersion: '0.27.9',
+        createdAt: '2026-04-14',
+        encryptionKeyHash: null,
+        includesCaches: false,
+        data: {
+          settings: 'not-an-array',
+          users: [],
+          oauthTokens: [],
+          oidcTokens: [],
+          targets: [],
+          subscriptions: [],
+          jobRuns: [],
+          recommendationBatches: [],
+          recommendations: [],
+          playlists: [],
+          playlistTracks: [],
+        },
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+})


### PR DESCRIPTION
Batch 8a of the 0.27.x hardening sweep. Foundation + five of the highest-risk write/admin endpoints now validate input with Zod before touching business logic.

## Summary

- ``zod@4``, ``@hono/zod-validator``, ``drizzle-zod`` added.
- ``src/server/schemas/`` foundation: per-route schemas + a ``zJson/zQuery/zParam`` helper with one consistent 400 shape: ``{ error, code: 'validation_failed', details: [...] }``. ``error`` is human-readable (keeps existing frontend error display working); ``code`` is the stable machine identifier.
- Migrated:
  - ``POST /api/auth/register`` + ``POST /api/auth/change-password`` (login deliberately kept on manual handler so its ``credentialsRequired`` error stays i18n'd in 15 locales).
  - ``POST + PATCH /api/users`` — type-checked ``isAdmin`` boolean, ``.strict()`` PATCH rejects unknown keys, id coerced/range-checked.
  - ``POST + PATCH + DELETE /api/targets`` — ``type`` constrained to ``TARGET_TYPES`` enum, ``config.url`` forced to http(s), PATCH ``.strict()``.
  - ``PATCH /api/settings`` — 30+ fields type-checked, preferences enums + [0,1] ranges enforced. Unknown top-level keys still silently dropped to preserve allowlist semantics.
  - ``POST /api/admin/restore`` — backup envelope validated before ``restoreBackup`` runs. Non-array table payloads, missing envelope keys, and wrong types all 400 out at the edge.
- 15 new invalid-input tests in ``tests/server/routes/validation.test.ts``.

## Out of scope (batch 8b)

- subscriptions, playlists, pipeline, jobs, setup wizard POSTs.
- GET query-param validation (listening, analytics, recommendations).
- ``drizzle-zod``-derived schemas.
- Validator-level i18n for Zod-generated messages (login's manual handler preserves i18n for the highest-visibility surface).

## Test plan

- [x] ``bun run lint``, ``bun run typecheck``, ``bun run i18n:check`` clean
- [x] ``bun run test`` 1818 pass; only the pre-existing scrypt flake in ``auth > changes the password`` fails under full-suite concurrency (passes in isolation, confirmed)
- [x] Per-file tests: ``auth.test.ts`` 27/27, ``users.test.ts`` 10/10, ``targets.test.ts`` 8/8, ``settings.test.ts`` 32/32, ``validation.test.ts`` 15/15, ``backup.test.ts`` 401/401
- [ ] CI green