### PR TITLE
feat(api): Zod validation sweep on the remaining write routes (v0.27.10)

### DIFF
--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.27.9
-appVersion: "0.27.9"
+version: 0.27.10
+appVersion: "0.27.10"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.27.9"
+  tag: "0.27.10"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
   digest: "sha256:76e908d844f7ea98ee14eb747e7196a65e8760e15a8b4fd70321c1b88406ee0c"
   pullPolicy: Always

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.27.9",
+  "version": "0.27.10",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/server/routes/jobs.ts
+++ b/src/server/routes/jobs.ts
@@ -3,17 +3,9 @@ import type { JobRunRow, JobType } from '@/core/jobs/types'
 import type { HealthSummary } from '@/db/queries/jobs'
 import type { AppDependencies } from '@/server'
 import { adminGuard } from '@/server/middleware/admin-guard'
+import { jobIdParamSchema, listJobsQuerySchema } from '@/server/schemas/jobs'
+import { zParam, zQuery } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
-
-const VALID_TYPES = new Set<string>([
-  'pipeline',
-  'quick_discover',
-  'subscription',
-  'target',
-  'playlist',
-  'library_sync',
-])
-const VALID_STATUSES = new Set<string>(['running', 'completed', 'failed', 'stuck'])
 
 type JobRouteDeps = Pick<AppDependencies, 'getUserById'> & {
   jobQueries: {
@@ -42,31 +34,24 @@ export function jobRoutes(deps: JobRouteDeps) {
   })
 
   // Single job detail
-  router.get('/api/jobs/:id', async (c) => {
-    const id = Number(c.req.param('id'))
-    if (Number.isNaN(id)) return c.json({ error: 'Invalid job ID' }, 400)
+  router.get('/api/jobs/:id', zParam(jobIdParamSchema), async (c) => {
+    const { id } = c.req.valid('param')
     const job = await deps.jobQueries.getJobById(id)
     if (!job) return c.json({ error: 'Job not found' }, 404)
     return c.json(job)
   })
 
   // Paginated job list
-  router.get('/api/jobs', async (c) => {
-    const typeParam = c.req.query('type')
-    if (typeParam && !VALID_TYPES.has(typeParam)) {
-      return c.json({ error: `Invalid type. Use: ${Array.from(VALID_TYPES).join(', ')}` }, 400)
-    }
-    const type = typeParam as JobType | undefined
-    const statusParam = c.req.query('status')
-    if (statusParam && !VALID_STATUSES.has(statusParam)) {
-      return c.json({ error: `Invalid status. Use: ${Array.from(VALID_STATUSES).join(', ')}` }, 400)
-    }
-    const status = statusParam
-    const rawLimit = Number(c.req.query('limit'))
-    const rawOffset = Number(c.req.query('offset'))
-    const limit = Math.max(1, Math.min(Number.isFinite(rawLimit) ? rawLimit : 50, 100))
-    const offset = Math.max(0, Number.isFinite(rawOffset) ? rawOffset : 0)
-    const result = await deps.jobQueries.listJobs({ type, status, limit, offset })
+  router.get('/api/jobs', zQuery(listJobsQuerySchema), async (c) => {
+    const { type, status, limit: rawLimit, offset: rawOffset } = c.req.valid('query')
+    const limit = rawLimit ?? 50
+    const offset = rawOffset ?? 0
+    const result = await deps.jobQueries.listJobs({
+      type: type as JobType | undefined,
+      status,
+      limit,
+      offset,
+    })
     return c.json(result)
   })
 

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -7,6 +7,8 @@ import {
   upsertOAuthToken,
 } from '@/db/queries/oauth-tokens'
 import type { AppDependencies } from '@/server'
+import { oauthInitiateSchema } from '@/server/schemas/oauth'
+import { zJson } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 const SPOTIFY_AUTH_URL = 'https://accounts.spotify.com/authorize'
@@ -22,17 +24,12 @@ export function oauthRoutes(deps: AppDependencies) {
   const router = new Hono<HonoEnv>()
 
   // Initiate OAuth flow for a provider
-  router.post('/api/auth/oauth/:provider/initiate', async (c) => {
+  router.post('/api/auth/oauth/:provider/initiate', zJson(oauthInitiateSchema), async (c) => {
     const provider = c.req.param('provider')
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Authentication required' }, 401)
 
-    const body = await c.req.json().catch(() => ({}))
-    const { clientId, clientSecret, redirectUri } = body as {
-      clientId?: string
-      clientSecret?: string
-      redirectUri?: string
-    }
+    const { clientId, clientSecret, redirectUri } = c.req.valid('json')
 
     switch (provider) {
       case 'spotify': {

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -25,6 +25,8 @@ import { mergePreferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
 import { resolveUserPreferences } from '@/server/helpers/preferences'
 import { resolveRequestLocale } from '@/server/locale'
+import { discoveryModeRunSchema, quickDiscoverSchema } from '@/server/schemas/pipeline'
+import { zJson } from '@/server/schemas/validator'
 import { createPipelineSSEStream } from '@/server/sse'
 import type { HonoEnv } from '@/server/types'
 
@@ -120,7 +122,7 @@ export function pipelineRoutes(deps: AppDependencies) {
     return c.json({ message: 'Pipeline started' }, 202)
   })
 
-  router.post('/api/discovery-modes/run', async (c) => {
+  router.post('/api/discovery-modes/run', zJson(discoveryModeRunSchema), async (c) => {
     if (deps.orchestrator.isRunning) {
       return c.json({ error: 'A scan is already running' }, 409)
     }
@@ -134,7 +136,7 @@ export function pipelineRoutes(deps: AppDependencies) {
     }
 
     try {
-      const body = await c.req.json()
+      const body = c.req.valid('json')
       const request = normalizeDiscoveryModeRequest(userId, body, deps.discoveryModeRegistry)
       const preparedRequest = await prepareDiscoveryModeRequest(request, deps.discoveryModeRegistry)
       const snapshot = await (deps.getDiscoveryConnectionSnapshot?.(userId) ??
@@ -193,17 +195,13 @@ export function pipelineRoutes(deps: AppDependencies) {
   })
 
   // Quick discover: find similar artists to a specific artist
-  router.post('/api/pipeline/quick-discover', async (c) => {
+  router.post('/api/pipeline/quick-discover', zJson(quickDiscoverSchema), async (c) => {
     if (deps.orchestrator.isRunning) {
       return c.json({ error: 'A scan is already running' }, 409)
     }
 
-    const body = await c.req.json()
-    const { artistName } = body as { artistName: string }
-    const trimmedArtistName = artistName?.trim()
-    if (!trimmedArtistName) {
-      return c.json({ error: 'artistName is required' }, 400)
-    }
+    const { artistName } = c.req.valid('json')
+    const trimmedArtistName = artistName
 
     const settings = await deps.getSettings()
     if (!settings) {

--- a/src/server/routes/playlists.ts
+++ b/src/server/routes/playlists.ts
@@ -1,4 +1,3 @@
-import { Cron } from 'croner'
 import { Hono } from 'hono'
 import {
   exportPlaylistToCsv,
@@ -18,7 +17,14 @@ import {
   updatePlaylist,
 } from '@/db/queries/playlists'
 import { getSettings } from '@/db/queries/settings'
-import { mergePreferences, type PlaylistConfig, type PlaylistStrategy } from '@/db/schema'
+import { mergePreferences, type PlaylistConfig } from '@/db/schema'
+import {
+  createPlaylistSchema,
+  playlistExportFormatParamSchema,
+  playlistIdParamSchema,
+  updatePlaylistSchema,
+} from '@/server/schemas/playlists'
+import { zJson, zParam } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 export type PlaylistDeps = {
@@ -27,15 +33,6 @@ export type PlaylistDeps = {
   runPlaylistGeneration: (playlistId: number) => Promise<void>
   restartPlaylistScheduler: () => Promise<void>
 }
-
-const ALLOWED_UPDATE_FIELDS = new Set<string>([
-  'name',
-  'strategy',
-  'targetIds',
-  'schedule',
-  'config',
-  'enabled',
-])
 
 const PLAYLIST_EXPORT_CONTENT_TYPES: Record<PlaylistExportFormat, string> = {
   json: 'application/json',
@@ -103,40 +100,19 @@ export function playlistRoutes(deps: PlaylistDeps) {
   })
 
   // POST /api/playlists
-  router.post('/api/playlists', async (c) => {
+  router.post('/api/playlists', zJson(createPlaylistSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    const body: Record<string, unknown> = await c.req.json()
-    const { name, strategy } = body
-
-    if (!name || typeof name !== 'string') {
-      return c.json({ error: 'name is required' }, 400)
-    }
-    if (!strategy || typeof strategy !== 'string') {
-      return c.json({ error: 'strategy is required' }, 400)
-    }
-
-    const validStrategies = ['weekly_digest', 'genre_focus', 'mood_mix', 'rediscover']
-    if (!validStrategies.includes(strategy)) {
-      return c.json({ error: `strategy must be one of: ${validStrategies.join(', ')}` }, 400)
-    }
-    if (body.schedule != null && typeof body.schedule === 'string') {
-      try {
-        new Cron(body.schedule, { maxRuns: 0 })
-      } catch {
-        return c.json({ error: 'Invalid schedule cron expression' }, 400)
-      }
-    }
-
+    const body = c.req.valid('json')
     const data: PlaylistInsert = {
-      name,
+      name: body.name,
       userId,
-      strategy: strategy as PlaylistStrategy,
-      targetIds: Array.isArray(body.targetIds) ? (body.targetIds as number[]) : [],
-      schedule: typeof body.schedule === 'string' ? body.schedule : null,
-      config: body.config != null ? (body.config as PlaylistConfig) : null,
-      enabled: typeof body.enabled === 'boolean' ? body.enabled : true,
+      strategy: body.strategy,
+      targetIds: body.targetIds ?? [],
+      schedule: body.schedule ?? null,
+      config: (body.config ?? null) as PlaylistConfig | null,
+      enabled: body.enabled ?? true,
     }
 
     const row = await createPlaylist(db, data)
@@ -145,12 +121,11 @@ export function playlistRoutes(deps: PlaylistDeps) {
   })
 
   // GET /api/playlists/:id
-  router.get('/api/playlists/:id', async (c) => {
+  router.get('/api/playlists/:id', zParam(playlistIdParamSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    const id = Number(c.req.param('id'))
-    if (Number.isNaN(id)) return c.json({ error: 'Invalid id' }, 400)
+    const { id } = c.req.valid('param')
 
     const result = await getPlaylistWithTracks(db, id)
     if (!result) return c.json({ error: 'Not found' }, 404)
@@ -160,76 +135,61 @@ export function playlistRoutes(deps: PlaylistDeps) {
   })
 
   // GET /api/playlists/:id/export/:format
-  router.get('/api/playlists/:id/export/:format', async (c) => {
-    const userId = c.get('userId')
-    if (!userId) return c.json({ error: 'Unauthorized' }, 401)
+  router.get(
+    '/api/playlists/:id/export/:format',
+    zParam(playlistExportFormatParamSchema),
+    async (c) => {
+      const userId = c.get('userId')
+      if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    const id = Number(c.req.param('id'))
-    if (Number.isNaN(id)) return c.json({ error: 'Invalid id' }, 400)
+      const { id, format } = c.req.valid('param')
+      const exporter = PLAYLIST_EXPORTERS[format]
+      const contentType = PLAYLIST_EXPORT_CONTENT_TYPES[format]
 
-    const format = c.req.param('format') as PlaylistExportFormat
-    const exporter = PLAYLIST_EXPORTERS[format]
-    const contentType = PLAYLIST_EXPORT_CONTENT_TYPES[format]
-    if (!exporter || !contentType) {
-      return c.json({ error: 'Unsupported format. Use json, csv, m3u, or xspf' }, 400)
-    }
+      const result = await getPlaylistWithTracks(db, id)
+      if (!result) return c.json({ error: 'Not found' }, 404)
+      if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
 
-    const result = await getPlaylistWithTracks(db, id)
-    if (!result) return c.json({ error: 'Not found' }, 404)
-    if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
+      const tracks = result.tracks.slice().sort((a, b) => a.position - b.position)
+      const filename = sanitizeFilename(result.playlist.name) || `playlist-${id}`
+      const body = exporter({ name: result.playlist.name, tracks })
 
-    const tracks = result.tracks.slice().sort((a, b) => a.position - b.position)
-    const filename = sanitizeFilename(result.playlist.name) || `playlist-${id}`
-    const body = exporter({ name: result.playlist.name, tracks })
-
-    return new Response(body, {
-      headers: {
-        'Content-Type': contentType,
-        'Content-Disposition': `attachment; filename="${filename}.${format}"`,
-      },
-    })
-  })
+      return new Response(body, {
+        headers: {
+          'Content-Type': contentType,
+          'Content-Disposition': `attachment; filename="${filename}.${format}"`,
+        },
+      })
+    },
+  )
 
   // PATCH /api/playlists/:id
-  router.patch('/api/playlists/:id', async (c) => {
-    const userId = c.get('userId')
-    if (!userId) return c.json({ error: 'Unauthorized' }, 401)
+  router.patch(
+    '/api/playlists/:id',
+    zParam(playlistIdParamSchema),
+    zJson(updatePlaylistSchema),
+    async (c) => {
+      const userId = c.get('userId')
+      if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    const id = Number(c.req.param('id'))
-    if (Number.isNaN(id)) return c.json({ error: 'Invalid id' }, 400)
+      const { id } = c.req.valid('param')
+      const existing = await getPlaylistWithTracks(db, id)
+      if (!existing) return c.json({ error: 'Not found' }, 404)
+      if (existing.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
 
-    const existing = await getPlaylistWithTracks(db, id)
-    if (!existing) return c.json({ error: 'Not found' }, 404)
-    if (existing.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
-
-    const body: Record<string, unknown> = await c.req.json()
-    const update: Record<string, unknown> = {}
-    for (const key of ALLOWED_UPDATE_FIELDS) {
-      if (Object.hasOwn(body, key)) {
-        update[key] = body[key]
-      }
-    }
-
-    if (Object.hasOwn(update, 'schedule') && update.schedule != null) {
-      try {
-        new Cron(String(update.schedule), { maxRuns: 0 })
-      } catch {
-        return c.json({ error: 'Invalid schedule cron expression' }, 400)
-      }
-    }
-
-    await updatePlaylist(db, id, update)
-    await deps.restartPlaylistScheduler()
-    return c.json({ updated: true })
-  })
+      const body = c.req.valid('json')
+      await updatePlaylist(db, id, body as Record<string, unknown>)
+      await deps.restartPlaylistScheduler()
+      return c.json({ updated: true })
+    },
+  )
 
   // DELETE /api/playlists/:id
-  router.delete('/api/playlists/:id', async (c) => {
+  router.delete('/api/playlists/:id', zParam(playlistIdParamSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    const id = Number(c.req.param('id'))
-    if (Number.isNaN(id)) return c.json({ error: 'Invalid id' }, 400)
+    const { id } = c.req.valid('param')
 
     const result = await getPlaylistWithTracks(db, id)
     if (!result) return c.json({ error: 'Not found' }, 404)
@@ -241,12 +201,11 @@ export function playlistRoutes(deps: PlaylistDeps) {
   })
 
   // POST /api/playlists/:id/generate
-  router.post('/api/playlists/:id/generate', async (c) => {
+  router.post('/api/playlists/:id/generate', zParam(playlistIdParamSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    const id = Number(c.req.param('id'))
-    if (Number.isNaN(id)) return c.json({ error: 'Invalid id' }, 400)
+    const { id } = c.req.valid('param')
 
     const result = await getPlaylistWithTracks(db, id)
     if (!result) return c.json({ error: 'Not found' }, 404)

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -2,6 +2,13 @@ import { Hono } from 'hono'
 import { mergePreferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
 import { resolveUserPreferences } from '@/server/helpers/preferences'
+import {
+  bulkRecommendationSchema,
+  listRecommendationsQuerySchema,
+  recommendationIdParamSchema,
+  updateRecommendationSchema,
+} from '@/server/schemas/recommendations'
+import { zJson, zParam, zQuery } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 type TargetWithCapabilities = Awaited<
@@ -27,15 +34,6 @@ type TargetExecutionResult = {
   success: boolean
   lidarrArtistId?: number | string
   lidarrError?: string
-}
-
-function parseOptionalInteger(value: string | undefined, field: string): number | undefined {
-  if (value === undefined) return undefined
-  const parsed = Number(value)
-  if (!Number.isInteger(parsed)) {
-    throw new Error(`Invalid ${field}: ${value}`)
-  }
-  return parsed
 }
 
 async function addArtistToTarget(
@@ -232,26 +230,17 @@ async function buildAddOptions(
 export function recommendationRoutes(deps: AppDependencies) {
   const router = new Hono<HonoEnv>()
 
-  router.get('/api/recommendations', async (c) => {
-    const query = c.req.query()
+  router.get('/api/recommendations', zQuery(listRecommendationsQuerySchema), async (c) => {
     const userId = c.get('userId')
-    let batchId: number | undefined
-    try {
-      batchId = parseOptionalInteger(query.batchId, 'batchId')
-    } catch (err) {
-      return c.json({ error: (err as Error).message }, 400)
-    }
+    const query = c.req.valid('query')
     const filters = {
       status: query.status,
-      batchId,
+      batchId: query.batchId,
       userId,
       decades: query.decades || undefined,
-      sort: query.sort as 'score_desc' | 'score_asc' | 'created_desc' | 'acted_on_desc' | undefined,
-      limit:
-        query.limit !== undefined
-          ? Math.max(1, Math.min(200, Number(query.limit) || 20))
-          : undefined,
-      offset: query.offset !== undefined ? Math.max(0, Number(query.offset) || 0) : undefined,
+      sort: query.sort,
+      limit: query.limit,
+      offset: query.offset,
     }
     const result = await deps.listRecommendations(filters)
     return c.json(result)
@@ -274,9 +263,8 @@ export function recommendationRoutes(deps: AppDependencies) {
     return c.json({ summary })
   })
 
-  router.get('/api/recommendations/:id', async (c) => {
-    const id = Number(c.req.param('id'))
-    if (!Number.isFinite(id)) return c.json({ error: 'Invalid recommendation ID' }, 400)
+  router.get('/api/recommendations/:id', zParam(recommendationIdParamSchema), async (c) => {
+    const { id } = c.req.valid('param')
     const rec = await deps.getRecommendation(id)
     if (!rec) return c.json({ error: 'Recommendation not found' }, 404)
     const userId = c.get('userId')
@@ -284,157 +272,140 @@ export function recommendationRoutes(deps: AppDependencies) {
     return c.json(rec)
   })
 
-  router.patch('/api/recommendations/:id', async (c) => {
-    const id = Number(c.req.param('id'))
-    if (!Number.isFinite(id)) return c.json({ error: 'Invalid recommendation ID' }, 400)
-    const body = await c.req.json()
-    const {
-      status,
-      approvalMode: rawApprovalMode,
-      lidarrTargetId,
-      monitorOption,
-      selectedAlbumIds,
-      targetId,
-      qualityProfileId: qpOverride,
-      metadataProfileId: mpOverride,
-      rootFolderId: rfOverride,
-    } = body as {
-      status: string
-      approvalMode?: ApprovalMode
-      lidarrTargetId?: string
-      monitorOption?: 'all' | 'new' | 'none' | 'selected'
-      selectedAlbumIds?: string[]
-      targetId?: string
-      qualityProfileId?: number
-      metadataProfileId?: number
-      rootFolderId?: number
-    }
+  router.patch(
+    '/api/recommendations/:id',
+    zParam(recommendationIdParamSchema),
+    zJson(updateRecommendationSchema),
+    async (c) => {
+      const { id } = c.req.valid('param')
+      const body = c.req.valid('json')
+      const {
+        status,
+        approvalMode: rawApprovalMode,
+        lidarrTargetId,
+        monitorOption,
+        selectedAlbumIds,
+        targetId,
+        qualityProfileId: qpOverride,
+        metadataProfileId: mpOverride,
+        rootFolderId: rfOverride,
+      } = body
 
-    if (!status) return c.json({ error: 'status is required' }, 400)
+      const approvalMode: ApprovalMode = rawApprovalMode ?? 'single_target'
 
-    const approvalMode = rawApprovalMode ?? 'single_target'
-    if (approvalMode !== 'single_target' && approvalMode !== 'combined_lidarr_slskd') {
-      return c.json({ error: `Invalid approvalMode: ${approvalMode}` }, 400)
-    }
+      if (status === 'approved') {
+        const rec = await deps.getRecommendation(id)
+        if (!rec) return c.json({ error: 'Recommendation not found' }, 404)
+        const userId = c.get('userId')
+        if (!isOwned(rec, userId)) return c.json({ error: 'Recommendation not found' }, 404)
 
-    // Validate status early -- before any DB work
-    if (status !== 'approved' && status !== 'rejected' && status !== 'pending') {
-      return c.json({ error: `Invalid status: ${status}` }, 400)
-    }
+        const targets = userId ? await deps.getEnabledTargetsForUser(userId) : []
+        const effectiveTargets = targetId ? targets.filter((t) => t.id === targetId) : targets
+        const lidarrTargets = targets.filter(
+          (target) => target.type === 'lidarr' && target.capabilities?.includes('addArtist'),
+        )
+        const slskdTarget = effectiveTargets.find(
+          (target) => target.type === 'slskd' && target.capabilities?.includes('addArtist'),
+        )
+        const selectedLidarrTargetId =
+          lidarrTargetId ??
+          (slskdTarget?.type === 'slskd' ? slskdTarget.linkedLidarrTargetId : undefined)
+        const lidarrTarget = selectedLidarrTargetId
+          ? lidarrTargets.find((target) => target.id === selectedLidarrTargetId)
+          : lidarrTargets[0]
 
-    if (status === 'approved') {
+        if (approvalMode === 'combined_lidarr_slskd') {
+          if (!targetId) {
+            return c.json({ error: 'targetId is required for combined approval' }, 400)
+          }
+          if (!slskdTarget) {
+            return c.json({ error: `Unknown targetId: ${targetId}` }, 400)
+          }
+          if (selectedLidarrTargetId) {
+            if (!lidarrTarget) {
+              return c.json({ error: `Unknown lidarrTargetId: ${selectedLidarrTargetId}` }, 400)
+            }
+          } else if (lidarrTargets.length !== 1) {
+            return c.json(
+              { error: 'Combined approval requires exactly one enabled Lidarr target' },
+              400,
+            )
+          }
+        } else {
+          if (targetId && effectiveTargets.length === 0) {
+            return c.json({ error: `Unknown targetId: ${targetId}` }, 400)
+          }
+          if (targetId && !effectiveTargets.some((t) => t.capabilities?.includes('addArtist'))) {
+            return c.json({ error: `Target does not support artist approval: ${targetId}` }, 400)
+          }
+        }
+
+        // Pre-warm SkyHook if any Lidarr target exists
+        if (
+          deps.skyhookWarmer &&
+          rec.artist?.mbid &&
+          (approvalMode === 'combined_lidarr_slskd'
+            ? Boolean(lidarrTarget)
+            : effectiveTargets.some((t) => t.type === 'lidarr'))
+        ) {
+          try {
+            await deps.skyhookWarmer.warm(rec.artist.mbid)
+          } catch {
+            // Best-effort
+          }
+        }
+
+        const addOptions = await buildAddOptions(deps, userId, {
+          monitorOption: monitorOption ?? 'all',
+          selectedAlbumIds,
+          qualityProfileId: qpOverride,
+          metadataProfileId: mpOverride,
+          rootFolderId: rfOverride,
+        })
+
+        const result =
+          approvalMode === 'combined_lidarr_slskd' && lidarrTarget && slskdTarget
+            ? await approveWithCombinedLidarrSlskd(
+                { mbid: rec.artist.mbid, name: rec.artist.name },
+                lidarrTarget,
+                slskdTarget,
+                addOptions,
+                id,
+                deps.jobRecorder,
+                userId,
+              )
+            : await approveToTargets(
+                { mbid: rec.artist.mbid, name: rec.artist.name },
+                effectiveTargets,
+                addOptions,
+                deps.jobRecorder,
+                userId,
+                id,
+              )
+
+        const extra: Record<string, unknown> = { targetActions: result.targetActions }
+        if (result.lidarrArtistId) extra.lidarrArtistId = result.lidarrArtistId
+        if (result.lidarrError) extra.lidarrError = result.lidarrError
+
+        await deps.updateRecommendationStatus(id, result.status, extra)
+        return c.json({
+          status: result.status,
+          targetActions: result.targetActions,
+          ...(result.lidarrError ? { lidarrError: result.lidarrError } : {}),
+        })
+      }
+
       const rec = await deps.getRecommendation(id)
       if (!rec) return c.json({ error: 'Recommendation not found' }, 404)
       const userId = c.get('userId')
       if (!isOwned(rec, userId)) return c.json({ error: 'Recommendation not found' }, 404)
 
-      const targets = userId ? await deps.getEnabledTargetsForUser(userId) : []
-      const effectiveTargets = targetId ? targets.filter((t) => t.id === targetId) : targets
-      const lidarrTargets = targets.filter(
-        (target) => target.type === 'lidarr' && target.capabilities?.includes('addArtist'),
-      )
-      const slskdTarget = effectiveTargets.find(
-        (target) => target.type === 'slskd' && target.capabilities?.includes('addArtist'),
-      )
-      const selectedLidarrTargetId =
-        lidarrTargetId ??
-        (slskdTarget?.type === 'slskd' ? slskdTarget.linkedLidarrTargetId : undefined)
-      const lidarrTarget = selectedLidarrTargetId
-        ? lidarrTargets.find((target) => target.id === selectedLidarrTargetId)
-        : lidarrTargets[0]
+      await deps.updateRecommendationStatus(id, status)
+      return c.json({ status })
+    },
+  )
 
-      if (approvalMode === 'combined_lidarr_slskd') {
-        if (!targetId) {
-          return c.json({ error: 'targetId is required for combined approval' }, 400)
-        }
-        if (!slskdTarget) {
-          return c.json({ error: `Unknown targetId: ${targetId}` }, 400)
-        }
-        if (selectedLidarrTargetId) {
-          if (!lidarrTarget) {
-            return c.json({ error: `Unknown lidarrTargetId: ${selectedLidarrTargetId}` }, 400)
-          }
-        } else if (lidarrTargets.length !== 1) {
-          return c.json(
-            { error: 'Combined approval requires exactly one enabled Lidarr target' },
-            400,
-          )
-        }
-      } else {
-        if (targetId && effectiveTargets.length === 0) {
-          return c.json({ error: `Unknown targetId: ${targetId}` }, 400)
-        }
-        if (targetId && !effectiveTargets.some((t) => t.capabilities?.includes('addArtist'))) {
-          return c.json({ error: `Target does not support artist approval: ${targetId}` }, 400)
-        }
-      }
-
-      // Pre-warm SkyHook if any Lidarr target exists
-      if (
-        deps.skyhookWarmer &&
-        rec.artist?.mbid &&
-        (approvalMode === 'combined_lidarr_slskd'
-          ? Boolean(lidarrTarget)
-          : effectiveTargets.some((t) => t.type === 'lidarr'))
-      ) {
-        try {
-          await deps.skyhookWarmer.warm(rec.artist.mbid)
-        } catch {
-          // Best-effort
-        }
-      }
-
-      const addOptions = await buildAddOptions(deps, userId, {
-        monitorOption: monitorOption ?? 'all',
-        selectedAlbumIds,
-        qualityProfileId: qpOverride,
-        metadataProfileId: mpOverride,
-        rootFolderId: rfOverride,
-      })
-
-      const result =
-        approvalMode === 'combined_lidarr_slskd' && lidarrTarget && slskdTarget
-          ? await approveWithCombinedLidarrSlskd(
-              { mbid: rec.artist.mbid, name: rec.artist.name },
-              lidarrTarget,
-              slskdTarget,
-              addOptions,
-              id,
-              deps.jobRecorder,
-              userId,
-            )
-          : await approveToTargets(
-              { mbid: rec.artist.mbid, name: rec.artist.name },
-              effectiveTargets,
-              addOptions,
-              deps.jobRecorder,
-              userId,
-              id,
-            )
-
-      const extra: Record<string, unknown> = { targetActions: result.targetActions }
-      if (result.lidarrArtistId) extra.lidarrArtistId = result.lidarrArtistId
-      if (result.lidarrError) extra.lidarrError = result.lidarrError
-
-      await deps.updateRecommendationStatus(id, result.status, extra)
-      return c.json({
-        status: result.status,
-        targetActions: result.targetActions,
-        ...(result.lidarrError ? { lidarrError: result.lidarrError } : {}),
-      })
-    }
-
-    const rec = await deps.getRecommendation(id)
-    if (!rec) return c.json({ error: 'Recommendation not found' }, 404)
-    const userId = c.get('userId')
-    if (!isOwned(rec, userId)) return c.json({ error: 'Recommendation not found' }, 404)
-
-    await deps.updateRecommendationStatus(id, status)
-    return c.json({ status })
-  })
-
-  router.post('/api/recommendations/bulk', async (c) => {
-    const body = await c.req.json()
+  router.post('/api/recommendations/bulk', zJson(bulkRecommendationSchema), async (c) => {
     const {
       ids,
       action,
@@ -442,21 +413,7 @@ export function recommendationRoutes(deps: AppDependencies) {
       qualityProfileId: qpOverride,
       metadataProfileId: mpOverride,
       rootFolderId: rfOverride,
-    } = body as {
-      ids: number[]
-      action: 'approve' | 'reject'
-      targetId?: string
-      qualityProfileId?: number
-      metadataProfileId?: number
-      rootFolderId?: number
-    }
-
-    if (!ids || !Array.isArray(ids) || ids.length === 0) {
-      return c.json({ error: 'ids array is required' }, 400)
-    }
-    if (action !== 'approve' && action !== 'reject') {
-      return c.json({ error: 'action must be approve or reject' }, 400)
-    }
+    } = c.req.valid('json')
 
     const userId = c.get('userId')
 

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -3,6 +3,8 @@ import { validatePublicServiceUrl } from '@/core/url-safety'
 import type { SetupConfig } from '@/db/queries/settings'
 import { updateUserConnections } from '@/db/queries/users'
 import type { AppDependencies } from '@/server'
+import { setupCompleteSchema } from '@/server/schemas/setup'
+import { zJson } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 export function setupRoutes(deps: AppDependencies) {
@@ -23,13 +25,13 @@ export function setupRoutes(deps: AppDependencies) {
     return c.json({ setupComplete: complete })
   })
 
-  router.post('/api/setup/complete', async (c) => {
+  router.post('/api/setup/complete', zJson(setupCompleteSchema), async (c) => {
     const alreadyDone = await deps.isSetupComplete()
     if (alreadyDone) {
       return c.json({ error: 'Setup already complete' }, 409)
     }
 
-    const body = (await c.req.json()) as Record<string, unknown>
+    const body = c.req.valid('json') as Record<string, unknown>
     const sanitized = Object.fromEntries(
       Object.entries(body).filter(([key]) => GLOBAL_SETUP_FIELDS.has(key)),
     )

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -1,4 +1,3 @@
-import { Cron } from 'croner'
 import { Hono } from 'hono'
 import { createDeezerUserClient } from '@/core/clients/deezer-user'
 import { resolveDeezerToken } from '@/core/deezer-auth'
@@ -12,6 +11,15 @@ import { errMsg } from '@/core/validation'
 import { getOAuthToken } from '@/db/queries/oauth-tokens'
 import type { AppDependencies } from '@/server'
 import { resolveRequestMessages } from '@/server/locale'
+import {
+  bulkToggleSchema,
+  createSubscriptionSchema,
+  deezerPlaylistImportSchema,
+  spotifyPlaylistImportSchema,
+  subscriptionIdParamSchema,
+  updateSubscriptionSchema,
+} from '@/server/schemas/subscriptions'
+import { zJson, zParam } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 /** Extract the bare playlist ID from a URL, URI, or raw ID. */
@@ -22,18 +30,6 @@ function extractPlaylistId(raw: string): string {
   if (urlMatch?.[1]) return urlMatch[1]
   return raw.trim()
 }
-
-const ALLOWED_UPDATE_FIELDS = new Set([
-  'name',
-  'enabled',
-  'sourceConfig',
-  'maxArtistsPerRun',
-  'listenerRange',
-  'cron',
-  'scoreThreshold',
-  'scoringWeightPreset',
-  'scoringWeightOverrides',
-])
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -273,31 +269,17 @@ export function subscriptionRoutes(deps: AppDependencies) {
     return c.json(subs)
   })
 
-  router.post('/api/subscriptions', async (c) => {
+  router.post('/api/subscriptions', zJson(createSubscriptionSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401)
     }
 
-    const body = await c.req.json()
-    const { name, sourceType, sourceProvider, sourceConfig, cron } = body as Record<string, unknown>
-
-    if (!name || typeof name !== 'string') {
-      return c.json({ error: 'name is required' }, 400)
-    }
-    if (!sourceType || typeof sourceType !== 'string') {
-      return c.json({ error: 'sourceType is required' }, 400)
-    }
-    if (!sourceProvider || typeof sourceProvider !== 'string') {
-      return c.json({ error: 'sourceProvider is required' }, 400)
-    }
-    if (!sourceConfig || typeof sourceConfig !== 'object' || Array.isArray(sourceConfig)) {
-      return c.json({ error: 'sourceConfig is required' }, 400)
-    }
-    let normalizedSourceConfig = sourceConfig as Record<string, unknown>
-    if (sourceType === DISCOVERY_MODE_SUBSCRIPTION_TYPE) {
+    const body = c.req.valid('json')
+    let normalizedSourceConfig = body.sourceConfig
+    if (body.sourceType === DISCOVERY_MODE_SUBSCRIPTION_TYPE) {
       const { error, normalizedConfig } = await resolveDiscoveryModeSourceConfig(
-        sourceConfig,
+        body.sourceConfig,
         userId,
         deps,
       )
@@ -306,33 +288,20 @@ export function subscriptionRoutes(deps: AppDependencies) {
       }
       normalizedSourceConfig = normalizedConfig as Record<string, unknown>
     }
-    if (!cron || typeof cron !== 'string') {
-      return c.json({ error: 'cron is required' }, 400)
-    }
-    try {
-      new Cron(cron, { maxRuns: 0 })
-    } catch {
-      return c.json({ error: 'Invalid cron expression' }, 400)
-    }
 
     const sub = await deps.subscriptionQueries.createSubscription({
-      name,
+      name: body.name,
       userId,
-      sourceType,
-      sourceProvider,
+      sourceType: body.sourceType,
+      sourceProvider: body.sourceProvider,
       sourceConfig: normalizedSourceConfig,
-      cron,
-      enabled: typeof body.enabled === 'boolean' ? body.enabled : true,
-      maxArtistsPerRun:
-        typeof body.maxArtistsPerRun === 'number' ? body.maxArtistsPerRun : undefined,
+      cron: body.cron,
+      enabled: body.enabled ?? true,
+      maxArtistsPerRun: body.maxArtistsPerRun,
       action: 'add_to_recommendations',
       scoreThreshold: undefined,
-      listenerRange:
-        body.listenerRange && typeof body.listenerRange === 'object'
-          ? (body.listenerRange as { min?: number; max?: number })
-          : undefined,
-      scoringWeightPreset:
-        typeof body.scoringWeightPreset === 'string' ? body.scoringWeightPreset : undefined,
+      listenerRange: body.listenerRange,
+      scoringWeightPreset: body.scoringWeightPreset,
     })
 
     // Auto-schedule if enabled (default is true)
@@ -446,61 +415,61 @@ export function subscriptionRoutes(deps: AppDependencies) {
     )
   })
 
-  router.post('/api/subscriptions/import/spotify-playlist', async (c) => {
-    const userId = c.get('userId')
-    if (!userId) {
-      return c.json({ error: 'Unauthorized' }, 401)
-    }
+  router.post(
+    '/api/subscriptions/import/spotify-playlist',
+    zJson(spotifyPlaylistImportSchema),
+    async (c) => {
+      const userId = c.get('userId')
+      if (!userId) {
+        return c.json({ error: 'Unauthorized' }, 401)
+      }
 
-    const body = await c.req.json()
-    const rawId = String((body as Record<string, unknown>).playlistId ?? '').trim()
-    if (!rawId) {
-      return c.json({ error: 'playlistId is required' }, 400)
-    }
+      const { playlistId: rawId } = c.req.valid('json')
 
-    const spotifyToken = await getOAuthToken(deps.db, userId, 'spotify')
-    if (!spotifyToken || spotifyToken.accessToken.startsWith('pending:')) {
-      return c.json({ error: 'Spotify is not connected' }, 400)
-    }
+      const spotifyToken = await getOAuthToken(deps.db, userId, 'spotify')
+      if (!spotifyToken || spotifyToken.accessToken.startsWith('pending:')) {
+        return c.json({ error: 'Spotify is not connected' }, 400)
+      }
 
-    // Normalize URL/URI to bare ID
-    const playlistId = extractPlaylistId(rawId)
+      // Normalize URL/URI to bare ID
+      const playlistId = extractPlaylistId(rawId)
 
-    const existingSubs = await deps.subscriptionQueries.getSubscriptionsByUser(userId)
-    const existing = existingSubs.find(
-      (sub) =>
-        sub.sourceType === 'spotify-playlist' &&
-        (sub.sourceConfig as Record<string, unknown>).playlistId === playlistId,
-    )
+      const existingSubs = await deps.subscriptionQueries.getSubscriptionsByUser(userId)
+      const existing = existingSubs.find(
+        (sub) =>
+          sub.sourceType === 'spotify-playlist' &&
+          (sub.sourceConfig as Record<string, unknown>).playlistId === playlistId,
+      )
 
-    const subscription =
-      existing ??
-      (await deps.subscriptionQueries.createSubscription({
-        name: `Spotify Playlist Import`,
-        userId,
-        sourceType: 'spotify-playlist',
-        sourceProvider: 'spotify',
-        sourceConfig: { playlistId },
-        cron: '0 6 * * 1',
-        enabled: false,
-        maxArtistsPerRun: 100,
-        action: 'add_to_recommendations',
-        scoringWeightPreset: 'default',
-      }))
+      const subscription =
+        existing ??
+        (await deps.subscriptionQueries.createSubscription({
+          name: `Spotify Playlist Import`,
+          userId,
+          sourceType: 'spotify-playlist',
+          sourceProvider: 'spotify',
+          sourceConfig: { playlistId },
+          cron: '0 6 * * 1',
+          enabled: false,
+          maxArtistsPerRun: 100,
+          action: 'add_to_recommendations',
+          scoringWeightPreset: 'default',
+        }))
 
-    deps.runSubscription(subscription.id).catch((err: unknown) => {
-      console.error('Spotify playlist import failed:', err)
-    })
+      deps.runSubscription(subscription.id).catch((err: unknown) => {
+        console.error('Spotify playlist import failed:', err)
+      })
 
-    return c.json(
-      {
-        message: 'Spotify playlist import started',
-        subscriptionId: subscription.id,
-        created: !existing,
-      },
-      202,
-    )
-  })
+      return c.json(
+        {
+          message: 'Spotify playlist import started',
+          subscriptionId: subscription.id,
+          created: !existing,
+        },
+        202,
+      )
+    },
+  )
 
   router.post('/api/subscriptions/import/deezer-favorites', async (c) => {
     const userId = c.get('userId')
@@ -614,71 +583,66 @@ export function subscriptionRoutes(deps: AppDependencies) {
     return c.json({ playlists })
   })
 
-  router.post('/api/subscriptions/import/deezer-playlists', async (c) => {
-    const userId = c.get('userId')
-    if (!userId) {
-      return c.json({ error: 'Unauthorized' }, 401)
-    }
+  router.post(
+    '/api/subscriptions/import/deezer-playlists',
+    zJson(deezerPlaylistImportSchema),
+    async (c) => {
+      const userId = c.get('userId')
+      if (!userId) {
+        return c.json({ error: 'Unauthorized' }, 401)
+      }
 
-    const deezerToken = await getOAuthToken(deps.db, userId, 'deezer')
-    if (!deezerToken || deezerToken.accessToken.startsWith('pending:')) {
-      return c.json({ error: 'Deezer is not connected' }, 400)
-    }
+      const deezerToken = await getOAuthToken(deps.db, userId, 'deezer')
+      if (!deezerToken || deezerToken.accessToken.startsWith('pending:')) {
+        return c.json({ error: 'Deezer is not connected' }, 400)
+      }
 
-    const body = await c.req.json()
-    const playlistIds = (body as Record<string, unknown>).playlistIds
-    if (!Array.isArray(playlistIds) || playlistIds.length === 0) {
-      return c.json({ error: 'playlistIds must be a non-empty array' }, 400)
-    }
+      const { playlistIds } = c.req.valid('json')
 
-    const existingSubs = await deps.subscriptionQueries.getSubscriptionsByUser(userId)
-    const playlistIdsStr = (playlistIds as number[]).join(',')
-    const existing = existingSubs.find(
-      (sub) =>
-        sub.sourceType === 'deezer' &&
-        (sub.sourceConfig as Record<string, unknown>).feedType === 'playlists' &&
-        (sub.sourceConfig as Record<string, unknown>).playlistIds === playlistIdsStr,
-    )
+      const existingSubs = await deps.subscriptionQueries.getSubscriptionsByUser(userId)
+      const playlistIdsStr = playlistIds.map((v) => String(v)).join(',')
+      const existing = existingSubs.find(
+        (sub) =>
+          sub.sourceType === 'deezer' &&
+          (sub.sourceConfig as Record<string, unknown>).feedType === 'playlists' &&
+          (sub.sourceConfig as Record<string, unknown>).playlistIds === playlistIdsStr,
+      )
 
-    const subscription =
-      existing ??
-      (await deps.subscriptionQueries.createSubscription({
-        name: 'Deezer Playlist Import',
-        userId,
-        sourceType: 'deezer',
-        sourceProvider: 'deezer',
-        sourceConfig: { feedType: 'playlists', playlistIds: playlistIdsStr },
-        cron: '0 6 * * 1',
-        enabled: false,
-        maxArtistsPerRun: 100,
-        action: 'add_to_recommendations',
-        scoringWeightPreset: 'default',
-      }))
+      const subscription =
+        existing ??
+        (await deps.subscriptionQueries.createSubscription({
+          name: 'Deezer Playlist Import',
+          userId,
+          sourceType: 'deezer',
+          sourceProvider: 'deezer',
+          sourceConfig: { feedType: 'playlists', playlistIds: playlistIdsStr },
+          cron: '0 6 * * 1',
+          enabled: false,
+          maxArtistsPerRun: 100,
+          action: 'add_to_recommendations',
+          scoringWeightPreset: 'default',
+        }))
 
-    deps.runSubscription(subscription.id).catch((err: unknown) => {
-      console.error('Deezer playlist import failed:', err)
-    })
+      deps.runSubscription(subscription.id).catch((err: unknown) => {
+        console.error('Deezer playlist import failed:', err)
+      })
 
-    return c.json(
-      {
-        message: 'Deezer Playlist import started',
-        subscriptionId: subscription.id,
-        created: !existing,
-      },
-      202,
-    )
-  })
+      return c.json(
+        {
+          message: 'Deezer Playlist import started',
+          subscriptionId: subscription.id,
+          created: !existing,
+        },
+        202,
+      )
+    },
+  )
 
-  router.post('/api/subscriptions/bulk-toggle', async (c) => {
+  router.post('/api/subscriptions/bulk-toggle', zJson(bulkToggleSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    const body = await c.req.json()
-    const enabled =
-      typeof (body as Record<string, unknown>).enabled === 'boolean'
-        ? ((body as Record<string, unknown>).enabled as boolean)
-        : null
-    if (enabled === null) return c.json({ error: 'enabled (boolean) is required' }, 400)
+    const { enabled } = c.req.valid('json')
 
     const subs = await deps.subscriptionQueries.getSubscriptionsByUser(userId)
     let updated = 0
@@ -707,14 +671,69 @@ export function subscriptionRoutes(deps: AppDependencies) {
     return c.json({ jobs })
   })
 
-  router.patch('/api/subscriptions/:id', async (c) => {
+  router.patch(
+    '/api/subscriptions/:id',
+    zParam(subscriptionIdParamSchema),
+    zJson(updateSubscriptionSchema),
+    async (c) => {
+      const userId = c.get('userId')
+      if (!userId) {
+        return c.json({ error: 'Unauthorized' }, 401)
+      }
+
+      const { id } = c.req.valid('param')
+      const existing = await deps.subscriptionQueries.getSubscription(id)
+      if (!existing) {
+        return c.json({ error: 'Subscription not found' }, 404)
+      }
+      if (existing.userId !== userId) {
+        return c.json({ error: 'Forbidden' }, 403)
+      }
+
+      const body = c.req.valid('json')
+      const update: Record<string, unknown> = { ...body, action: 'add_to_recommendations' }
+
+      if (
+        existing.sourceType === DISCOVERY_MODE_SUBSCRIPTION_TYPE &&
+        update.sourceConfig !== undefined
+      ) {
+        const { error, normalizedConfig } = await resolveDiscoveryModeSourceConfig(
+          update.sourceConfig,
+          userId,
+          deps,
+        )
+        if (error) {
+          return c.json({ error }, 400)
+        }
+        update.sourceConfig = normalizedConfig as Record<string, unknown>
+      }
+
+      await deps.subscriptionQueries.updateSubscription(id, update)
+
+      // Sync scheduler when cron or enabled changes
+      const jobName = `subscription-${id}`
+      const newEnabled = Object.hasOwn(update, 'enabled')
+        ? (update.enabled as boolean)
+        : existing.enabled
+      const newCron = (update.cron as string | undefined) ?? existing.cron
+
+      if (!newEnabled) {
+        deps.scheduler.remove(jobName)
+      } else if (Object.hasOwn(update, 'enabled') || Object.hasOwn(update, 'cron')) {
+        // Re/schedule if enabled toggled on OR cron changed while enabled
+        deps.scheduler.schedule(jobName, newCron, () => deps.runSubscription(id))
+      }
+
+      return c.json({ updated: true })
+    },
+  )
+
+  router.delete('/api/subscriptions/:id', zParam(subscriptionIdParamSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401)
     }
-
-    const id = Number(c.req.param('id'))
-    if (!Number.isFinite(id)) return c.json({ error: 'Invalid subscription ID' }, 400)
+    const { id } = c.req.valid('param')
     const existing = await deps.subscriptionQueries.getSubscription(id)
     if (!existing) {
       return c.json({ error: 'Subscription not found' }, 404)
@@ -722,87 +741,18 @@ export function subscriptionRoutes(deps: AppDependencies) {
     if (existing.userId !== userId) {
       return c.json({ error: 'Forbidden' }, 403)
     }
-
-    const body = await c.req.json()
-    const update: Record<string, unknown> = {}
-    for (const key of ALLOWED_UPDATE_FIELDS) {
-      if (Object.hasOwn(body, key)) {
-        update[key] = (body as Record<string, unknown>)[key]
-      }
-    }
-    update.action = 'add_to_recommendations'
-
-    if (Object.hasOwn(update, 'cron') && update.cron !== undefined) {
-      try {
-        new Cron(update.cron as string, { maxRuns: 0 })
-      } catch {
-        return c.json({ error: 'Invalid cron expression' }, 400)
-      }
-    }
-
-    if (
-      existing.sourceType === DISCOVERY_MODE_SUBSCRIPTION_TYPE &&
-      Object.hasOwn(update, 'sourceConfig')
-    ) {
-      const { error, normalizedConfig } = await resolveDiscoveryModeSourceConfig(
-        update.sourceConfig,
-        userId,
-        deps,
-      )
-      if (error) {
-        return c.json({ error }, 400)
-      }
-      update.sourceConfig = normalizedConfig as Record<string, unknown>
-    }
-
-    await deps.subscriptionQueries.updateSubscription(id, update)
-
-    // Sync scheduler when cron or enabled changes
-    const jobName = `subscription-${id}`
-    const newEnabled = Object.hasOwn(update, 'enabled')
-      ? (update.enabled as boolean)
-      : existing.enabled
-    const newCron = (update.cron as string | undefined) ?? existing.cron
-
-    if (!newEnabled) {
-      deps.scheduler.remove(jobName)
-    } else if (Object.hasOwn(update, 'enabled') || Object.hasOwn(update, 'cron')) {
-      // Re/schedule if enabled toggled on OR cron changed while enabled
-      deps.scheduler.schedule(jobName, newCron, () => deps.runSubscription(id))
-    }
-
-    return c.json({ updated: true })
-  })
-
-  router.delete('/api/subscriptions/:id', async (c) => {
-    const userId = c.get('userId')
-    if (!userId) {
-      return c.json({ error: 'Unauthorized' }, 401)
-    }
-
-    const id = Number(c.req.param('id'))
-    if (!Number.isFinite(id)) return c.json({ error: 'Invalid subscription ID' }, 400)
-    const existing = await deps.subscriptionQueries.getSubscription(id)
-    if (!existing) {
-      return c.json({ error: 'Subscription not found' }, 404)
-    }
-    if (existing.userId !== userId) {
-      return c.json({ error: 'Forbidden' }, 403)
-    }
-
     await deps.subscriptionQueries.deleteSubscription(id)
     deps.scheduler.remove(`subscription-${id}`)
     return c.json({ deleted: true })
   })
 
-  router.post('/api/subscriptions/:id/run', async (c) => {
+  router.post('/api/subscriptions/:id/run', zParam(subscriptionIdParamSchema), async (c) => {
     const userId = c.get('userId')
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401)
     }
 
-    const id = Number(c.req.param('id'))
-    if (!Number.isFinite(id)) return c.json({ error: 'Invalid subscription ID' }, 400)
+    const { id } = c.req.valid('param')
     const existing = await deps.subscriptionQueries.getSubscription(id)
     if (!existing) {
       return c.json({ error: 'Subscription not found' }, 404)

--- a/src/server/schemas/jobs.ts
+++ b/src/server/schemas/jobs.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+export const jobTypeSchema = z.enum([
+  'pipeline',
+  'quick_discover',
+  'subscription',
+  'target',
+  'playlist',
+  'library_sync',
+])
+
+export const jobStatusSchema = z.enum(['running', 'completed', 'failed', 'stuck'])
+
+export const jobIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})
+
+export const listJobsQuerySchema = z.object({
+  type: jobTypeSchema.optional(),
+  status: jobStatusSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+})

--- a/src/server/schemas/oauth.ts
+++ b/src/server/schemas/oauth.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+// Initiate body is optional overall (Deezer branch reads env config only),
+// but if any field is set for the Spotify branch, all three must be strings.
+// Handler still enforces "all three required" after the switch so this schema
+// stays lenient.
+export const oauthInitiateSchema = z
+  .object({
+    clientId: z.string().max(500).optional(),
+    clientSecret: z.string().max(500).optional(),
+    redirectUri: z
+      .string()
+      .max(2048)
+      .refine((v) => v.startsWith('http://') || v.startsWith('https://'), {
+        message: 'redirectUri must start with http:// or https://',
+      })
+      .optional(),
+  })
+  .passthrough()
+
+export const oauthProviderParamSchema = z.object({
+  provider: z.enum(['spotify', 'deezer']),
+})

--- a/src/server/schemas/pipeline.ts
+++ b/src/server/schemas/pipeline.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+// normalizeDiscoveryModeRequest is the authoritative parser for the body
+// shape; schema here catches gross mismatches (wrong types on the top-level
+// fields) before it runs. The nested `settings` object is adapter-specific
+// and stays permissive.
+export const discoveryModeRunSchema = z
+  .object({
+    modeId: z.string().trim().min(1).max(100).optional(),
+    settingsMode: z.string().max(64).optional(),
+    settings: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough()
+
+export const quickDiscoverSchema = z.object({
+  artistName: z.string().trim().min(1).max(200),
+})

--- a/src/server/schemas/playlists.ts
+++ b/src/server/schemas/playlists.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod'
+import { cronSchema } from './subscriptions'
+
+export const playlistStrategySchema = z.enum([
+  'weekly_digest',
+  'genre_focus',
+  'mood_mix',
+  'rediscover',
+])
+
+export const playlistIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})
+
+export const playlistExportFormatParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+  format: z.enum(['json', 'csv', 'm3u', 'xspf']),
+})
+
+export const createPlaylistSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  strategy: playlistStrategySchema,
+  targetIds: z.array(z.number().int().positive()).max(50).optional(),
+  schedule: cronSchema.nullable().optional(),
+  config: z.record(z.string(), z.unknown()).nullable().optional(),
+  enabled: z.boolean().optional(),
+})
+
+export const updatePlaylistSchema = z
+  .object({
+    name: z.string().trim().min(1).max(200).optional(),
+    strategy: playlistStrategySchema.optional(),
+    targetIds: z.array(z.number().int().positive()).max(50).optional(),
+    schedule: cronSchema.nullable().optional(),
+    config: z.record(z.string(), z.unknown()).nullable().optional(),
+    enabled: z.boolean().optional(),
+  })
+  .strict()

--- a/src/server/schemas/recommendations.ts
+++ b/src/server/schemas/recommendations.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+
+// MAX_BULK_IDS caps the bulk write surface so one approve-all payload cannot
+// starve the worker. 500 matches the Spotify CSV import truncation ceiling.
+const MAX_BULK_IDS = 500
+
+export const recommendationIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})
+
+export const recommendationStatusSchema = z.enum(['approved', 'rejected', 'pending'])
+export const approvalModeSchema = z.enum(['single_target', 'combined_lidarr_slskd'])
+export const monitorOptionSchema = z.enum(['all', 'new', 'none', 'selected'])
+export const sortSchema = z.enum(['score_desc', 'score_asc', 'created_desc', 'acted_on_desc'])
+
+export const updateRecommendationSchema = z.object({
+  status: recommendationStatusSchema,
+  approvalMode: approvalModeSchema.optional(),
+  lidarrTargetId: z.string().optional(),
+  monitorOption: monitorOptionSchema.optional(),
+  selectedAlbumIds: z.array(z.string()).max(200).optional(),
+  targetId: z.string().optional(),
+  qualityProfileId: z.number().int().optional(),
+  metadataProfileId: z.number().int().optional(),
+  rootFolderId: z.number().int().optional(),
+})
+
+export const bulkRecommendationSchema = z.object({
+  ids: z.array(z.number().int().positive()).min(1).max(MAX_BULK_IDS),
+  action: z.enum(['approve', 'reject']),
+  targetId: z.string().optional(),
+  qualityProfileId: z.number().int().optional(),
+  metadataProfileId: z.number().int().optional(),
+  rootFolderId: z.number().int().optional(),
+})
+
+// GET /api/recommendations query: permissive (optional, empty strings tolerated)
+// so existing frontend URLs keep working.
+export const listRecommendationsQuerySchema = z.object({
+  batchId: z.coerce.number().int().positive().optional(),
+  status: z.string().max(200).optional(),
+  decades: z.string().max(100).optional(),
+  sort: sortSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+})

--- a/src/server/schemas/setup.ts
+++ b/src/server/schemas/setup.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+// Setup wizard accepts a bunch of fields, most optional, with
+// conditional-require rules enforced in the handler (e.g., lidarrApiKey
+// required when lidarrUrl is set). The schema normalizes types and caps
+// length so opaque blobs cannot slip through.
+export const setupCompleteSchema = z
+  .object({
+    // Global settings (filtered via allowlist in handler)
+    lidarrUrl: z.string().max(2048).optional(),
+    lidarrApiKey: z.string().max(200).optional(),
+    skipTlsVerify: z.boolean().optional(),
+    aiProvider: z.string().max(64).optional(),
+    aiApiKey: z.string().max(500).optional(),
+    aiModel: z.string().max(200).optional(),
+    aiBaseUrl: z.string().max(2048).optional(),
+    preferences: z.record(z.string(), z.unknown()).optional(),
+    // Emby credentials (persisted separately on users row)
+    embyUrl: z.string().max(2048).optional(),
+    embyApiKey: z.string().max(200).optional(),
+    embyUserId: z.string().max(200).optional(),
+  })
+  .passthrough()

--- a/src/server/schemas/subscriptions.ts
+++ b/src/server/schemas/subscriptions.ts
@@ -1,0 +1,76 @@
+import { Cron } from 'croner'
+import { z } from 'zod'
+
+// Cron string: any expression croner can parse. Validate by construction
+// attempt so the error surfaces at the schema boundary instead of later.
+export const cronSchema = z
+  .string()
+  .trim()
+  .min(1, 'cron expression is required')
+  .max(100)
+  .refine(
+    (value) => {
+      try {
+        new Cron(value, { maxRuns: 0 })
+        return true
+      } catch {
+        return false
+      }
+    },
+    { message: 'Invalid cron expression' },
+  )
+
+export const subscriptionIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})
+
+const listenerRangeSchema = z.object({
+  min: z.number().int().nonnegative().optional(),
+  max: z.number().int().nonnegative().optional(),
+})
+
+// sourceConfig varies per sourceType (discovery-mode-config, spotify-playlist
+// id, deezer feedType+playlistIds, etc.). Adapters own the inner shape;
+// here we only gate that it is an object and impose an overall size ceiling.
+const sourceConfigSchema = z.record(z.string(), z.unknown())
+
+export const createSubscriptionSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  sourceType: z.string().trim().min(1).max(64),
+  sourceProvider: z.string().trim().min(1).max(64),
+  sourceConfig: sourceConfigSchema,
+  cron: cronSchema,
+  enabled: z.boolean().optional(),
+  maxArtistsPerRun: z.number().int().min(1).max(1000).optional(),
+  listenerRange: listenerRangeSchema.optional(),
+  scoringWeightPreset: z.string().max(64).optional(),
+})
+
+export const updateSubscriptionSchema = z
+  .object({
+    name: z.string().trim().min(1).max(200).optional(),
+    enabled: z.boolean().optional(),
+    sourceConfig: sourceConfigSchema.optional(),
+    maxArtistsPerRun: z.number().int().min(1).max(1000).optional(),
+    listenerRange: listenerRangeSchema.optional(),
+    cron: cronSchema.optional(),
+    scoreThreshold: z.number().min(0).max(1).optional(),
+    scoringWeightPreset: z.string().max(64).optional(),
+    scoringWeightOverrides: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict()
+
+export const bulkToggleSchema = z.object({
+  enabled: z.boolean(),
+})
+
+export const deezerPlaylistImportSchema = z.object({
+  playlistIds: z
+    .array(z.union([z.number().int(), z.string().regex(/^\d+$/)]))
+    .min(1)
+    .max(100),
+})
+
+export const spotifyPlaylistImportSchema = z.object({
+  playlistId: z.string().trim().min(1).max(100),
+})

--- a/tests/server/routes/jobs.test.ts
+++ b/tests/server/routes/jobs.test.ts
@@ -74,20 +74,20 @@ describe('GET /api/jobs', () => {
     })
   })
 
-  it('caps limit at 100', async () => {
+  it('rejects limit above 100', async () => {
     const deps = makeMockDeps()
     const app = createApp(deps)
-    await app.request('/api/jobs?limit=999')
-    expect(deps.jobQueries.listJobs).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }))
+    const res = await app.request('/api/jobs?limit=999')
+    expect(res.status).toBe(400)
+    expect(deps.jobQueries.listJobs).not.toHaveBeenCalled()
   })
 
-  it('clamps limit to 1 and offset to 0 for negative values', async () => {
+  it('rejects negative limit / offset', async () => {
     const deps = makeMockDeps()
     const app = createApp(deps)
-    await app.request('/api/jobs?limit=-10&offset=-5')
-    expect(deps.jobQueries.listJobs).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: 1, offset: 0 }),
-    )
+    const res = await app.request('/api/jobs?limit=-10&offset=-5')
+    expect(res.status).toBe(400)
+    expect(deps.jobQueries.listJobs).not.toHaveBeenCalled()
   })
 
   it('accepts library_sync as a valid job type filter', async () => {

--- a/tests/server/routes/subscriptions.test.ts
+++ b/tests/server/routes/subscriptions.test.ts
@@ -515,17 +515,17 @@ describe('PATCH /api/subscriptions/:id', () => {
     )
   })
 
-  it('strips non-allowlisted fields from update', async () => {
+  it('rejects non-allowlisted fields on update (strict schema)', async () => {
     const app = createTestApp(makeDeps(), USER_ID)
-    await app.request('/api/subscriptions/1', {
+    const res = await app.request('/api/subscriptions/1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'ok', sourceType: 'evil', userId: 999 }),
     })
-    expect(mockSubQueries.updateSubscription).toHaveBeenCalledWith(
-      1,
-      expect.not.objectContaining({ sourceType: 'evil', userId: 999 }),
-    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('validation_failed')
+    expect(mockSubQueries.updateSubscription).not.toHaveBeenCalled()
   })
 })
 

--- a/tests/server/routes/validation.test.ts
+++ b/tests/server/routes/validation.test.ts
@@ -212,6 +212,143 @@ describe('validation: settings PATCH', () => {
   })
 })
 
+describe('validation: subscriptions', () => {
+  it('rejects POST /api/subscriptions with missing cron', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/subscriptions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        name: 'Test',
+        sourceType: 'listenbrainz',
+        sourceProvider: 'listenbrainz',
+        sourceConfig: { userName: 'x' },
+        // cron missing
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects POST /api/subscriptions with invalid cron', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/subscriptions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        name: 'Test',
+        sourceType: 'listenbrainz',
+        sourceProvider: 'listenbrainz',
+        sourceConfig: {},
+        cron: 'not a cron expression',
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects deezer-playlists import with empty playlistIds array', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/subscriptions/import/deezer-playlists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ playlistIds: [] }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects deezer-playlists import with >100 playlistIds (array size cap)', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/subscriptions/import/deezer-playlists', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        playlistIds: Array.from({ length: 101 }, (_, i) => i + 1),
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects bulk-toggle without enabled field', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/subscriptions/bulk-toggle', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('validation: recommendations', () => {
+  it('rejects PATCH with invalid status enum', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/recommendations/1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ status: 'maybe' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects bulk with >500 ids (array size cap)', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/recommendations/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        ids: Array.from({ length: 501 }, (_, i) => i + 1),
+        action: 'reject',
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects bulk with invalid action', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/recommendations/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ ids: [1, 2], action: 'delete' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects GET query with invalid sort enum', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/recommendations?sort=random', { headers })
+    expect(res.status).toBe(400)
+  })
+})
+
+// Playlist routes need playlistDeps wired; covered by playlists.test.ts.
+
+describe('validation: oauth initiate', () => {
+  it('rejects non-http redirectUri', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/auth/oauth/spotify/initiate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({
+        clientId: 'x',
+        clientSecret: 'y',
+        redirectUri: 'javascript:alert(1)',
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('validation: quick-discover', () => {
+  it('rejects empty artistName', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/pipeline/quick-discover', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({ artistName: '' }),
+    })
+    expect(res.status).toBe(400)
+  })
+})
+
 describe('validation: admin restore', () => {
   it('rejects POST /api/admin/restore with missing data section', async () => {
     const { app, headers } = await authedApp()


### PR DESCRIPTION
Batch 8b of the 0.27.x hardening sweep. Closes out the Zod migration started in 8a by covering subscriptions, playlists, recommendations, pipeline, setup, OAuth, and jobs.

## Summary

- **7 new schemas** (``src/server/schemas/{subscriptions,recommendations,pipeline,setup,playlists,oauth,jobs}.ts``), including a reusable ``cronSchema`` (croner-verified) and enum types for statuses, sort orders, export formats, and job types.
- **Array size caps** at the schema layer: ``deezer-playlists`` import max 100, ``recommendations bulk`` max 500, ``selectedAlbumIds`` max 200, ``targetIds`` max 50. One approve-all payload can no longer starve the worker.
- **Strict PATCH** on subscriptions, playlists (plus users and targets from 8a) rejects unknown keys with 400 rather than silently stripping. One subscription test covered the old silent-drop; updated to assert the new strict-reject.
- **jobs list query** out-of-range ``limit``/``offset`` now returns 400 instead of clamping. Existing tests updated.
- **OAuth ``redirectUri``** refined to ``http(s)`` only - ``javascript:`` / ``data:`` URIs rejected at the schema boundary before they hit the auth-URL string render.
- Dead code removed: ``ALLOWED_UPDATE_FIELDS`` sets in subscriptions and playlists; ``parseOptionalInteger`` helper in recommendations.

## Test plan

- [x] ``bun run lint``, ``bun run typecheck``, ``bun run i18n:check`` clean
- [x] ``bun run test`` 1830/1830 (scrypt flake from 8a happened to pass this run)
- [x] Per-file tests all green: ``subscriptions.test.ts`` 52/52, ``recommendations*.test.ts`` 25+9/34, ``playlists.test.ts`` 28/28, ``jobs.test.ts`` 13/13, ``oauth*.test.ts`` 20/20, ``pipeline.test.ts``, ``setup.test.ts``, ``validation.test.ts`` 26/26
- [x] CI green

## Follow-ups

- Zod error-message i18n (non-trivial - touches 15 locale catalogs + a per-issue code map). Documented as deferred; login still manual-validates for 8a compatibility.
- ``drizzle-zod``-derived schemas now have a legitimate home (most write routes use an adapter-shaped record that partially mirrors DB insert shapes). Low-priority cleanup.