### PR TITLE
fix(self-hosted): allow private IPs for Plex, Jellyfin, Emby, and AI base URLs (v0.27.11)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -40,7 +40,7 @@ body:
     attributes:
       label: Digarr version
       description: Visible in the footer of the web UI, or `package.json`.
-      placeholder: "e.g. 0.27.3"
+      placeholder: "e.g. 0.27.11"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes are documented here.
 
 ## Unreleased
 
+## v0.27.11 - 2026-04-15
+
+### Fixed
+
+- Self-hosted Plex, Jellyfin, Emby URLs behind reverse proxies on a LAN are no longer rejected as SSRF targets. The "URL resolves to a private/internal IP" block treated the user's own media server like an untrusted webhook destination, which broke split-horizon DNS deployments (public hostname resolving to a private IP) and every direct-LAN setup.
+- Self-hosted AI base URLs are accepted for the same reason. Local Ollama at the default `http://localhost:11434` and any OpenAI-compatible endpoint on a private address now work without tripping the private-IP guard on connect or at request time.
+
+### Changed
+
+- The private-IP guard stays in place for user-configurable outbound URLs that can plausibly be adversarially set (webhooks, OIDC issuer, metadata fallback, fanart.tv, musicinfo.pro). It's only relaxed on admin-owned service URLs where private IPs are the expected default.
+
 ## v0.26.7 - 2026-04-14
 
 ### Fixed

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -5,11 +5,11 @@
 
 services:
   app:
-    image: docker.io/iuliandita/digarr:0.26
+    image: docker.io/iuliandita/digarr:0.27
     # Pin to a patch version for full stability:
-    # image: docker.io/iuliandita/digarr:0.26.7
+    # image: docker.io/iuliandita/digarr:0.27.11
     # Alpine variant (smaller image, musl libc):
-    # image: docker.io/iuliandita/digarr:0.26.7-alpine
+    # image: docker.io/iuliandita/digarr:0.27.11-alpine
     env_file:
       - path: .env
         required: false

--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.27.10
-appVersion: "0.27.10"
+version: 0.27.11
+appVersion: "0.27.11"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.27.10"
+  tag: "0.27.11"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
   digest: "sha256:1a88f37c94cd9d46a798d8d1594c6a0f3ee53fc47fd22a1667168c8347f51f78"
   pullPolicy: Always

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-   <Repository>docker.io/iuliandita/digarr:0.26.7</Repository>
-   <Tag>0.26.7</Tag>
-   <TagDescription>v0.26.7 stable release</TagDescription>
+   <Repository>docker.io/iuliandita/digarr:0.27.11</Repository>
+   <Tag>0.27.11</Tag>
+   <TagDescription>v0.27.11 stable release</TagDescription>
   <Network>bridge</Network>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Updated: 2026-04-14 | Current: v0.27.8
+> Updated: 2026-04-15 | Current: v0.27.11
 >
 > Priorities change with feedback. This is current intent, not a promise.
 
@@ -104,12 +104,14 @@ Release reminder: after publishing a new app image, update the pinned digests in
 - Operations and safety now include backup/restore, pre-flight migration checks, auto-backups, job history, stuck-task detection, and browser-test release gates
 - Recent integration work added Deezer OAuth feeds, Emby support, linked `slskd` targets, and broader playlist export coverage
 
-### v0.27.0 -- v0.27.8
+### v0.27.0 -- v0.27.11
 
 - Data-safety fixes for legacy `SERIAL` sequence restore and identity-index carryover
 - Pipeline isolation so manual runs no longer share state with scheduled runs
 - `oidc_tokens` table now encrypted at rest via the same AES-256-GCM / HKDF envelope as other sensitive columns
-- Full SSRF sweep: CGNAT (100.64.0.0/10), LIKE-escape on OAuth state lookup, OIDC IP pinning via `openid-client` `customFetch`, route + client + provider-level URL validation, `publicIpOnly` on HTTP clients that talk to user-configured endpoints
+- Full SSRF sweep: CGNAT (100.64.0.0/10), LIKE-escape on OAuth state lookup, OIDC IP pinning via `openid-client` `customFetch`, route + client + provider-level URL validation, `publicIpOnly` on HTTP clients that talk to webhooks and third-party APIs
+- Self-hosted media and AI targets are no longer blocked by that private-IP guard (v0.27.11): Plex, Jellyfin, Emby, Ollama, and openai-compatible endpoints accept LAN addresses and split-horizon hostnames, matching what self-hosters actually deploy
+- Zod validation sweep across auth, users, targets, settings, subscriptions, playlists, recommendations, pipeline, oauth, jobs, setup, and admin-restore routes with a shared error shape and strict `.strict()`/array-cap protections on write paths
 - i18n coverage sweep across components and library-sync progress messages; catalog parity held at 15 locales with targeted MT-quality fixes
 - Kubernetes hardening: dedicated ServiceAccount with token automount disabled, PodDisruptionBudget template gated on replicas > 1, Pod Security Standards `enforce: restricted` on the namespace, bundled Postgres container now drops all capabilities
 - CI supply chain: all Forgejo runner images and Dockerfile FROMs pinned by `@sha256` digest; GitHub release workflow now signs every published image with cosign via Sigstore OIDC (keyless) and attaches the SBOM as a cosign attestation bound to the image digest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.27.10",
+  "version": "0.27.11",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/core/clients/emby.ts
+++ b/src/core/clients/emby.ts
@@ -15,7 +15,6 @@ export function createEmbyClient(
       'X-Emby-Token': apiKey,
     },
     skipTlsVerify: options?.skipTlsVerify,
-    publicIpOnly: true,
   })
 
   const queue = new PQueue({ concurrency: 3, interval: 1000, intervalCap: 10 })

--- a/src/core/clients/jellyfin.ts
+++ b/src/core/clients/jellyfin.ts
@@ -63,7 +63,6 @@ export function createJellyfinClient(
       Authorization: `MediaBrowser Token="${apiKey}"`,
     },
     skipTlsVerify: options?.skipTlsVerify,
-    publicIpOnly: true,
   })
 
   const queue = new PQueue({ concurrency: 3, interval: 1000, intervalCap: 10 })

--- a/src/core/clients/plex.ts
+++ b/src/core/clients/plex.ts
@@ -86,7 +86,6 @@ export function createPlexClient(
       'X-Plex-Token': token,
       Accept: 'application/json',
     },
-    publicIpOnly: true,
   })
 
   const queue = new PQueue({ concurrency: 3, interval: 1000, intervalCap: 10 })

--- a/src/core/providers/ollama.ts
+++ b/src/core/providers/ollama.ts
@@ -1,5 +1,4 @@
 import type { AiRecommendation, TasteProfile } from '@/core/types'
-import { validatePublicServiceUrl } from '@/core/url-safety'
 import { errMsg } from '@/core/validation'
 import { buildRecommendationPrompt, parseRecommendationResponse } from './prompt'
 import type { RecommendationProvider } from './types'
@@ -26,13 +25,7 @@ export class OllamaProvider implements RecommendationProvider {
     this.baseUrl = baseUrl.replace(/\/$/, '')
   }
 
-  private async ensureBaseUrlSafe(): Promise<void> {
-    const validation = await validatePublicServiceUrl(this.baseUrl, 'Ollama base URL')
-    if (!validation.ok) throw new Error(validation.message)
-  }
-
   async getRecommendations(profile: TasteProfile): Promise<AiRecommendation[]> {
-    await this.ensureBaseUrlSafe()
     const prompt = buildRecommendationPrompt(profile)
 
     const controller = new AbortController()
@@ -68,11 +61,6 @@ export class OllamaProvider implements RecommendationProvider {
   }
 
   async testConnection(): Promise<{ success: boolean; message: string }> {
-    try {
-      await this.ensureBaseUrlSafe()
-    } catch (err: unknown) {
-      return { success: false, message: errMsg(err) }
-    }
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), 10_000)
     try {

--- a/src/core/providers/openai-compatible.ts
+++ b/src/core/providers/openai-compatible.ts
@@ -1,5 +1,4 @@
 import type { AiRecommendation, TasteProfile } from '@/core/types'
-import { validatePublicServiceUrl } from '@/core/url-safety'
 import { errMsg } from '@/core/validation'
 import {
   buildRecommendationPrompt,
@@ -19,13 +18,7 @@ export class OpenAICompatibleProvider implements RecommendationProvider {
     this.apiKey = apiKey
   }
 
-  private async ensureBaseUrlSafe(): Promise<void> {
-    const validation = await validatePublicServiceUrl(this.baseUrl, 'AI base URL')
-    if (!validation.ok) throw new Error(validation.message)
-  }
-
   async getRecommendations(profile: TasteProfile): Promise<AiRecommendation[]> {
-    await this.ensureBaseUrlSafe()
     const prompt = buildRecommendationPrompt(profile)
     const headers: Record<string, string> = { 'Content-Type': 'application/json' }
     if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`
@@ -64,11 +57,6 @@ export class OpenAICompatibleProvider implements RecommendationProvider {
   }
 
   async testConnection(): Promise<{ success: boolean; message: string }> {
-    try {
-      await this.ensureBaseUrlSafe()
-    } catch (err: unknown) {
-      return { success: false, message: errMsg(err) }
-    }
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), 10_000)
     try {

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -236,27 +236,6 @@ export function settingsRoutes(deps: AppDependencies) {
       return c.json({ error: 'Admin access required to modify global settings' }, 403)
     }
 
-    for (const [field, label] of [
-      ['plexUrl', 'Plex URL'],
-      ['jellyfinUrl', 'Jellyfin URL'],
-      ['embyUrl', 'Emby URL'],
-    ] as const) {
-      const url = userUpdate[field]
-      if (typeof url === 'string' && url) {
-        const validation = await validatePublicServiceUrl(url, label)
-        if (!validation.ok) {
-          return c.json({ error: validation.message }, 400)
-        }
-      }
-    }
-
-    if (typeof globalFields.aiBaseUrl === 'string' && globalFields.aiBaseUrl) {
-      const validation = await validatePublicServiceUrl(globalFields.aiBaseUrl, 'AI base URL')
-      if (!validation.ok) {
-        return c.json({ error: validation.message }, 400)
-      }
-    }
-
     if (userId && Object.keys(userUpdate).length > 0) {
       await updateUserConnections(deps.db, userId, userUpdate)
     }
@@ -366,12 +345,6 @@ export function settingsRoutes(deps: AppDependencies) {
       case 'ai': {
         try {
           const effectiveBaseUrl = body.baseUrl || (stored?.aiBaseUrl as string) || ''
-          if (effectiveBaseUrl) {
-            const validation = await validatePublicServiceUrl(effectiveBaseUrl, 'AI base URL')
-            if (!validation.ok) {
-              return c.json({ success: false, message: validation.message }, 400)
-            }
-          }
           const provider = await deps.providerRegistry.create(
             body.provider || (stored?.aiProvider as string) || '',
             {

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -1,5 +1,4 @@
 import { Hono } from 'hono'
-import { validatePublicServiceUrl } from '@/core/url-safety'
 import type { SetupConfig } from '@/db/queries/settings'
 import { updateUserConnections } from '@/db/queries/users'
 import type { AppDependencies } from '@/server'
@@ -53,13 +52,6 @@ export function setupRoutes(deps: AppDependencies) {
 
     if (missing.length > 0) {
       return c.json({ error: 'Missing required fields', fields: missing }, 400)
-    }
-
-    if (typeof body.embyUrl === 'string' && body.embyUrl) {
-      const validation = await validatePublicServiceUrl(body.embyUrl, 'Emby URL')
-      if (!validation.ok) {
-        return c.json({ error: validation.message }, 400)
-      }
     }
 
     await deps.completeSetup(sanitized as SetupConfig)

--- a/tests/core/clients/emby.test.ts
+++ b/tests/core/clients/emby.test.ts
@@ -3,15 +3,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createEmbyClient } from '@/core/clients/emby'
 
-// publicIpOnly triggers dns.lookup; the test URLs aren't resolvable.
-vi.mock('node:dns/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:dns/promises')>()
-  return {
-    ...actual,
-    lookup: vi.fn(async () => ({ address: '93.184.216.34', family: 4 })),
-  }
-})
-
 describe('createEmbyClient', () => {
   beforeEach(() => {
     vi.restoreAllMocks()

--- a/tests/core/providers/ollama.test.ts
+++ b/tests/core/providers/ollama.test.ts
@@ -2,13 +2,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { OllamaProvider } from '@/core/providers/ollama'
 import type { TasteProfile } from '@/core/types'
 
-// OllamaProvider runs the user-supplied baseUrl through validatePublicServiceUrl
-// at request time for SSRF defense-in-depth. Mock DNS + URL helpers so the
-// test's stand-in hostname resolves cleanly without hitting the network.
-vi.mock('@/core/url-safety', () => ({
-  validatePublicServiceUrl: vi.fn(async () => ({ ok: true })),
-}))
-
 const TEST_BASE_URL = 'http://ollama.example.com:11434'
 
 const sampleProfile: TasteProfile = {

--- a/tests/core/providers/openai-compatible.test.ts
+++ b/tests/core/providers/openai-compatible.test.ts
@@ -1,12 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { OpenAICompatibleProvider } from '@/core/providers/openai-compatible'
 
-// Mock URL safety helpers so the provider's SSRF check doesn't trip on
-// the stand-in hostname used below.
-vi.mock('@/core/url-safety', () => ({
-  validatePublicServiceUrl: vi.fn(async () => ({ ok: true })),
-}))
-
 const TEST_BASE_URL = 'http://openai.example.com:8080'
 
 describe('OpenAICompatibleProvider', () => {

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -498,7 +498,7 @@ describe('PATCH /api/settings', () => {
     expect(res.status).toBe(403)
   })
 
-  it('rejects private media-server URLs for non-admin users', async () => {
+  it('accepts private media-server URLs (self-hosted LAN / reverse-proxy setups)', async () => {
     await clearAllSessions()
     await createSession(7, 'user-session-token')
 
@@ -560,11 +560,19 @@ describe('PATCH /api/settings', () => {
       }),
     })
 
-    expect(res.status).toBe(400)
-    await expect(res.json()).resolves.toEqual({
-      error: 'Emby URL must not point to a private or internal address',
-    })
-    expect(dbWithUpdate.update).not.toHaveBeenCalled()
+    // Self-hosted media servers are the user's own box. Private IPs and
+    // split-horizon-DNS hostnames that resolve to LAN addresses must be
+    // accepted -- that's the default deployment, not an SSRF target.
+    expect(res.status).toBe(200)
+    expect(mockUpdateUserConnections).toHaveBeenCalledWith(
+      expect.anything(),
+      7,
+      expect.objectContaining({
+        embyUrl: 'http://127.0.0.1:8096',
+        embyApiKey: 'secret',
+        embyUserId: 'user-1',
+      }),
+    )
   })
 })
 


### PR DESCRIPTION
Fixes #113.

## Summary

The private-IP SSRF guard treated self-hosted media servers and AI endpoints the same as untrusted webhook destinations. For self-hosters behind a reverse proxy or on a LAN, this blocked the default deployment:

- Split-horizon DNS hostnames that resolve to private IPs (the reporter's case)
- Direct LAN addresses (192.168.x, 10.x, 127.0.0.1)
- The default Ollama endpoint \`http://localhost:11434\`

Both the \`PATCH /api/settings\` save step and the \`POST /api/settings/test/plex\` (and friends) endpoints would 400 with \`URL resolves to a private/internal IP\`, plus Ollama/openai-compatible providers had a request-time guard that threw the same error on every call.

## What changed

**Dropped \`publicIpOnly\` from self-hosted media clients:**
- \`src/core/clients/plex.ts\`
- \`src/core/clients/jellyfin.ts\`
- \`src/core/clients/emby.ts\`

**Removed \`ensureBaseUrlSafe\` from self-hosted AI providers:**
- \`src/core/providers/ollama.ts\`
- \`src/core/providers/openai-compatible.ts\`

**Removed pre-check URL validations from routes:**
- \`PATCH /api/settings\` (\`plexUrl\`, \`jellyfinUrl\`, \`embyUrl\`, \`aiBaseUrl\`)
- \`POST /api/settings/test/ai\`
- \`POST /api/setup/complete\` (\`embyUrl\`)

## What stayed strict

- Webhook SSRF guard (user-configurable, plausibly adversarial)
- OIDC issuer URL check (external IdP is the norm)
- Metadata fallback URL (external service)
- \`fanart.tv\` and \`musicinfo.pro\` clients (external APIs)

## Rationale

These service URLs are admin-owned pointers to the user's own infrastructure. Blocking private IPs there protects no one and breaks the most common self-hosted deployment (Plex, Jellyfin, Emby on LAN; Ollama on localhost). Lidarr has never enforced \`publicIpOnly\`, so this restores consistency across media and AI targets.

## Test plan

- [x] Full vitest suite passes locally (1852 tests, one scrypt-slow flake under full-suite load that passes in isolation)
- [x] \`bun run lint\` clean
- [x] \`bun run typecheck\` clean
- [x] Flipped the \`settings.test.ts\` SSRF rejection test to assert that \`http://127.0.0.1:8096\` is now accepted and reaches \`updateUserConnections\`
- [ ] Post-merge: digest repin for \`v0.27.11\` (separate chore commit once GHCR build publishes)

## Release surface

Version bumped to \`v0.27.11\` across \`package.json\`, Helm chart + values, K8s deployment tag, docker-compose, Unraid template, issue template placeholder, CHANGELOG, and both ROADMAPs.