### PR TITLE
fix(library): graceful degradation when MusicBrainz returns 5xx (v0.27.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-facing changes are documented here.
 
 ## Unreleased
 
+## v0.27.12 - 2026-04-16
+
+### Fixed
+
+- Library sync no longer aborts when MusicBrainz returns a transient error (HTTP 503, timeouts, network blips). The affected artist or album is left unreconciled and retried on the next sync run. A warning with the failure count appears on the Library Sources panel so the user knows some data was skipped. Applies to all library sources (Plex, Jellyfin, Emby, Lidarr) since they share the same reconciler. Fixes #115.
+
+### Changed
+
+- The MusicBrainz client now retries transient failures (5xx, 429, network errors) up to 3 times with exponential backoff plus jitter, honoring `Retry-After` when provided. This absorbs short MB hiccups before the graceful-degrade path kicks in.
+
 ## v0.27.11 - 2026-04-15
 
 ### Fixed

--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: digarr
 description: Music discovery app -- finds new artists based on your listening history
 type: application
-version: 0.27.11
-appVersion: "0.27.11"
+version: 0.27.12
+appVersion: "0.27.12"

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.27.11"
+  tag: "0.27.12"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
   digest: "sha256:178bde804376f798ee2dc51c9221f66d84f30e2b18ef7d4b9e27dd798996dd9f"
   pullPolicy: Always

--- a/docs/API.md
+++ b/docs/API.md
@@ -147,12 +147,12 @@ Locale notes:
 | GET | `/api/recommendations/feedback-summary` | Yes | Genre approval rates (top 20) |
 
 **GET /api/recommendations** query params:
-- `status` -- `pending`, `approved`, `rejected`, `added_to_lidarr`, `add_failed` (comma-separated)
-- `batchId` -- filter by batch
-- `sort` -- `score_desc` (default), `score_asc`, `created_desc`, `acted_on_desc`
-- `decades` -- era filter, comma-separated: `60s`, `70s`, `80s`, `90s`, `00s`, `10s`, `20s`
-- `limit` -- 1-200 (default 20)
-- `offset` -- pagination offset
+- `status` - `pending`, `approved`, `rejected`, `added_to_lidarr`, `add_failed` (comma-separated)
+- `batchId` - filter by batch
+- `sort` - `score_desc` (default), `score_asc`, `created_desc`, `acted_on_desc`
+- `decades` - era filter, comma-separated: `60s`, `70s`, `80s`, `90s`, `00s`, `10s`, `20s`
+- `limit` - 1-200 (default 20)
+- `offset` - pagination offset
 
 **PATCH /api/recommendations/:id** body:
 ```json
@@ -185,8 +185,8 @@ Approval notes:
 | GET | `/api/preview/audio` | Yes | Proxy Deezer preview audio (CORS bypass) |
 
 **GET /api/preview/audio** query params:
-- `url` -- Deezer CDN preview URL (must match `*.dzcdn.net`)
-- `token` -- auth token (for `<audio>` elements that can't send headers)
+- `url` - Deezer CDN preview URL (must match `*.dzcdn.net`)
+- `token` - auth token (for `<audio>` elements that can't send headers)
 
 ---
 
@@ -373,9 +373,9 @@ Locale notes:
 Each source includes a `stability` field (`stable` or `experimental`). TIDAL and Bandcamp are experimental.
 
 **GET /api/search** query params:
-- `q` -- required search string
-- `sources` -- optional comma-separated source IDs
-- `limit` -- 1-50 (default 20)
+- `q` - required search string
+- `sources` - optional comma-separated source IDs
+- `limit` - 1-50 (default 20)
 
 When one enabled source fails, Digarr still returns results from the healthy sources when possible.
 
@@ -432,7 +432,7 @@ Notes:
 - Only the first 50 MBIDs are queued per request
 
 **GET /api/library/warm/status** query params:
-- `mbids` -- comma-separated MBIDs to inspect (up to 100)
+- `mbids` - comma-separated MBIDs to inspect (up to 100)
 
 **POST /api/library/sync** notes:
 - Rate limited: 5/min
@@ -531,10 +531,10 @@ Query params: `range` (week/month/year), `limit` (1-50).
 | GET | `/api/jobs/health` | Admin | System health summary (pipeline, subscriptions, playlists, library sync, sources) |
 
 **GET /api/jobs** query params:
-- `type` -- `pipeline`, `quick_discover`, `subscription`, `target`, `playlist`, `library_sync`
-- `status` -- `running`, `completed`, `failed`, `stuck`
-- `limit` -- 1-100 (default 50)
-- `offset` -- pagination offset (minimum 0)
+- `type` - `pipeline`, `quick_discover`, `subscription`, `target`, `playlist`, `library_sync`
+- `status` - `running`, `completed`, `failed`, `stuck`
+- `limit` - 1-100 (default 50)
+- `offset` - pagination offset (minimum 0)
 - Invalid `type` or `status` values return `400`
 
 ---

--- a/docs/API.md
+++ b/docs/API.md
@@ -418,6 +418,7 @@ When one enabled source fails, Digarr still returns results from the healthy sou
 **GET /api/library/sources** response notes:
 - `lastSyncCounts.albumsSynced` is present for album-capable sources after a successful sync
 - Lidarr, Plex, and Jellyfin source rows now include artist sync counts plus the number of reconciled album rows written for that source snapshot
+- `lastSyncCounts.mbApiCallsFailed` is the number of MusicBrainz lookups that failed after internal retries. A non-zero value means the sync completed with partial reconciliation; affected artists and albums are retried on the next sync
 
 **POST /api/library/warm** body:
 ```json

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,23 +10,23 @@ All five v1 exit criteria now pass. Digarr is feature-complete for a v1 release,
 
 ## v1 Goals
 
-### New User Can Reach First Value -- Pass
+### New User Can Reach First Value - Pass
 
 Setup wizard, Spotify playlist import, CSV import, and guided empty states get new users to their first recommendations without friction.
 
-### Core Discovery Is Resilient -- Pass
+### Core Discovery Is Resilient - Pass
 
 External source failures degrade gracefully. Image and metadata fallbacks cover the major fragile paths. The app gives useful results even when Spotify is unavailable.
 
-### Operators Have Safety Rails -- Pass
+### Operators Have Safety Rails - Pass
 
 Backup/restore, pre-flight migration checks, auto-backup before upgrades, and data hygiene repair tools are all in place.
 
-### Background Work Is Observable -- Pass
+### Background Work Is Observable - Pass
 
 Admin job tracking surface with health endpoint, run history, stuck-task detection, and actionable error messages.
 
-### Critical Workflows Have Release Protection -- Pass
+### Critical Workflows Have Release Protection - Pass
 
 End-to-end browser test suite (Playwright) covering setup, login, scan, approve/reject, discovery modes, subscriptions, and playlists. CI gates on critical workflow failures.
 
@@ -90,8 +90,8 @@ Low confidence. Would build only with real demand.
 - Advanced analytics export
 - Navidrome WASM plugin
 - TUI client (terminal UI for discovery and approval)
-- Native desktop client (Linux/Mac/Windows) -- PWA install already covers most of this
-- Native mobile apps (Android/iOS) -- PWA is already installable; native value is mostly reliable push notifications
+- Native desktop client (Linux/Mac/Windows) - PWA install already covers most of this
+- Native mobile apps (Android/iOS) - PWA is already installable; native value is mostly reliable push notifications
 
 ## Shipped Highlights
 
@@ -104,7 +104,7 @@ Release reminder: after publishing a new app image, update the pinned digests in
 - Operations and safety now include backup/restore, pre-flight migration checks, auto-backups, job history, stuck-task detection, and browser-test release gates
 - Recent integration work added Deezer OAuth feeds, Emby support, linked `slskd` targets, and broader playlist export coverage
 
-### v0.27.0 -- v0.27.11
+### v0.27.0 - v0.27.11
 
 - Data-safety fixes for legacy `SERIAL` sequence restore and identity-index carryover
 - Pipeline isolation so manual runs no longer share state with scheduled runs
@@ -165,12 +165,12 @@ Release reminder: after publishing a new app image, update the pinned digests in
 - Emby support for library sync and playlist push
 - Setup wizard Emby connection flow with auto-created playlist target
 
-### v0.19.0 -- v0.19.2
+### v0.19.0 - v0.19.2
 
 - Per-user listening source connections (ListenBrainz, Last.fm) instead of shared globals
 - Hermetic settings route tests that no longer depend on public external APIs
 
-### v0.18.0 -- v0.19.0
+### v0.18.0 - v0.19.0
 
 - Album coverage service and API with persistent album overrides
 - Album coverage badge on recommendation cards
@@ -178,21 +178,21 @@ Release reminder: after publishing a new app image, update the pinned digests in
 - Album sync coverage summary in the admin Library Sources panel
 - Helm chart version aligned with app version
 
-### v0.17.0 -- v0.18.0
+### v0.17.0 - v0.18.0
 
 - Album-level library sync for Lidarr, Plex, and Jellyfin
 - Per-source album sync counts in the admin Library Sources panel
 - Atomic artist+album snapshot writes for source syncs
 - Album reconciliation pipeline with MusicBrainz release-group matching
 
-### v0.16.0 -- v0.17.0
+### v0.16.0 - v0.17.0
 
 - Plex and Jellyfin library sync
 - Reconciliation review page with correct/ignore actions and rerun support
 - Setup wizard first-sync guidance and admin library sources/status surface
 - Library-aware pipeline integration with regression, integration, and browser coverage
 
-### v0.15.0 -- v0.16.0
+### v0.15.0 - v0.16.0
 
 - Background job tracking with admin UI, health endpoint, and stuck-task detection
 - E2E browser test suite (Playwright) with CI gates
@@ -202,7 +202,7 @@ Release reminder: after publishing a new app image, update the pinned digests in
 - Security hardening (two full audit rounds)
 - API docs: rate limits, OIDC notes, decades query param
 
-### v0.13.0 -- v0.14.0
+### v0.13.0 - v0.14.0
 
 - Spotify playlist one-click import
 - Generic CSV artist import (flexible column detection, up to 500 artists)

--- a/docs/guides/synology.md
+++ b/docs/guides/synology.md
@@ -8,7 +8,7 @@
 
 ---
 
-## DSM 7.2+ (Container Manager -- has Project support)
+## DSM 7.2+ (Container Manager - has Project support)
 
 Container Manager supports compose projects natively. Use it if you want a no-SSH setup.
 
@@ -18,7 +18,7 @@ Container Manager supports compose projects natively. Use it if you want a no-SS
 2. Set the project name to `digarr`
 3. Set the path to a shared folder (e.g., `/volume1/docker/digarr`)
 4. Paste the contents of the [docker-compose.yml](https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/docker-compose.yml)
-5. In the environment/variables section, set at minimum: `DB_PASS` (pick any password -- this is internal to the containers)
+5. In the environment/variables section, set at minimum: `DB_PASS` (pick any password - this is internal to the containers)
 6. Click **Done**
 
 Both the app and PostgreSQL containers start together automatically.
@@ -36,7 +36,7 @@ sudo docker compose up -d
 
 ---
 
-## DSM 7.1 (Docker package -- no Project support)
+## DSM 7.1 (Docker package - no Project support)
 
 The Docker package on DSM 7.1 does not support compose projects in the GUI.
 You can create containers individually with the Launch wizard.
@@ -92,9 +92,9 @@ If you prefer the GUI, you must create each container separately. A custom
 network lets them reach each other by container name.
 
 > **Important:** DSM 7.1 only shows network and environment settings during
-> container **creation**. You cannot change them afterward -- if you make a
+> container **creation**. You cannot change them afterward - if you make a
 > mistake, delete the container and recreate it. Using `localhost` in
-> DATABASE_URL will not work -- each container has its own network namespace.
+> DATABASE_URL will not work - each container has its own network namespace.
 
 #### Step 1: Create a network
 
@@ -109,11 +109,11 @@ network lets them reach each other by container name.
 3. **Image** > select `postgres:17-alpine` > **Launch**
 4. **Network**: select `digarr-net` (deselect `bridge`)
 5. Container name: `digarr-db`
-6. Click **Advanced Settings** > **Environment** -- add these variables:
+6. Click **Advanced Settings** > **Environment** - add these variables:
    - `POSTGRES_USER` = `digarr`
    - `POSTGRES_PASSWORD` = pick a password (remember it for step 3)
    - `POSTGRES_DB` = `digarr`
-7. Still in **Advanced Settings** > **Volume** -- add a folder mapping:
+7. Still in **Advanced Settings** > **Volume** - add a folder mapping:
    - File/Folder: create `/volume1/docker/digarr-db` (or any path)
    - Mount path: `/var/lib/postgresql/data`
 8. Click **Next** / **Apply** to create and start the container
@@ -127,9 +127,9 @@ network lets them reach each other by container name.
 4. **Network**: select `digarr-net` (deselect `bridge`)
 5. Container name: `digarr`
 6. **Port Settings**: set local port `3000` -> container port `3000`
-7. Click **Advanced Settings** > **Environment** -- add these variables:
+7. Click **Advanced Settings** > **Environment** - add these variables:
    - `DATABASE_URL` = `postgresql://digarr:YOUR_PASSWORD@digarr-db:5432/digarr`
-     (replace `YOUR_PASSWORD` with the password from step 2 -- the hostname
+     (replace `YOUR_PASSWORD` with the password from step 2 - the hostname
      `digarr-db` resolves because both containers are on `digarr-net`)
    - `DIGARR_INITIAL_USERNAME` = pick an admin username
    - `DIGARR_INITIAL_PASSWORD` = pick a password (min 8 chars)
@@ -142,7 +142,7 @@ Open `http://<nas-ip>:3000` in your browser.
 ## ARM-based Synology models
 
 Digarr publishes multi-arch images (amd64 + arm64). ARM-based models
-(DS220j, DS223, DS124, etc.) work out of the box -- Docker pulls the
+(DS220j, DS223, DS124, etc.) work out of the box - Docker pulls the
 correct architecture automatically.
 
 ## Updating

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.27.11",
+  "version": "0.27.12",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -72,7 +72,7 @@ export const envConfig = {
   // Webhook (injected into preferences during auto-setup only)
   webhookUrl: env('WEBHOOK_URL'),
 
-  // Encryption (optional -- encrypts API keys and tokens at rest in the DB)
+  // Encryption (optional - encrypts API keys and tokens at rest in the DB)
   encryptionKey: env('DIGARR_ENCRYPTION_KEY'),
 
   // Registration control
@@ -140,6 +140,6 @@ export function canAutoSetup(): boolean {
   const { aiProvider, aiModel } = envConfig
   // AI provider + model are always required
   if (!aiProvider || !aiModel) return false
-  // Lidarr is optional -- if not set, runs in discovery-only mode
+  // Lidarr is optional - if not set, runs in discovery-only mode
   return true
 }

--- a/src/core/auth/cidr.ts
+++ b/src/core/auth/cidr.ts
@@ -2,7 +2,7 @@ function ipToInt(ip: string): number {
   return ip.split('.').reduce((acc, octet) => (acc << 8) + Number.parseInt(octet, 10), 0) >>> 0
 }
 
-/** Check if an IPv4 address is within a CIDR range. IPv4 only -- IPv6 CIDRs are not supported. */
+/** Check if an IPv4 address is within a CIDR range. IPv4 only - IPv6 CIDRs are not supported. */
 export function isIpInCidr(ip: string, cidr: string): boolean {
   const [cidrIp, bitsStr] = cidr.split('/')
   if (!cidrIp) return false

--- a/src/core/clients/bandcamp.ts
+++ b/src/core/clients/bandcamp.ts
@@ -102,7 +102,7 @@ function parseSearchResults(html: string, limit: number): BandcampSearchResult[]
 export function createBandcampClient(config?: { baseUrl?: string }) {
   const baseUrl = config?.baseUrl ?? DEFAULT_BASE_URL
 
-  // 1 request per 2 seconds -- Bandcamp will throttle/block higher rates
+  // 1 request per 2 seconds - Bandcamp will throttle/block higher rates
   const queue = new PQueue({ concurrency: 1, interval: 2000, intervalCap: 1 })
 
   async function fetchHtml(url: string): Promise<string> {
@@ -133,7 +133,7 @@ export function createBandcampClient(config?: { baseUrl?: string }) {
       const html = await (queue.add(() => fetchHtml(url)) as Promise<string>)
       return parseSearchResults(html, limit)
     } catch {
-      // Scraping is fragile -- always return empty on any error
+      // Scraping is fragile - always return empty on any error
       return []
     }
   }
@@ -143,11 +143,11 @@ export function createBandcampClient(config?: { baseUrl?: string }) {
       const params = new URLSearchParams({ q: 'test', item_type: 'b' })
       const url = `${baseUrl}/search?${params.toString()}`
       const html = await (queue.add(() => fetchHtml(url)) as Promise<string>)
-      // Just check we got HTML back -- don't care about parse results
+      // Just check we got HTML back - don't care about parse results
       if (html.includes('bandcamp') || html.includes('search')) {
         return {
           success: true,
-          message: 'Connected to Bandcamp -- HTML scraper responding',
+          message: 'Connected to Bandcamp - HTML scraper responding',
         }
       }
       return { success: false, message: 'Unexpected response from Bandcamp' }

--- a/src/core/clients/deezer.ts
+++ b/src/core/clients/deezer.ts
@@ -112,7 +112,7 @@ export function createDeezerClient(config?: { baseUrl?: string }) {
       const results = await searchArtists('test', 1)
       return {
         success: true,
-        message: `Connected to Deezer -- API responding`,
+        message: `Connected to Deezer - API responding`,
         details: { resultCount: results.length },
       }
     } catch (err: unknown) {

--- a/src/core/clients/jellyfin.ts
+++ b/src/core/clients/jellyfin.ts
@@ -284,7 +284,7 @@ export function createJellyfinClient(
       const artists = await getTopArtists(5)
       return {
         success: true,
-        message: `Connected to Jellyfin "${info.ServerName}" v${info.Version} -- ${artists.length} top artist(s)`,
+        message: `Connected to Jellyfin "${info.ServerName}" v${info.Version} - ${artists.length} top artist(s)`,
         details: {
           serverName: info.ServerName,
           version: info.Version,

--- a/src/core/clients/lastfm.ts
+++ b/src/core/clients/lastfm.ts
@@ -115,7 +115,7 @@ export function createLastFmClient(username: string, apiKey: string) {
       const artists = await getTopArtists('7day')
       return {
         success: true,
-        message: `Connected to Last.fm -- ${artists.length} top artists for ${username}`,
+        message: `Connected to Last.fm - ${artists.length} top artists for ${username}`,
         details: { artistCount: artists.length },
       }
     } catch (err: unknown) {

--- a/src/core/clients/lidarr.ts
+++ b/src/core/clients/lidarr.ts
@@ -79,7 +79,7 @@ export function createLidarrClient(url: string, apiKey: string, skipTlsVerify = 
 
   async function getArtists(): Promise<LidarrArtist[]> {
     const raw = await http.get<Record<string, unknown>[]>('/api/v1/artist')
-    // Strip to only the fields we need -- the full Lidarr response includes
+    // Strip to only the fields we need - the full Lidarr response includes
     // images, statistics, albums, links, ratings etc. that we don't use,
     // which wastes significant memory for large libraries.
     return raw.map((a) => ({
@@ -146,7 +146,7 @@ export function createLidarrClient(url: string, apiKey: string, skipTlsVerify = 
 
   async function getAlbums(artistId: number): Promise<LidarrAlbum[]> {
     const raw = await http.get<Record<string, unknown>[]>(`/api/v1/album?artistId=${artistId}`)
-    // Strip to only the fields we need -- Lidarr album responses include
+    // Strip to only the fields we need - Lidarr album responses include
     // full track lists, images, and other metadata we don't use.
     return raw.map((a) => ({
       id: a.id as number,
@@ -213,7 +213,7 @@ export function createLidarrClient(url: string, apiKey: string, skipTlsVerify = 
       const profiles = await http.get<QualityProfile[]>('/api/v1/qualityprofile')
       return {
         success: true,
-        message: `Connected to Lidarr -- ${profiles.length} quality profile(s) found`,
+        message: `Connected to Lidarr - ${profiles.length} quality profile(s) found`,
         details: { profileCount: profiles.length },
       }
     } catch (err: unknown) {

--- a/src/core/clients/listenbrainz.ts
+++ b/src/core/clients/listenbrainz.ts
@@ -242,7 +242,7 @@ export function createListenBrainzClient(username: string, token: string) {
       const count = await getListenCount()
       return {
         success: true,
-        message: `Connected to ListenBrainz -- ${count} listens for ${username}`,
+        message: `Connected to ListenBrainz - ${count} listens for ${username}`,
         details: { listenCount: count },
       }
     } catch (err: unknown) {

--- a/src/core/clients/musicbrainz.ts
+++ b/src/core/clients/musicbrainz.ts
@@ -173,7 +173,7 @@ export function createMusicBrainzClient() {
         lastErr = err
       }
     }
-    // Unreachable under normal flow -- loop either returns or throws above.
+    // Unreachable under normal flow - loop either returns or throws above.
     throw lastErr instanceof Error ? lastErr : new Error(`MusicBrainz request failed for ${path}`)
   }
 

--- a/src/core/clients/musicbrainz.ts
+++ b/src/core/clients/musicbrainz.ts
@@ -89,29 +89,96 @@ const STREAMING_PATTERNS: Array<[RegExp, keyof StreamingUrls]> = [
 
 const STREAMING_TYPES = new Set(['streaming music', 'free streaming'])
 
+const TRANSIENT_STATUSES = new Set([429, 500, 502, 503, 504])
+const MAX_RETRIES = 3
+const BASE_BACKOFF_MS = 1000
+const MAX_RETRY_AFTER_MS = 30_000
+
+function parseRetryAfterMs(header: string | null): number | null {
+  if (!header) return null
+  const seconds = Number(header)
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS)
+  }
+  // HTTP-date form
+  const when = Date.parse(header)
+  if (Number.isFinite(when)) {
+    return Math.min(Math.max(when - Date.now(), 0), MAX_RETRY_AFTER_MS)
+  }
+  return null
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 export function createMusicBrainzClient() {
   const queue = new PQueue({ concurrency: 1, interval: 1000, intervalCap: 1 })
 
-  async function request<T>(path: string): Promise<T> {
-    return queue.add(async () => {
-      const controller = new AbortController()
-      const timer = setTimeout(() => controller.abort(), 10_000)
+  async function fetchOnce(path: string): Promise<Response> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 10_000)
+    try {
+      return await fetch(`${BASE_URL}${path}`, {
+        headers: { 'User-Agent': USER_AGENT },
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timer)
+    }
+  }
 
+  async function requestWithRetry<T>(path: string): Promise<T> {
+    let lastErr: unknown
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt += 1) {
       try {
-        const res = await fetch(`${BASE_URL}${path}`, {
-          headers: { 'User-Agent': USER_AGENT },
-          signal: controller.signal,
-        })
+        const res = await fetchOnce(path)
 
-        if (!res.ok) {
+        if (res.ok) {
+          return (await res.json()) as T
+        }
+
+        // Non-retryable HTTP status: surface immediately.
+        if (!TRANSIENT_STATUSES.has(res.status)) {
           throw new Error(`MusicBrainz HTTP ${res.status} for ${path}`)
         }
 
-        return res.json() as Promise<T>
-      } finally {
-        clearTimeout(timer)
+        // Transient HTTP status: prefer server-provided Retry-After, else
+        // exponential backoff with jitter. Final failed attempt throws out.
+        if (attempt === MAX_RETRIES) {
+          throw new Error(`MusicBrainz HTTP ${res.status} for ${path}`)
+        }
+        const retryAfter = parseRetryAfterMs(res.headers.get('retry-after'))
+        const backoff = retryAfter ?? BASE_BACKOFF_MS * 2 ** attempt + Math.random() * 250
+        console.warn(
+          `[musicbrainz] HTTP ${res.status} for ${path} (attempt ${attempt + 1}/${MAX_RETRIES + 1}); retrying in ${Math.round(backoff)}ms`,
+        )
+        await sleep(backoff)
+        lastErr = new Error(`MusicBrainz HTTP ${res.status} for ${path}`)
+      } catch (err) {
+        // Network/timeout errors are retryable. The final attempt rethrows.
+        const retryable =
+          err instanceof Error &&
+          (err.name === 'AbortError' ||
+            err instanceof TypeError ||
+            /fetch failed|network|ECONN|ENOTFOUND|ETIMEDOUT|ECONNRESET/i.test(err.message))
+        if (!retryable || attempt === MAX_RETRIES) {
+          throw err
+        }
+        const backoff = BASE_BACKOFF_MS * 2 ** attempt + Math.random() * 250
+        console.warn(
+          `[musicbrainz] ${err instanceof Error ? err.message : String(err)} for ${path} (attempt ${attempt + 1}/${MAX_RETRIES + 1}); retrying in ${Math.round(backoff)}ms`,
+        )
+        await sleep(backoff)
+        lastErr = err
       }
-    }) as Promise<T>
+    }
+    // Unreachable under normal flow -- loop either returns or throws above.
+    throw lastErr instanceof Error ? lastErr : new Error(`MusicBrainz request failed for ${path}`)
+  }
+
+  async function request<T>(path: string): Promise<T> {
+    return queue.add(() => requestWithRetry<T>(path)) as Promise<T>
   }
 
   function lookupArtist(mbid: string): Promise<MBArtist> {

--- a/src/core/clients/plex.ts
+++ b/src/core/clients/plex.ts
@@ -219,7 +219,7 @@ export function createPlexClient(
       const sectionId = await getMusicSectionId()
       return {
         success: true,
-        message: `Connected to Plex -- music library section ${sectionId}`,
+        message: `Connected to Plex - music library section ${sectionId}`,
         details: { sectionId },
       }
     } catch (err: unknown) {

--- a/src/core/clients/tidal.ts
+++ b/src/core/clients/tidal.ts
@@ -1,6 +1,6 @@
 // FRAGILE: TIDAL has no official public API. This uses client credentials OAuth2
 // against undocumented/semi-public endpoints that may change without notice.
-// All errors are caught and return empty results or failure -- do NOT throw here.
+// All errors are caught and return empty results or failure - do NOT throw here.
 
 import { createHttpClient } from '@/core/clients/http'
 import type { ServiceTestResult } from '@/core/types'
@@ -113,7 +113,7 @@ export function createTidalClient(config: {
       // Create a fresh http client per search so the Authorization header reflects
       // the current (possibly just-refreshed) token. The token fetch above uses raw
       // fetch because it hits a different base URL (auth.tidal.com) with form-encoded
-      // body -- createHttpClient only handles JSON, so the auth endpoint stays as-is.
+      // body - createHttpClient only handles JSON, so the auth endpoint stays as-is.
       const http = createHttpClient({
         baseUrl: searchBaseUrl,
         headers: {
@@ -144,7 +144,7 @@ export function createTidalClient(config: {
         ]
       })
     } catch {
-      // TIDAL API is fragile -- swallow all errors and return empty
+      // TIDAL API is fragile - swallow all errors and return empty
       return []
     }
   }
@@ -155,7 +155,7 @@ export function createTidalClient(config: {
       const results = await searchArtists('test', 1)
       return {
         success: true,
-        message: `Connected to TIDAL -- API responding`,
+        message: `Connected to TIDAL - API responding`,
         details: { resultCount: results.length },
       }
     } catch (err: unknown) {

--- a/src/core/crypto.ts
+++ b/src/core/crypto.ts
@@ -16,7 +16,7 @@ export function initEncryption(keyInput: string | undefined): void {
   }
   // HKDF-derived key (current)
   derivedKey = Buffer.from(hkdfSync('sha256', keyInput, '', 'digarr-field-encryption', 32))
-  // SHA-256 key (legacy -- kept for decrypting pre-migration values)
+  // SHA-256 key (legacy - kept for decrypting pre-migration values)
   legacyKey = createHash('sha256').update(keyInput).digest()
 }
 
@@ -82,7 +82,7 @@ export function decryptField(value: string | null | undefined): typeof value {
         // Both keys failed
       }
     }
-    throw new Error('Decryption failed -- check DIGARR_ENCRYPTION_KEY')
+    throw new Error('Decryption failed - check DIGARR_ENCRYPTION_KEY')
   }
 }
 

--- a/src/core/i18n/messages/de.ts
+++ b/src/core/i18n/messages/de.ts
@@ -762,6 +762,8 @@ export const de = {
   'librarySources.justNow': 'gerade eben',
   'librarySources.minAgo': 'vor {0} Min.',
   'librarySources.hoursAgo': 'vor {0} Std.',
+  'librarySources.mbWarning':
+    '{0} MusicBrainz-Abfragen fehlgeschlagen. Betroffene Künstler bleiben unabgeglichen und werden beim nächsten Sync erneut versucht.',
   'libraryStats.title': 'Bibliotheksstatistik',
   'libraryStats.artists': 'Künstler',
   'libraryStats.monitored': 'Überwacht',

--- a/src/core/i18n/messages/en.ts
+++ b/src/core/i18n/messages/en.ts
@@ -841,6 +841,8 @@ export const en = {
   'librarySources.justNow': 'just now',
   'librarySources.minAgo': '{0} min ago',
   'librarySources.hoursAgo': '{0} h ago',
+  'librarySources.mbWarning':
+    '{0} MusicBrainz lookups failed. Affected artists are left unreconciled and will retry next sync.',
 
   // Library Stats
   'libraryStats.title': 'Library Statistics',

--- a/src/core/i18n/messages/es.ts
+++ b/src/core/i18n/messages/es.ts
@@ -746,6 +746,8 @@ export const es = {
   'librarySources.justNow': 'ahora mismo',
   'librarySources.minAgo': 'hace {0} min',
   'librarySources.hoursAgo': 'hace {0} h',
+  'librarySources.mbWarning':
+    '{0} consultas a MusicBrainz fallaron. Los artistas afectados quedan sin reconciliar y se reintentarán en la próxima sincronización.',
   'libraryStats.title': 'Estadísticas de biblioteca',
   'libraryStats.artists': 'Artistas',
   'libraryStats.monitored': 'Monitorizados',

--- a/src/core/i18n/messages/fr.ts
+++ b/src/core/i18n/messages/fr.ts
@@ -744,6 +744,8 @@ export const fr = {
   'librarySources.justNow': "à l'instant",
   'librarySources.minAgo': 'il y a {0} min',
   'librarySources.hoursAgo': 'il y a {0} h',
+  'librarySources.mbWarning':
+    '{0} requêtes MusicBrainz ont échoué. Les artistes concernés restent non rapprochés et seront réessayés lors de la prochaine synchronisation.',
   'libraryStats.title': 'Statistiques de la bibliothèque',
   'libraryStats.artists': 'Artistes',
   'libraryStats.monitored': 'Surveillés',

--- a/src/core/i18n/messages/it.ts
+++ b/src/core/i18n/messages/it.ts
@@ -748,6 +748,8 @@ export const it = {
   'librarySources.justNow': 'proprio ora',
   'librarySources.minAgo': '{0} min fa',
   'librarySources.hoursAgo': '{0} h fa',
+  'librarySources.mbWarning':
+    '{0} richieste a MusicBrainz non riuscite. Gli artisti interessati restano non riconciliati e verranno riprovati alla prossima sincronizzazione.',
   'libraryStats.title': 'Statistiche della libreria',
   'libraryStats.artists': 'Artisti',
   'libraryStats.monitored': 'Monitorati',

--- a/src/core/i18n/messages/ja.ts
+++ b/src/core/i18n/messages/ja.ts
@@ -739,6 +739,8 @@ export const ja = {
   'librarySources.justNow': 'たった今',
   'librarySources.minAgo': '{0} 分前',
   'librarySources.hoursAgo': '{0} 時間前',
+  'librarySources.mbWarning':
+    '{0} 件の MusicBrainz クエリが失敗しました。影響を受けたアーティストは未照合のままで、次回の同期で再試行されます。',
   'libraryStats.title': 'ライブラリ統計',
   'libraryStats.artists': 'アーティスト',
   'libraryStats.monitored': '監視中',

--- a/src/core/i18n/messages/ko.ts
+++ b/src/core/i18n/messages/ko.ts
@@ -730,6 +730,8 @@ export const ko = {
   'librarySources.justNow': '방금',
   'librarySources.minAgo': '{0}분 전',
   'librarySources.hoursAgo': '{0}시간 전',
+  'librarySources.mbWarning':
+    'MusicBrainz 조회 {0}건이 실패했습니다. 해당 아티스트는 매칭되지 않은 상태로 유지되며 다음 동기화 때 다시 시도됩니다.',
   'libraryStats.title': '라이브러리 통계',
   'libraryStats.artists': '아티스트',
   'libraryStats.monitored': '모니터링 중',

--- a/src/core/i18n/messages/nl.ts
+++ b/src/core/i18n/messages/nl.ts
@@ -754,6 +754,8 @@ export const nl = {
   'librarySources.justNow': 'zojuist',
   'librarySources.minAgo': '{0} min. geleden',
   'librarySources.hoursAgo': '{0} u geleden',
+  'librarySources.mbWarning':
+    '{0} MusicBrainz-verzoeken mislukt. Betroffen artiesten blijven niet gekoppeld en worden bij de volgende synchronisatie opnieuw geprobeerd.',
   'libraryStats.title': 'Bibliotheekstatistieken',
   'libraryStats.artists': 'Artiesten',
   'libraryStats.monitored': 'Bewaakt',

--- a/src/core/i18n/messages/pl.ts
+++ b/src/core/i18n/messages/pl.ts
@@ -753,6 +753,8 @@ export const pl = {
   'librarySources.justNow': 'przed chwila',
   'librarySources.minAgo': '{0} min temu',
   'librarySources.hoursAgo': '{0} godz. temu',
+  'librarySources.mbWarning':
+    '{0} zapytan MusicBrainz nie powiodlo sie. Artyscie nie zostali dopasowani i zostana ponownie sprobowani przy nastepnej synchronizacji.',
   'libraryStats.title': 'Statystyki biblioteki',
   'libraryStats.artists': 'Artysci',
   'libraryStats.monitored': 'Monitorowani',

--- a/src/core/i18n/messages/pt-BR.ts
+++ b/src/core/i18n/messages/pt-BR.ts
@@ -751,6 +751,8 @@ export const ptBR = {
   'librarySources.justNow': 'agora mesmo',
   'librarySources.minAgo': 'há {0} min',
   'librarySources.hoursAgo': 'há {0} h',
+  'librarySources.mbWarning':
+    '{0} consultas ao MusicBrainz falharam. Os artistas afetados ficam sem reconciliação e serão tentados novamente na próxima sincronização.',
   'libraryStats.title': 'Estatísticas da biblioteca',
   'libraryStats.artists': 'Artistas',
   'libraryStats.monitored': 'Monitorados',

--- a/src/core/i18n/messages/ro.ts
+++ b/src/core/i18n/messages/ro.ts
@@ -751,6 +751,8 @@ export const ro = {
   'librarySources.justNow': 'chiar acum',
   'librarySources.minAgo': 'acum {0} min',
   'librarySources.hoursAgo': 'acum {0} h',
+  'librarySources.mbWarning':
+    '{0} cereri MusicBrainz au eșuat. Artiștii afectați rămân nereconciliați și vor fi reîncercați la următoarea sincronizare.',
   'libraryStats.title': 'Statistici bibliotecă',
   'libraryStats.artists': 'Artiști',
   'libraryStats.monitored': 'Monitorizați',

--- a/src/core/i18n/messages/ru.ts
+++ b/src/core/i18n/messages/ru.ts
@@ -761,6 +761,8 @@ export const ru = {
   'librarySources.justNow': 'только что',
   'librarySources.minAgo': '{0} мин назад',
   'librarySources.hoursAgo': '{0} ч назад',
+  'librarySources.mbWarning':
+    '{0} запросов к MusicBrainz не удались. Затронутые исполнители остаются не сопоставленными и будут повторены при следующей синхронизации.',
   'libraryStats.title': 'Статистика библиотеки',
   'libraryStats.artists': 'Исполнители',
   'libraryStats.monitored': 'Отслеживаемые',

--- a/src/core/i18n/messages/tr.ts
+++ b/src/core/i18n/messages/tr.ts
@@ -750,6 +750,8 @@ export const tr = {
   'librarySources.justNow': 'az once',
   'librarySources.minAgo': '{0} dk once',
   'librarySources.hoursAgo': '{0} sa once',
+  'librarySources.mbWarning':
+    '{0} MusicBrainz sorgusu basarisiz oldu. Etkilenen sanatcilar eslesmemis olarak kalir ve bir sonraki esitlemede tekrar denenir.',
   'libraryStats.title': 'Kutuphane Istatistikleri',
   'libraryStats.artists': 'Sanatcilar',
   'libraryStats.monitored': 'Izlenenler',

--- a/src/core/i18n/messages/uk.ts
+++ b/src/core/i18n/messages/uk.ts
@@ -757,6 +757,8 @@ export const uk = {
   'librarySources.justNow': 'щойно',
   'librarySources.minAgo': '{0} хв тому',
   'librarySources.hoursAgo': '{0} год тому',
+  'librarySources.mbWarning':
+    '{0} запитів до MusicBrainz не вдалися. Порушені виконавці залишаться незіставленими і будуть повторені при наступній синхронізації.',
   'libraryStats.title': 'Статистика бібліотеки',
   'libraryStats.artists': 'Виконавці',
   'libraryStats.monitored': 'Відстежувані',

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -692,6 +692,8 @@ export const zhCN = {
   'librarySources.justNow': '刚刚',
   'librarySources.minAgo': '{0} 分钟前',
   'librarySources.hoursAgo': '{0} 小时前',
+  'librarySources.mbWarning':
+    '{0} 次 MusicBrainz 查询失败。受影响的艺术家未匹配，将在下次同步时重试。',
   'libraryStats.title': '资料库统计',
   'libraryStats.artists': '艺术家',
   'libraryStats.monitored': '监控中',

--- a/src/core/library/album-reconciler.ts
+++ b/src/core/library/album-reconciler.ts
@@ -46,9 +46,26 @@ function makeRow(
 export async function reconcileAlbumsForArtist(
   artistMbid: string,
   albums: LibraryAlbum[],
-  deps: { mbClient: MBClient },
+  deps: {
+    mbClient: MBClient
+    /**
+     * Invoked when MB getReleaseGroups throws (5xx, timeout, network). Albums
+     * for this artist fall through to `albumMbid: null` rather than aborting
+     * the sync.
+     */
+    onMbError?: (err: unknown) => void
+  },
 ): Promise<ReconciledAlbum[]> {
-  const releaseGroups = await deps.mbClient.getReleaseGroups(artistMbid)
+  let releaseGroups: Awaited<ReturnType<MBClient['getReleaseGroups']>>
+  try {
+    releaseGroups = await deps.mbClient.getReleaseGroups(artistMbid)
+  } catch (err) {
+    deps.onMbError?.(err)
+    console.warn(
+      `[library-reconcile] MB getReleaseGroups failed for artist ${artistMbid}; albums left unreconciled: ${err instanceof Error ? err.message : String(err)}`,
+    )
+    releaseGroups = []
+  }
 
   return albums.map((album) => {
     const titleNormalized = normalizeAlbumTitle(album.title)

--- a/src/core/library/health.ts
+++ b/src/core/library/health.ts
@@ -99,7 +99,7 @@ export class LibraryHealthService {
     return this._scanning
   }
 
-  // startScan -- fire-and-forget, returns immediately
+  // startScan - fire-and-forget, returns immediately
 
   startScan(): void {
     if (this._scanning) return
@@ -409,7 +409,7 @@ function extractImageUrl(results: unknown[]): string | null {
     if (typeof result !== 'object' || result === null) continue
     const r = result as Record<string, unknown>
 
-    // Look for images array (Lidarr lookup format -- remoteUrl is the CDN URL)
+    // Look for images array (Lidarr lookup format - remoteUrl is the CDN URL)
     if (Array.isArray(r.images)) {
       for (const img of r.images as Array<Record<string, unknown>>) {
         if (img.coverType === 'poster' && typeof img.remoteUrl === 'string') return img.remoteUrl

--- a/src/core/library/normalize.ts
+++ b/src/core/library/normalize.ts
@@ -11,7 +11,7 @@
  * 7. Strip interior ", The ": "Tyler, The Creator" -> "tyler, creator"
  * 8. Collapse whitespace and trim
  *
- * Used by the reconciler. Pure function -- no I/O, no globals.
+ * Used by the reconciler. Pure function - no I/O, no globals.
  */
 export function normalizeArtistName(raw: string): string {
   if (!raw.trim()) return ''

--- a/src/core/library/reconciler.ts
+++ b/src/core/library/reconciler.ts
@@ -10,6 +10,14 @@ type MBClient = Pick<
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+function mbErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function bumpMbFailed(counts: LibrarySyncCounts): void {
+  counts.mbApiCallsFailed = (counts.mbApiCallsFailed ?? 0) + 1
+}
+
 export type ReconciledArtist = {
   sourceArtistId: string
   name: string
@@ -123,9 +131,22 @@ export async function reconcileArtist(
     return matchedRow(artist, nameNormalized, cached[0].mbid, 'name_anchored', 0.85)
   }
 
-  // Cache miss or ambiguous: fall through to MB API
+  // Cache miss or ambiguous: fall through to MB API.
+  // MB errors (5xx, timeout, network) are soft-failed so one flaky upstream
+  // call doesn't abort the whole sync. The artist is left unreconciled and
+  // will retry on the next sync run.
   ctx.counts.mbApiCalls += 1
-  const mbResult = await ctx.mbClient.searchArtist(nameNormalized)
+  let mbResult: Awaited<ReturnType<MBClient['searchArtist']>>
+  try {
+    mbResult = await ctx.mbClient.searchArtist(nameNormalized)
+  } catch (err) {
+    bumpMbFailed(ctx.counts)
+    console.warn(
+      `[library-reconcile] MB searchArtist failed for "${artist.name}"; leaving unreconciled: ${mbErrorMessage(err)}`,
+    )
+    ctx.counts.unreconciledNoCandidate += 1
+    return unreconciledRow(artist, nameNormalized, 'no_candidate')
+  }
   const candidates = (mbResult.artists ?? []).filter(
     (c) => normalizeArtistName(c.name) === nameNormalized,
   )
@@ -154,13 +175,21 @@ export async function reconcileArtist(
     const normalizedSourceTitles = new Set(sourceAlbumTitles.map(normalizeArtistName))
     const scored = await Promise.all(
       candidates.map(async (c) => {
-        const releaseGroups = await ctx.mbClient.getReleaseGroups(c.id)
-        const mbTitles = new Set(releaseGroups.map((rg) => normalizeArtistName(rg.title)))
-        let overlap = 0
-        for (const t of normalizedSourceTitles) {
-          if (mbTitles.has(t)) overlap += 1
+        try {
+          const releaseGroups = await ctx.mbClient.getReleaseGroups(c.id)
+          const mbTitles = new Set(releaseGroups.map((rg) => normalizeArtistName(rg.title)))
+          let overlap = 0
+          for (const t of normalizedSourceTitles) {
+            if (mbTitles.has(t)) overlap += 1
+          }
+          return { candidate: c, overlap }
+        } catch (err) {
+          bumpMbFailed(ctx.counts)
+          console.warn(
+            `[library-reconcile] MB getReleaseGroups failed for candidate ${c.id} of "${artist.name}"; treating as zero overlap: ${mbErrorMessage(err)}`,
+          )
+          return { candidate: c, overlap: 0 }
         }
-        return { candidate: c, overlap }
       }),
     )
     scored.sort((a, b) => b.overlap - a.overlap)

--- a/src/core/library/skyhook-warmer.ts
+++ b/src/core/library/skyhook-warmer.ts
@@ -25,7 +25,7 @@ export class SkyHookWarmer {
 
   private evictIfNeeded(): void {
     if (this.status.size <= 5000) return
-    // Evict 'warm' entries -- cheapest to re-warm if needed
+    // Evict 'warm' entries - cheapest to re-warm if needed
     for (const [mbid, s] of this.status) {
       if (s === 'warm') this.status.delete(mbid)
     }

--- a/src/core/library/sources/plex.ts
+++ b/src/core/library/sources/plex.ts
@@ -5,7 +5,7 @@ type PlexClient = ReturnType<typeof createPlexClient>
 
 /**
  * Wraps the existing Plex client as a LibrarySource. The default Plex
- * Music agent does not store MBIDs, so mbidQuality is 'low' -- the
+ * Music agent does not store MBIDs, so mbidQuality is 'low' - the
  * reconciler will name-match against MusicBrainz and anchor against
  * Lidarr/Jellyfin rows when possible.
  *

--- a/src/core/library/store.ts
+++ b/src/core/library/store.ts
@@ -142,6 +142,7 @@ export function emptyLibrarySyncCounts(): LibrarySyncCounts {
     unreconciledNoCandidate: 0,
     cacheHits: 0,
     mbApiCalls: 0,
+    mbApiCallsFailed: 0,
   }
 }
 

--- a/src/core/library/sync.ts
+++ b/src/core/library/sync.ts
@@ -152,19 +152,31 @@ export function createSyncOrchestrator(deps: SyncOrchestratorDeps) {
               const rawAlbums = await listAlbums(artist.sourceArtistId)
               const reconciledAlbums = await reconcileAlbumsForArtist(artist.mbid, rawAlbums, {
                 mbClient: deps.mbClient,
+                onMbError: () => {
+                  counts.mbApiCallsFailed = (counts.mbApiCallsFailed ?? 0) + 1
+                },
               })
               albumRows.push(...reconciledAlbums)
             }),
           )
         }
 
+        // Per-artist album tasks fail soft: any rejected task is logged and
+        // counted, but the sync still completes. MB-domain errors (5xx,
+        // timeouts) are already caught inside reconcileAlbumsForArtist; this
+        // outer catch protects against unexpected failures from the source's
+        // listAlbums() implementation.
         const albumResults = await Promise.allSettled(albumTasks)
         await albumQueue.onIdle()
-        const albumFailure = albumResults.find(
-          (result): result is PromiseRejectedResult => result.status === 'rejected',
-        )
-        if (albumFailure) {
-          throw albumFailure.reason
+        for (const result of albumResults) {
+          if (result.status === 'rejected') {
+            counts.mbApiCallsFailed = (counts.mbApiCallsFailed ?? 0) + 1
+            console.warn(
+              `[library-sync] album task failed during ${source.id} sync; continuing: ${
+                result.reason instanceof Error ? result.reason.message : String(result.reason)
+              }`,
+            )
+          }
         }
 
         writtenCounts = await deps.store.replaceLibrarySnapshot(
@@ -181,6 +193,7 @@ export function createSyncOrchestrator(deps: SyncOrchestratorDeps) {
         ...writtenCounts,
         cacheHits: counts.cacheHits,
         mbApiCalls: counts.mbApiCalls,
+        mbApiCallsFailed: counts.mbApiCallsFailed ?? 0,
         albumsSynced: writtenCounts.albumsSynced ?? 0,
       }
 

--- a/src/core/oauth.ts
+++ b/src/core/oauth.ts
@@ -32,7 +32,7 @@ export async function getValidToken(
     return token.accessToken
   }
 
-  // Token expired or about to expire -- refresh it
+  // Token expired or about to expire - refresh it
   if (!token.refreshToken) return null
 
   const params = new URLSearchParams({

--- a/src/core/pipeline/auto-approve.ts
+++ b/src/core/pipeline/auto-approve.ts
@@ -60,7 +60,7 @@ export async function autoApprove(
     }
 
     if (addTargets.length === 0) {
-      // No targets -- mark as approved (discovery-only)
+      // No targets - mark as approved (discovery-only)
       await deps.updateRecommendationStatus(rec.id, 'approved', { targetActions: {} })
       approved++
       continue

--- a/src/core/pipeline/discover.ts
+++ b/src/core/pipeline/discover.ts
@@ -11,7 +11,7 @@ function normalizeName(name: string): string {
 }
 
 /**
- * Detect likely AI name confusion -- the model meant to describe a top artist
+ * Detect likely AI name confusion - the model meant to describe a top artist
  * but output a similarly-named different artist. Checks substring containment
  * in both directions (covers "Sonic Youth" in "Sonic Youth Junior").
  */

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -150,7 +150,7 @@ export class PipelineOrchestrator extends EventEmitter {
         registry.register(createLastFmSource(lfUsername, lfApiKey))
       }
 
-      // Spotify (OAuth -- token resolved before pipeline run)
+      // Spotify (OAuth - token resolved before pipeline run)
       if (settings.spotifyAccessToken) {
         registry.register(createSpotifySource(settings.spotifyAccessToken))
       }
@@ -388,7 +388,7 @@ export class PipelineOrchestrator extends EventEmitter {
         libraryMbids.add(mbid)
       }
 
-      // Also exclude top artists from listening history -- the AI prompt asks
+      // Also exclude top artists from listening history - the AI prompt asks
       // models to skip these, but smaller models ignore the instruction.
       const topArtistNames = new Set<string>()
       for (const artist of tasteProfile.topArtists) {

--- a/src/core/pipeline/resolve.ts
+++ b/src/core/pipeline/resolve.ts
@@ -118,7 +118,7 @@ export async function resolve(
           const mbArtist = await mb.lookupArtist(hit.id)
 
           if (discoveryGenres.length === 0) {
-            // No genre data -- trust MB search ranking
+            // No genre data - trust MB search ranking
             bestCandidate = mbArtist
             break
           }
@@ -137,7 +137,7 @@ export async function resolve(
       // Skip when AI provided genres but the best MB candidate has zero overlap --
       // strong signal that the AI confused similarly-named artists (e.g. "Digital
       // Underground" vs "The Velvet Underground"). bestOverlap of -1 means MB had
-      // no tags to compare, which is fine -- many lesser-known artists lack tags.
+      // no tags to compare, which is fine - many lesser-known artists lack tags.
       if (discoveryGenres.length > 0 && bestOverlap === 0) continue
 
       if (!bestCandidate || byMbid.has(bestCandidate.id)) continue
@@ -200,7 +200,7 @@ async function matchSuggestedAlbum(
       return { releaseGroupId: normalized.id, title: normalized.title, type: normalized.type }
     }
 
-    // Step 3: no match -- return free text without releaseGroupId
+    // Step 3: no match - return free text without releaseGroupId
     return { title: suggestedAlbum }
   } catch {
     return { title: suggestedAlbum }

--- a/src/core/pipeline/store.ts
+++ b/src/core/pipeline/store.ts
@@ -1,6 +1,6 @@
 import type { ScoredArtist } from '@/core/types'
 
-// Minimal database interface -- only what store() needs
+// Minimal database interface - only what store() needs
 export interface StoreDb {
   getExistingRecommendationMbids: (userId?: number) => Promise<Set<string>>
 

--- a/src/core/playlists/generator.ts
+++ b/src/core/playlists/generator.ts
@@ -24,7 +24,7 @@ export function getStrategy(strategy: PlaylistStrategy): PlaylistStrategyImpl {
     case 'rediscover':
       return rediscoverStrategy
     default: {
-      // TypeScript exhaustiveness check -- if PlaylistStrategy ever gains a new
+      // TypeScript exhaustiveness check - if PlaylistStrategy ever gains a new
       // variant and getStrategy isn't updated, this throws at runtime.
       const _exhaustive: never = strategy
       throw new Error(`Unknown playlist strategy: ${_exhaustive}`)
@@ -64,7 +64,7 @@ export async function generatePlaylist(
     const allTracks = await resolvePlaylistTracks(artists, resolverDeps, resolverConfig)
     tracks = allTracks.slice(0, config.size)
   } else {
-    // No track resolver deps configured -- create artist-level entries
+    // No track resolver deps configured - create artist-level entries
     // so playlists still show the selected artists
     tracks = artists.slice(0, config.size).map((a) => ({
       artistName: a.name,

--- a/src/core/playlists/track-resolver.ts
+++ b/src/core/playlists/track-resolver.ts
@@ -134,13 +134,13 @@ export async function resolveTracksForArtist(
     if (tracks.length > 0) return tracks
   }
 
-  // MusicBrainz fallback -- only if we have an MBID
+  // MusicBrainz fallback - only if we have an MBID
   if (artistMbid) {
     const mbTracks = await resolveFromMusicBrainz(artistName, artistMbid, deps, limit)
     if (mbTracks.length > 0) return mbTracks
   }
 
-  // Nothing resolved -- let the caller handle the empty case
+  // Nothing resolved - let the caller handle the empty case
   return []
 }
 

--- a/src/core/plugins/emby.ts
+++ b/src/core/plugins/emby.ts
@@ -34,10 +34,10 @@ export function createEmbySource(
         const key = fav.name.toLowerCase()
         const existing = merged.get(key)
         if (existing) {
-          // Favorite already in top list -- 1.2x play count boost
+          // Favorite already in top list - 1.2x play count boost
           existing.playCount = Math.round(existing.playCount * 1.2)
         } else {
-          // New favorite not in top list -- add with their play count (min 1)
+          // New favorite not in top list - add with their play count (min 1)
           merged.set(key, {
             name: fav.name,
             playCount: Math.max(fav.playCount, 1),

--- a/src/core/plugins/jellyfin.ts
+++ b/src/core/plugins/jellyfin.ts
@@ -34,10 +34,10 @@ export function createJellyfinSource(
         const key = fav.name.toLowerCase()
         const existing = merged.get(key)
         if (existing) {
-          // Favorite already in top list -- 1.2x play count boost
+          // Favorite already in top list - 1.2x play count boost
           existing.playCount = Math.round(existing.playCount * 1.2)
         } else {
-          // New favorite not in top list -- add with their play count (min 1)
+          // New favorite not in top list - add with their play count (min 1)
           merged.set(key, {
             name: fav.name,
             playCount: Math.max(fav.playCount, 1),

--- a/src/core/providers/ollama.ts
+++ b/src/core/providers/ollama.ts
@@ -80,7 +80,7 @@ export class OllamaProvider implements RecommendationProvider {
 
       return {
         success: true,
-        message: `Connected to Ollama -- ${modelCount} model(s) available`,
+        message: `Connected to Ollama - ${modelCount} model(s) available`,
       }
     } catch (err: unknown) {
       return { success: false, message: errMsg(err) }

--- a/src/core/providers/prompt.ts
+++ b/src/core/providers/prompt.ts
@@ -42,7 +42,7 @@ Return ONLY a JSON array with no additional text. Each element must have these f
 - reasoning: string (2-3 sentences: first describe what this artist sounds like and what they're known for, then explain why they match this listener's taste)
 - confidence: number (0.0 to 1.0, how confident you are in this recommendation)
 - genres: string[] (list of genres this artist represents)
-- suggestedAlbum: string (optional -- the best album to start with for a new listener)
+- suggestedAlbum: string (optional - the best album to start with for a new listener)
 
 Example:
 [

--- a/src/core/spotify-auth.ts
+++ b/src/core/spotify-auth.ts
@@ -12,7 +12,7 @@ const SPOTIFY_TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token'
 export async function resolveSpotifyToken(db: Database, userId: number): Promise<string> {
   const row = await getOAuthToken(db, userId, 'spotify')
   if (!row || row.accessToken.startsWith('pending:')) {
-    throw new Error('No Spotify OAuth token -- connect Spotify in Settings')
+    throw new Error('No Spotify OAuth token - connect Spotify in Settings')
   }
   if (row.clientId && row.clientSecret) {
     const token = await getValidToken(db, userId, 'spotify', {

--- a/src/core/subscriptions/adapters/spotify-charts.ts
+++ b/src/core/subscriptions/adapters/spotify-charts.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/core/subscriptions/types'
 import { extractArtistsFromPlaylist } from './spotify-shared'
 
-// Viral 50 playlists only have a reliable global ID -- regional viral playlists
+// Viral 50 playlists only have a reliable global ID - regional viral playlists
 // are not publicly stable, so we only offer viral50 for the global region.
 const CHART_PLAYLIST_IDS: Record<string, Record<string, string>> = {
   global: {

--- a/src/core/subscriptions/types.ts
+++ b/src/core/subscriptions/types.ts
@@ -87,7 +87,7 @@ export type SubscriptionRunDeps = {
   feedbackHistory: Map<string, { approved: number; total: number }>
   cooldownDays: number
   defaultScoreThreshold: number
-  /** Lowercase names of the user's top listened artists -- excluded from results. */
+  /** Lowercase names of the user's top listened artists - excluded from results. */
   topArtistNames?: Set<string>
   discoveryModeRunner?: typeof runDiscoveryMode
   discoveryModeRegistry?: DiscoveryModeRegistry

--- a/src/core/targets/lidarr.ts
+++ b/src/core/targets/lidarr.ts
@@ -54,7 +54,7 @@ export function createLidarrTarget(
               }
             }
           } catch {
-            // Best-effort -- artist was added, album monitoring is secondary
+            // Best-effort - artist was added, album monitoring is secondary
           }
         }
 

--- a/src/core/targets/navidrome-playlist.ts
+++ b/src/core/targets/navidrome-playlist.ts
@@ -21,7 +21,7 @@ function buildSubsonicUrl(
 ): string {
   const base = baseUrl.replace(/\/+$/, '')
   const salt = randomBytes(8).toString('hex')
-  // Subsonic API spec mandates md5(password + salt) auth -- no alternative
+  // Subsonic API spec mandates md5(password + salt) auth - no alternative
   const token = createHash('md5') // lgtm[js/insufficient-password-hash]
     .update(password + salt)
     .digest('hex')

--- a/src/db/queries/dashboard.ts
+++ b/src/db/queries/dashboard.ts
@@ -147,7 +147,7 @@ export async function getRecentActivity(
     })
   }
 
-  // 3. Recent batches (scan events) -- admin sees all
+  // 3. Recent batches (scan events) - admin sees all
   if (isAdmin) {
     const recentBatches = await db
       .select({

--- a/src/db/queries/oauth-tokens.ts
+++ b/src/db/queries/oauth-tokens.ts
@@ -35,7 +35,7 @@ export async function upsertOAuthToken(
   db: Database,
   data: OAuthTokenInsert,
 ): Promise<OAuthTokenRow> {
-  // Don't encrypt pending tokens -- they're searched by prefix and are temporary
+  // Don't encrypt pending tokens - they're searched by prefix and are temporary
   const isPending = data.accessToken.startsWith('pending:')
   const values = isPending
     ? data

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -616,6 +616,8 @@ export type LibrarySyncCounts = {
   unreconciledNoCandidate: number
   cacheHits: number
   mbApiCalls: number
+  /** MB API calls that threw (5xx, timeout, network). Artists/albums degrade to unreconciled. */
+  mbApiCallsFailed?: number
   estimatedSecondsRemaining?: number
   albumsSynced?: number
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ import {
 import { createApp } from './server'
 import { resolveUserPreferences } from './server/helpers/preferences'
 
-// Job recording -- initialized after DB setup, before createApp()
+// Job recording - initialized after DB setup, before createApp()
 let jobRecorder: import('./core/jobs/types').JobRecorder
 
 // Initialize encryption before any DB operations.
@@ -182,7 +182,7 @@ if (isEncryptionEnabled()) {
   console.log('Field-level encryption enabled')
 } else if (process.env.NODE_ENV === 'production') {
   console.warn(
-    'WARNING: DIGARR_ENCRYPTION_KEY is not set -- API keys and tokens are stored as plaintext in the database. Set this variable for production security.',
+    'WARNING: DIGARR_ENCRYPTION_KEY is not set - API keys and tokens are stored as plaintext in the database. Set this variable for production security.',
   )
 } else {
   console.log('Field-level encryption disabled (set DIGARR_ENCRYPTION_KEY to enable)')
@@ -192,7 +192,7 @@ if (isEncryptionEnabled()) {
 await runPreFlightCheck(db)
 
 // Run pending database migrations before anything else.
-// Uses drizzle-orm's programmatic migrator -- safe to run every boot (idempotent).
+// Uses drizzle-orm's programmatic migrator - safe to run every boot (idempotent).
 await migrate(db, { migrationsFolder: './drizzle' })
 console.log('Database migrations applied')
 
@@ -691,7 +691,7 @@ const subscriptionQueriesImpl = {
   deleteSubscription: (id: number) => deleteSubscription(db, id),
 }
 
-// Cache adapter registries per user -- building one per execution is redundant when
+// Cache adapter registries per user - building one per execution is redundant when
 // multiple subscriptions fire on the same schedule for the same user.
 // TTL is short (60s) so credential changes (e.g. new OAuth token) take effect quickly.
 const adapterRegistryCache = new Map<string, { registry: AdapterRegistry; builtAt: number }>()
@@ -712,7 +712,7 @@ function setCachedAdapterRegistry(userId: number | null, registry: AdapterRegist
 async function executeSubscription(subscriptionId: number): Promise<void> {
   const sub = await getSubscription(db, subscriptionId)
   if (!sub) {
-    console.warn(`[subscription-runner] Subscription ${subscriptionId} not found -- skipping`)
+    console.warn(`[subscription-runner] Subscription ${subscriptionId} not found - skipping`)
     return
   }
 
@@ -752,7 +752,7 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
   }
 
   // Build adapter registry from available sources, or reuse a cached one.
-  // Cache is keyed by userId with a 60s TTL -- short enough that credential
+  // Cache is keyed by userId with a 60s TTL - short enough that credential
   // changes take effect quickly, long enough to avoid rebuilding for every
   // subscription when many fire on the same schedule for the same user.
   const userId = sub.userId
@@ -768,18 +768,18 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
     )
     adapterRegistry.register(createCsvImportAdapter())
 
-    // Last.fm adapters -- only if the user has a Last.fm API key
+    // Last.fm adapters - only if the user has a Last.fm API key
     if (lfApiKey) {
       adapterRegistry.register(createLastfmTagAdapter({ apiKey: lfApiKey }))
       adapterRegistry.register(createLastfmChartsAdapter({ apiKey: lfApiKey }))
     }
 
-    // ListenBrainz adapter -- only if the user has LB credentials
+    // ListenBrainz adapter - only if the user has LB credentials
     if (lbUsername && lbToken) {
       adapterRegistry.register(createListenBrainzAdapter({ username: lbUsername, token: lbToken }))
     }
 
-    // Spotify adapters -- only if the user has a stored OAuth token
+    // Spotify adapters - only if the user has a stored OAuth token
     if (userId !== null && userId !== undefined) {
       const spotifyOAuthRow = await getOAuthToken(db, userId, 'spotify')
       if (spotifyOAuthRow) {
@@ -790,7 +790,7 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
       }
     }
 
-    // Deezer adapter -- only if the user has a stored OAuth token
+    // Deezer adapter - only if the user has a stored OAuth token
     if (userId !== null && userId !== undefined) {
       const deezerOAuthRow = await getOAuthToken(db, userId, 'deezer')
       if (deezerOAuthRow && !deezerOAuthRow.accessToken.startsWith('pending:')) {
@@ -805,7 +805,7 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
   const adapter = adapterRegistry.get(sub.sourceType)
   if (!adapter && sub.sourceType !== DISCOVERY_MODE_SUBSCRIPTION_TYPE) {
     console.warn(
-      `[subscription-runner] Unknown type '${sub.sourceType}' for subscription ${subscriptionId} -- skipping`,
+      `[subscription-runner] Unknown type '${sub.sourceType}' for subscription ${subscriptionId} - skipping`,
     )
     return
   }
@@ -937,7 +937,7 @@ async function executePlaylistGeneration(playlistId: number): Promise<void> {
 
   const result = await getPlaylistWithTracks(db, playlistId)
   if (!result) {
-    console.warn(`[playlist-scheduler] Playlist ${playlistId} not found -- skipping`)
+    console.warn(`[playlist-scheduler] Playlist ${playlistId} not found - skipping`)
     return
   }
 
@@ -1102,7 +1102,7 @@ function restartLibraryMaintenanceScheduler(intervalHours: number): void {
   })
 }
 
-// Lazy OIDC service getter -- reads current settings from DB on each call,
+// Lazy OIDC service getter - reads current settings from DB on each call,
 // reconstructs the service only when the config (issuer/client/secret/scopes) changes.
 // This ensures settings-UI changes to OIDC config take effect without a restart.
 let oidcServiceCache: { service: OidcService; configKey: string } | null = null
@@ -1130,7 +1130,7 @@ async function getOidcService(): Promise<OidcService | null> {
   return service
 }
 
-// Static search sources -- no auth required, safe to build once at startup.
+// Static search sources - no auth required, safe to build once at startup.
 function buildStaticSearchSources(): SearchSource[] {
   return [
     createMusicBrainzSearchSource(createMusicBrainzClient()),
@@ -1238,7 +1238,7 @@ const app = createApp({
     }
 
     if (type === 'spotify-playlist') {
-      // Spotify test requires OAuth -- can't test from config alone
+      // Spotify test requires OAuth - can't test from config alone
       return {
         success: false,
         message:
@@ -1390,7 +1390,7 @@ const server = serve({ fetch: app.fetch, port })
     if (initialUsername && initialPassword) {
       if (initialPassword.length < 8) {
         console.error(
-          'DIGARR_INITIAL_PASSWORD must be at least 8 characters -- skipping user creation',
+          'DIGARR_INITIAL_PASSWORD must be at least 8 characters - skipping user creation',
         )
       } else {
         const count = await getUserCount(db)
@@ -1440,7 +1440,7 @@ const server = serve({ fetch: app.fetch, port })
       }
     }
 
-    // Start schedulers -- single getSettings() call shared across all
+    // Start schedulers - single getSettings() call shared across all
     const prefs = mergePreferences(settings?.preferences)
     const cron = prefs.scheduleCron
     if (cron) {
@@ -1456,7 +1456,7 @@ const server = serve({ fetch: app.fetch, port })
 
     await restartPlaylistScheduler()
 
-    // Library maintenance schedulers -- background, idempotent. Boot fire is non-blocking.
+    // Library maintenance schedulers - background, idempotent. Boot fire is non-blocking.
     restartLibraryMaintenanceScheduler(librarySyncIntervalHours)
     // Fire one sync + health scan at boot so fresh installs don't wait for the first cron tick.
     void librarySyncOrchestrator
@@ -1494,12 +1494,12 @@ setInterval(
 console.log(`Digarr running on http://localhost:${port}`)
 if (!envConfig.allowedOrigin && process.env.NODE_ENV === 'production') {
   console.warn(
-    'ALLOWED_ORIGIN not set -- CORS rejects all cross-origin requests. Set ALLOWED_ORIGIN to your domain.',
+    'ALLOWED_ORIGIN not set - CORS rejects all cross-origin requests. Set ALLOWED_ORIGIN to your domain.',
   )
 }
 if (envConfig.authToken && envConfig.authToken.length < 16) {
   console.warn(
-    'DIGARR_AUTH_TOKEN is shorter than 16 characters -- this is trivially brute-forceable. Use a longer token.',
+    'DIGARR_AUTH_TOKEN is shorter than 16 characters - this is trivially brute-forceable. Use a longer token.',
   )
 }
 if (envConfig.authToken) {
@@ -1509,11 +1509,11 @@ if (envConfig.authToken) {
 }
 if (!envConfig.authToken && !envConfig.initialUsername) {
   console.warn(
-    'No DIGARR_AUTH_TOKEN or DIGARR_INITIAL_USERNAME set -- the API is unauthenticated until the first user registers. Set one for production security.',
+    'No DIGARR_AUTH_TOKEN or DIGARR_INITIAL_USERNAME set - the API is unauthenticated until the first user registers. Set one for production security.',
   )
 }
 
-// Graceful shutdown -- wait for in-flight pipeline runs before exiting
+// Graceful shutdown - wait for in-flight pipeline runs before exiting
 for (const signal of ['SIGTERM', 'SIGINT'] as const) {
   process.on(signal, async () => {
     console.log(`${signal} received, shutting down...`)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -130,7 +130,7 @@ export type AppDependencies = {
   genreService: GenreService
   // Library health service
   libraryHealth: LibraryHealthService
-  // SkyHook cache warmer (optional -- absent if Lidarr is not configured)
+  // SkyHook cache warmer (optional - absent if Lidarr is not configured)
   skyhookWarmer?: SkyHookWarmer | null
   // Library sync orchestrator + store
   librarySync: SyncOrchestrator
@@ -207,21 +207,21 @@ export type AppDependencies = {
       limit?: number,
     ) => Promise<import('@/core/jobs/types').JobRunRow[]>
   }
-  // Playlist deps (optional -- omit in test environments without a DB)
+  // Playlist deps (optional - omit in test environments without a DB)
   playlistDeps?: PlaylistDeps
-  // Search deps (optional -- absent when no search sources are configured)
+  // Search deps (optional - absent when no search sources are configured)
   search?: SearchDeps
 }
 
 export function createApp(deps: AppDependencies) {
   const app = new Hono<HonoEnv>()
 
-  // Log all requests first -- before auth/cors so we capture everything
+  // Log all requests first - before auth/cors so we capture everything
   app.use('*', requestLogger())
 
   if (!envConfig.allowedOrigin && process.env.NODE_ENV === 'production') {
     console.warn(
-      'ALLOWED_ORIGIN is not set in production -- CORS will reject cross-origin requests. Set ALLOWED_ORIGIN to your app URL.',
+      'ALLOWED_ORIGIN is not set in production - CORS will reject cross-origin requests. Set ALLOWED_ORIGIN to your app URL.',
     )
   }
   app.use(
@@ -273,7 +273,7 @@ export function createApp(deps: AppDependencies) {
   )
   app.use('*', setupGuard(deps.isSetupComplete))
 
-  // Auth status (unauthenticated -- tells the frontend whether auth is required)
+  // Auth status (unauthenticated - tells the frontend whether auth is required)
   app.get('/api/auth/status', async (c) => {
     const [userCount, setupComplete] = await Promise.all([
       deps.getUserCount(),

--- a/src/server/middleware/admin-guard.ts
+++ b/src/server/middleware/admin-guard.ts
@@ -5,7 +5,7 @@ type GetUserById = (id: number) => Promise<{ isAdmin: boolean } | null>
 
 /**
  * Middleware that rejects non-admin users with 403.
- * Legacy token auth (no userId) is NOT admin -- users should migrate to session auth.
+ * Legacy token auth (no userId) is NOT admin - users should migrate to session auth.
  * authSkipped (fresh installs) is allowed through because the setup guard already
  * blocks non-setup API paths when setup is not complete.
  */

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -49,7 +49,7 @@ export function authGuard(options: {
     // Other OAuth paths (initiate, status, delete) need auth so userId is set on context.
     if (publicPath && !OPTIONAL_AUTH_PATHS.has(c.req.path)) return next()
 
-    // Proxy auth already validated upstream -- skip token checks
+    // Proxy auth already validated upstream - skip token checks
     const proxyAuthed = c.get('proxyAuth')
     if (proxyAuthed) return next()
 
@@ -76,7 +76,7 @@ export function authGuard(options: {
     const legacyToken = envConfig.authToken
     if (legacyToken && provided && safeCompare(provided, legacyToken)) {
       console.warn(
-        `[auth] DEPRECATED: Legacy token auth from ${c.req.header('x-forwarded-for') ?? 'direct'} -- no admin access, no per-user features. Migrate to user sessions.`,
+        `[auth] DEPRECATED: Legacy token auth from ${c.req.header('x-forwarded-for') ?? 'direct'} - no admin access, no per-user features. Migrate to user sessions.`,
       )
       // Assign userId=1 (first user) so downstream queries scope correctly
       // instead of matching NULL userId records

--- a/src/server/middleware/proxy-auth.ts
+++ b/src/server/middleware/proxy-auth.ts
@@ -66,7 +66,7 @@ export function proxyAuthMiddleware(deps: ProxyAuthDeps) {
     let user = await deps.getUserByUsername(forwardedUser)
     if (!user) {
       const isFirstUser = (await deps.getUserCount()) === 0
-      // Generate random password hash -- proxy users authenticate via headers, not passwords
+      // Generate random password hash - proxy users authenticate via headers, not passwords
       const randomHash = hashPassword(crypto.randomUUID())
       user = await deps.createUser({
         username: forwardedUser,

--- a/src/server/middleware/rate-limit.ts
+++ b/src/server/middleware/rate-limit.ts
@@ -16,7 +16,7 @@ function getSocketIp(c: { env?: unknown }): string | null {
 
 /**
  * Simple in-memory rate limiter keyed by client IP.
- * Not shared across processes -- sufficient for single-process deployments.
+ * Not shared across processes - sufficient for single-process deployments.
  */
 export function rateLimiter(opts: { windowMs: number; max: number; keyPrefix?: string }) {
   const buckets = new Map<string, RateLimitBucket>()

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -36,7 +36,7 @@ const VALID_STATUSES = new Set([
 export function adminRoutes(deps: AdminDeps) {
   const router = new Hono<HonoEnv>()
 
-  // POST /api/admin/backup -- download backup JSON
+  // POST /api/admin/backup - download backup JSON
   router.post('/api/admin/backup', async (c) => {
     const includeCaches = c.req.query('includeCaches') === 'true'
     const backup = await createBackup(deps.db, { includeCaches })
@@ -52,7 +52,7 @@ export function adminRoutes(deps: AdminDeps) {
     })
   })
 
-  // POST /api/admin/restore -- upload and restore backup JSON.
+  // POST /api/admin/restore - upload and restore backup JSON.
   // Dual-format (multipart + raw JSON) rules out zJson middleware; we parse
   // then validate with the same schema in-handler. Zod catches prototype
   // pollution, missing top-level keys, and non-array table payloads before
@@ -119,13 +119,13 @@ export function adminRoutes(deps: AdminDeps) {
     return c.json(result)
   })
 
-  // GET /api/admin/backup/last -- last auto-backup metadata
+  // GET /api/admin/backup/last - last auto-backup metadata
   router.get('/api/admin/backup/last', async (c) => {
     const status = await getPendingMigrations(deps.db)
     return c.json({ lastAutoBackup: status.lastAutoBackup })
   })
 
-  // GET /api/admin/migrations/pending -- pending migration status
+  // GET /api/admin/migrations/pending - pending migration status
   router.get('/api/admin/migrations/pending', async (c) => {
     const status = await getPendingMigrations(deps.db)
     return c.json(status)
@@ -161,7 +161,7 @@ export function adminRoutes(deps: AdminDeps) {
       return c.json({ error: 'No valid status values provided' }, 400)
     }
 
-    // Library genres unavailable in offline rescore -- zero the weight to avoid score drift
+    // Library genres unavailable in offline rescore - zero the weight to avoid score drift
     const adjustedWeights = { ...prefs.scoringWeights, genreOverlap: 0 }
     const result = await rescoreRecommendations(deps.db, adjustedWeights, [], statuses)
     return c.json(result)

--- a/src/server/routes/artists.ts
+++ b/src/server/routes/artists.ts
@@ -70,7 +70,7 @@ export function artistRoutes(deps: AppDependencies) {
       }
     }
 
-    // Cache track names/durations (preview URLs are not cached -- fetched fresh each time)
+    // Cache track names/durations (preview URLs are not cached - fetched fresh each time)
     const toCache = tracks.map((t) => ({ name: t.name, durationMs: t.durationMs }))
     const topTracksCache: TopTracksCache = { tracks: toCache, cachedAt: new Date().toISOString() }
     await deps.db.update(artists).set({ topTracks: topTracksCache }).where(eq(artists.id, id))

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -99,7 +99,7 @@ export function authRoutes(deps: AppDependencies) {
 
   // Login with username + password.
   // Keeps manual validation so the "credentials required" error stays
-  // i18n'd via the request-locale messages bundle -- login is the most
+  // i18n'd via the request-locale messages bundle - login is the most
   // user-visible error surface and the existing locales cover it.
   router.post('/api/auth/login', async (c) => {
     const messages = getRequestMessages(c)

--- a/src/server/routes/exports.ts
+++ b/src/server/routes/exports.ts
@@ -77,7 +77,7 @@ export function exportRoutes(deps: ExportDeps) {
       suggestedAlbum: rec.recommendedReleaseGroupTitle ?? undefined,
     }))
 
-    // format already validated above -- safe to index directly
+    // format already validated above - safe to index directly
     const output = EXPORTERS[format]?.(exportable)
     const timestamp = new Date().toISOString().slice(0, 10)
 

--- a/src/server/routes/jobs.ts
+++ b/src/server/routes/jobs.ts
@@ -27,7 +27,7 @@ export function jobRoutes(deps: JobRouteDeps) {
   router.use('/api/jobs/*', adminGuard(deps.getUserById))
   router.use('/api/jobs', adminGuard(deps.getUserById))
 
-  // Health summary -- must be before /:id to avoid matching 'health' as an id
+  // Health summary - must be before /:id to avoid matching 'health' as an id
   router.get('/api/jobs/health', async (c) => {
     const health = await deps.jobQueries.getJobHealth(deps.scheduler.nextRun)
     return c.json(health)

--- a/src/server/routes/library.ts
+++ b/src/server/routes/library.ts
@@ -73,7 +73,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     return auth
   }
 
-  // GET /api/library/health -- return cached results + scanning status
+  // GET /api/library/health - return cached results + scanning status
   app.get('/api/library/health', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -88,7 +88,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     })
   })
 
-  // POST /api/library/health/scan -- kick off background scan, return 202
+  // POST /api/library/health/scan - kick off background scan, return 202
   app.post('/api/library/health/scan', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -96,7 +96,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     return c.json({ scanning: true }, 202)
   })
 
-  // POST /api/library/health/:checkId/fix -- trigger fix for a check
+  // POST /api/library/health/:checkId/fix - trigger fix for a check
   app.post('/api/library/health/:checkId/fix', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -112,7 +112,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     }
   })
 
-  // GET /api/library/stats -- library statistics
+  // GET /api/library/stats - library statistics
   app.get('/api/library/stats', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -120,7 +120,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     return c.json(stats)
   })
 
-  // POST /api/library/warm -- trigger background warming for a batch of MBIDs
+  // POST /api/library/warm - trigger background warming for a batch of MBIDs
   app.post('/api/library/warm', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -143,7 +143,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     return c.json({ queued: batch.length }, 202)
   })
 
-  // GET /api/library/warm/status -- check warm status for MBIDs
+  // GET /api/library/warm/status - check warm status for MBIDs
   app.get('/api/library/warm/status', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -159,7 +159,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     return c.json({ statuses })
   })
 
-  // GET /api/library/sources -- per-source sync state for current user + global rows
+  // GET /api/library/sources - per-source sync state for current user + global rows
   app.get('/api/library/sources', async (c) => {
     const auth = requireSessionUser(c)
     if (!auth.ok) return auth.response
@@ -167,7 +167,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     return c.json({ sources })
   })
 
-  // POST /api/library/sync -- manual "Sync now", rate-limited 5/min
+  // POST /api/library/sync - manual "Sync now", rate-limited 5/min
   app.use('/api/library/sync', rateLimiter({ windowMs: 60_000, max: 5, keyPrefix: 'libsync' }))
   app.post('/api/library/sync', async (c) => {
     const auth = await requireAdmin(c)
@@ -177,7 +177,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     const source = typeof body.source === 'string' ? body.source : undefined
     if (source) {
       let result = await deps.librarySync.syncSpecificSource(auth.userId, source, { force: true })
-      // Per-user source not configured -- retry as a global source. This is safe today because
+      // Per-user source not configured - retry as a global source. This is safe today because
       // (a) the route is admin-gated and (b) per-user/global source IDs do not overlap. If a
       // future source becomes both per-user AND global, restrict this fallback to known-global
       // IDs to avoid letting per-user calls trigger global syncs they shouldn't reach.
@@ -193,7 +193,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     }
   })
 
-  // GET /api/library/unreconciled -- rows where mbid IS NULL for current user + global
+  // GET /api/library/unreconciled - rows where mbid IS NULL for current user + global
   app.get('/api/library/unreconciled', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -219,7 +219,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     return c.json({ items })
   })
 
-  // POST /api/library/overrides -- create/update an MBID override
+  // POST /api/library/overrides - create/update an MBID override
   app.post('/api/library/overrides', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -273,7 +273,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     return c.json({ ok: true })
   })
 
-  // DELETE /api/library/overrides/:source/:sourceArtistId -- remove an override
+  // DELETE /api/library/overrides/:source/:sourceArtistId - remove an override
   app.delete('/api/library/overrides/:source/:sourceArtistId', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -283,7 +283,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     return c.json({ ok: true })
   })
 
-  // POST /api/library/reconcile -- re-run reconciler for current user (forced syncForUser)
+  // POST /api/library/reconcile - re-run reconciler for current user (forced syncForUser)
   // Note: a "reconcile only without re-fetch" path is a follow-up task.
   app.post('/api/library/reconcile', async (c) => {
     const auth = await requireAdmin(c)

--- a/src/server/routes/mood.ts
+++ b/src/server/routes/mood.ts
@@ -75,7 +75,7 @@ export function moodRoutes(deps: MoodDeps) {
         const artists = await lidarr.getArtists()
         libraryNames = new Set(artists.map((a) => a.artistName.toLowerCase()))
       } catch {
-        // Lidarr unavailable -- skip library check
+        // Lidarr unavailable - skip library check
       }
     }
 

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -36,7 +36,7 @@ export function oauthRoutes(deps: AppDependencies) {
         if (!clientId || !clientSecret || !redirectUri) {
           return c.json({ error: 'clientId, clientSecret, and redirectUri are required' }, 400)
         }
-        // Use opaque state token -- userId is stored server-side, not in the URL
+        // Use opaque state token - userId is stored server-side, not in the URL
         const state = crypto.randomUUID()
         // Store client credentials temporarily so the callback can use them
         await upsertOAuthToken(deps.db, {
@@ -95,7 +95,7 @@ export function oauthRoutes(deps: AppDependencies) {
     }
   })
 
-  // OAuth callback -- exchanges code for tokens
+  // OAuth callback - exchanges code for tokens
   router.get('/api/auth/oauth/:provider/callback', async (c) => {
     const provider = c.req.param('provider')
     const code = c.req.query('code')
@@ -194,7 +194,7 @@ export function oauthRoutes(deps: AppDependencies) {
           }
         } catch (err: unknown) {
           console.error('Failed to auto-create Spotify target:', err)
-          // Non-fatal -- OAuth succeeded, target creation is best-effort
+          // Non-fatal - OAuth succeeded, target creation is best-effort
         }
 
         return c.redirect('/settings?oauth_success=spotify')
@@ -257,7 +257,7 @@ export function oauthRoutes(deps: AppDependencies) {
           return c.redirect('/settings?oauth_error=token_exchange_failed')
         }
 
-        // expires=0 means long-lived -- treat as 1 year
+        // expires=0 means long-lived - treat as 1 year
         const expiresIn =
           deezerTokenData.expires === 0
             ? 365 * 24 * 3600

--- a/src/server/routes/oidc.ts
+++ b/src/server/routes/oidc.ts
@@ -90,7 +90,7 @@ export function oidcRoutes(deps: OidcRouteDeps) {
 
       const sessionToken = generateSessionToken()
       await createSession(user.id, sessionToken)
-      // Use fragment (#) not query param (?) -- fragments are never sent to
+      // Use fragment (#) not query param (?) - fragments are never sent to
       // the server in Referer headers or logged by reverse proxies
       return c.redirect(`/#oidc_token=${encodeURIComponent(sessionToken)}`)
     } catch (err: unknown) {

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -66,7 +66,7 @@ export function pipelineRoutes(deps: AppDependencies) {
       try {
         spotifyAccessToken = await resolveSpotifyToken(deps.db, userId)
       } catch {
-        // Best-effort -- continue without Spotify
+        // Best-effort - continue without Spotify
       }
     }
 
@@ -77,7 +77,7 @@ export function pipelineRoutes(deps: AppDependencies) {
       userId,
     )
 
-    // Build auto-approve deps -- closures capture userId for per-user target lookup
+    // Build auto-approve deps - closures capture userId for per-user target lookup
     const autoApproveDeps: AutoApproveDeps = {
       getRecommendationsByBatch: async (batchId) => {
         const result = await deps.listRecommendations({ batchId, limit: 1000 })
@@ -266,7 +266,7 @@ export function pipelineRoutes(deps: AppDependencies) {
               source: 'mood',
             },
           ]
-          // Resolve via MB only (no Lidarr image lookup -- avoids SkyHook dependency)
+          // Resolve via MB only (no Lidarr image lookup - avoids SkyHook dependency)
           const seedResolved = await resolve(seedDiscovered, mb)
           const newSeeds = seedResolved.filter((s) => !existingMbids.has(s.mbid))
           if (newSeeds.length > 0) {
@@ -468,7 +468,7 @@ export function pipelineRoutes(deps: AppDependencies) {
           })
           updated++
         } else {
-          // No image found -- refresh the negative cache TTL
+          // No image found - refresh the negative cache TTL
           await upsertArtist(deps.db, {
             mbid,
             name: artist.name as string,

--- a/src/server/routes/playlists.ts
+++ b/src/server/routes/playlists.ts
@@ -62,7 +62,7 @@ export function playlistRoutes(deps: PlaylistDeps) {
   const router = new Hono<HonoEnv>()
   const { db } = deps
 
-  // GET /api/playlists/scheduler -- must be registered before :id route
+  // GET /api/playlists/scheduler - must be registered before :id route
   router.get('/api/playlists/scheduler', async (c) => {
     const userId = c.get('userId')
     if (!userId) return c.json({ error: 'Unauthorized' }, 401)

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -287,7 +287,7 @@ export function settingsRoutes(deps: AppDependencies) {
     const body = await c.req.json()
     const testUserId = c.get('userId')
 
-    // Admin-only services: lidarr, ai, oidc -- only enforced when user sessions are active
+    // Admin-only services: lidarr, ai, oidc - only enforced when user sessions are active
     if (testUserId && (service === 'lidarr' || service === 'ai' || service === 'oidc')) {
       const isAdmin = await resolveAdmin(
         testUserId,
@@ -325,7 +325,7 @@ export function settingsRoutes(deps: AppDependencies) {
         const result = await client.testConnection()
         if (result.success && !token) {
           result.message +=
-            ' (warning: no API token set -- listening data, subscriptions, and recommendations will not work without it)'
+            ' (warning: no API token set - listening data, subscriptions, and recommendations will not work without it)'
         }
         return c.json(result)
       }
@@ -382,7 +382,7 @@ export function settingsRoutes(deps: AppDependencies) {
         const client = createJellyfinClient(url, apiKey, jfUserId, { skipTlsVerify: skipTls })
         const result = await client.testConnection()
         if (result.success && !jfUserId) {
-          result.message += ' (warning: no user ID set -- listening data will not work without it)'
+          result.message += ' (warning: no user ID set - listening data will not work without it)'
         }
         return c.json(result)
       }
@@ -398,7 +398,7 @@ export function settingsRoutes(deps: AppDependencies) {
         const client = createEmbyClient(url, apiKey, embyUserId, { skipTlsVerify: skipTls })
         const result = await client.testConnection()
         if (result.success && !embyUserId) {
-          result.message += ' (warning: no user ID set -- listening data will not work without it)'
+          result.message += ' (warning: no user ID set - listening data will not work without it)'
         }
         return c.json(result)
       }

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -38,14 +38,14 @@ export function setupRoutes(deps: AppDependencies) {
     const missing: string[] = []
     if (!sanitized.aiProvider) missing.push('aiProvider')
     if (!sanitized.aiModel) missing.push('aiModel')
-    // Lidarr is optional -- only validate if partially provided
+    // Lidarr is optional - only validate if partially provided
     if (sanitized.lidarrUrl && !sanitized.lidarrApiKey) {
       missing.push('lidarrApiKey (required when lidarrUrl is set)')
     }
     if (!sanitized.lidarrUrl && sanitized.lidarrApiKey) {
       missing.push('lidarrUrl (required when lidarrApiKey is set)')
     }
-    // Emby is optional -- only validate if partially provided
+    // Emby is optional - only validate if partially provided
     if (body.embyUrl && (!body.embyApiKey || !body.embyUserId)) {
       missing.push('embyApiKey and embyUserId (required when embyUrl is set)')
     }
@@ -71,7 +71,7 @@ export function setupRoutes(deps: AppDependencies) {
           userId,
         })
       } catch {
-        // Best-effort -- the boot-time backfill will handle it on next restart
+        // Best-effort - the boot-time backfill will handle it on next restart
       }
     }
 
@@ -108,7 +108,7 @@ export function setupRoutes(deps: AppDependencies) {
           userId,
         })
       } catch (err) {
-        // Best-effort -- surface failures later via the targets UI
+        // Best-effort - surface failures later via the targets UI
         console.warn('[setup] createTarget failed for emby-playlist:', err)
       }
     }

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -392,7 +392,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
       sourceType: 'csv-import',
       sourceProvider: 'csv',
       sourceConfig: { artists },
-      cron: '0 0 1 1 *', // never recurs -- just a carrier for the one-shot run
+      cron: '0 0 1 1 *', // never recurs - just a carrier for the one-shot run
       enabled: false,
       maxArtistsPerRun: artists.length,
       action: 'add_to_recommendations',

--- a/src/server/routes/users.ts
+++ b/src/server/routes/users.ts
@@ -31,7 +31,7 @@ export function userRoutes(deps: AppDependencies) {
     return { ok: true as const, userId }
   }
 
-  // GET /api/users -- list all users (admin only)
+  // GET /api/users - list all users (admin only)
   router.get('/api/users', async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -40,7 +40,7 @@ export function userRoutes(deps: AppDependencies) {
     return c.json(userList)
   })
 
-  // POST /api/users -- create a new user (admin only)
+  // POST /api/users - create a new user (admin only)
   router.post('/api/users', zJson(createUserSchema), async (c) => {
     const auth = await requireAdmin(c)
     if (!auth.ok) return auth.response
@@ -57,7 +57,7 @@ export function userRoutes(deps: AppDependencies) {
     return c.json(user, 201)
   })
 
-  // PATCH /api/users/:id -- update user (admin only)
+  // PATCH /api/users/:id - update user (admin only)
   // Body: { isAdmin?: boolean }
   // Guards: can't remove own admin role, can't remove last admin
   router.patch('/api/users/:id', zParam(userIdParamSchema), zJson(updateUserSchema), async (c) => {
@@ -89,7 +89,7 @@ export function userRoutes(deps: AppDependencies) {
     return c.json({ ok: true })
   })
 
-  // DELETE /api/users/:id -- delete user (admin only)
+  // DELETE /api/users/:id - delete user (admin only)
   // Guards: can't delete self, can't delete last admin
   router.delete('/api/users/:id', zParam(userIdParamSchema), async (c) => {
     const auth = await requireAdmin(c)

--- a/src/server/schemas/settings.ts
+++ b/src/server/schemas/settings.ts
@@ -41,7 +41,7 @@ const preferencesSchema = z
   })
   .passthrough()
 
-// PATCH body for /api/settings. Every field optional -- it's a partial update.
+// PATCH body for /api/settings. Every field optional - it's a partial update.
 // Unknown top-level keys are silently stripped (matches the existing allowlist
 // behavior). Per-field types prevent accidental string-where-number bugs from
 // the UI or curl.

--- a/src/server/schemas/targets.ts
+++ b/src/server/schemas/targets.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 import { TARGET_TYPES } from '@/core/targets/types'
 
 // URL must be http(s). Private-IP / SSRF checks live in handlers and
-// outbound HTTP clients (publicIpOnly) -- schema just enforces the scheme.
+// outbound HTTP clients (publicIpOnly) - schema just enforces the scheme.
 export const httpUrl = z
   .string()
   .trim()

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -427,7 +427,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
               <NavLink to="/" className="text-xl font-bold text-accent hover:opacity-90">
                 digarr
               </NavLink>
-              {/* Desktop nav links -- grouped */}
+              {/* Desktop nav links - grouped */}
               <div className="hidden sm:flex items-center gap-4">
                 <NavLink to="/" end className={navLinkClass}>
                   <span className="flex items-center gap-1">
@@ -675,7 +675,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
             </div>
           )}
         </nav>
-        {/* Main content -- add pb-16 on mobile so bottom nav doesn't overlap */}
+        {/* Main content - add pb-16 on mobile so bottom nav doesn't overlap */}
         <main className="pb-16 md:pb-0">{children}</main>
         <BottomNav />
         <KeyboardShortcuts open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
@@ -694,7 +694,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
   )
 }
 
-// Inner app -- only mounts after AuthGate has resolved auth
+// Inner app - only mounts after AuthGate has resolved auth
 function InnerApp() {
   const [setupComplete, setSetupComplete] = useState<boolean | null>(null)
 

--- a/src/web/components/album-picker.tsx
+++ b/src/web/components/album-picker.tsx
@@ -83,7 +83,7 @@ export function AlbumPicker({
   }
 
   return (
-    /* Modal backdrop -- aria-hidden because the close button inside handles keyboard */
+    /* Modal backdrop - aria-hidden because the close button inside handles keyboard */
     /* biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-dismiss is intentional; keyboard handled by Escape key */
     /* biome-ignore lint/a11y/useKeyWithClickEvents: close button inside provides keyboard alternative */
     <div

--- a/src/web/components/artist-thumb.tsx
+++ b/src/web/components/artist-thumb.tsx
@@ -7,7 +7,7 @@ import { hueFromName } from '../lib/utils'
  * Artist avatar: shows the image if available, falls back to a colored
  * two-letter placeholder derived from the artist name.
  *
- * size -- grid unit (Tailwind style, multiplied by 4 to get px). Default: 10.
+ * size - grid unit (Tailwind style, multiplied by 4 to get px). Default: 10.
  */
 export function ArtistThumb({
   name,

--- a/src/web/components/auth-gate.tsx
+++ b/src/web/components/auth-gate.tsx
@@ -33,7 +33,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
     async function checkAuth() {
       try {
-        // Handle OIDC callback -- token or error passed in URL fragment (#)
+        // Handle OIDC callback - token or error passed in URL fragment (#)
         // Fragments never leak to server logs or Referer headers
         const hash = window.location.hash.slice(1) // strip leading #
         const hashParams = new URLSearchParams(hash)
@@ -49,7 +49,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
         if (oidcError) {
           window.history.replaceState({}, '', window.location.pathname)
-          // Fall through -- show login with the error visible via state
+          // Fall through - show login with the error visible via state
         }
 
         const status = await getAuthStatus()
@@ -62,7 +62,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
           return
         }
 
-        // Proxy auth -- backend resolved the identity and issued a token
+        // Proxy auth - backend resolved the identity and issued a token
         if (status.proxyAuth && status.token) {
           setStoredToken(status.token)
           setState('authenticated')
@@ -80,7 +80,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
         setState(status.hasUsers ? 'login' : 'register')
       } catch {
-        // Can't reach server -- render children and let it fail naturally
+        // Can't reach server - render children and let it fail naturally
         setState('not-required')
       }
     }

--- a/src/web/components/bottom-nav.tsx
+++ b/src/web/components/bottom-nav.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom'
 import { useI18n } from '../lib/i18n'
 import { cn } from '../lib/utils'
 
-// Icons (inline SVG -- consistent with existing component style)
+// Icons (inline SVG - consistent with existing component style)
 
 function DashboardIcon({ className }: { className?: string }) {
   return (

--- a/src/web/components/keyboard-shortcuts.tsx
+++ b/src/web/components/keyboard-shortcuts.tsx
@@ -53,7 +53,7 @@ export function KeyboardShortcuts({ open, onClose }: KeyboardShortcutsProps) {
       onClick={onClose}
       onKeyDown={onBackdropKeyDown}
     >
-      {/* Dialog card -- stop propagation so clicking inside doesn't close */}
+      {/* Dialog card - stop propagation so clicking inside doesn't close */}
       <div
         role="dialog"
         aria-modal="true"

--- a/src/web/components/library-sources-panel.tsx
+++ b/src/web/components/library-sources-panel.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { RefreshCw } from 'lucide-react'
+import { AlertTriangle, RefreshCw } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { getLibrarySources, triggerLibrarySync } from '../lib/api'
@@ -134,6 +134,21 @@ export function LibrarySourcesPanel() {
                       {counts.matchedNameAnchored} anchored, {counts.matchedDisambiguated}{' '}
                       disambiguated, {unreconciled} unreconciled
                     </div>
+
+                    {typeof counts.mbApiCallsFailed === 'number' && counts.mbApiCallsFailed > 0 && (
+                      <div
+                        className="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400"
+                        data-testid={`mb-warning-${row.source}`}
+                      >
+                        <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+                        <span>
+                          {t('librarySources.mbWarning').replace(
+                            '{0}',
+                            String(counts.mbApiCallsFailed),
+                          )}
+                        </span>
+                      </div>
+                    )}
 
                     {typeof counts.albumsSynced === 'number' && (
                       <div className="space-y-1">

--- a/src/web/components/library-sources-panel.tsx
+++ b/src/web/components/library-sources-panel.tsx
@@ -127,9 +127,9 @@ export function LibrarySourcesPanel() {
                     <div className="text-xs text-muted">
                       {counts.total} artists
                       {typeof counts.albumsSynced === 'number'
-                        ? ` -- ${counts.albumsSynced} albums`
+                        ? ` - ${counts.albumsSynced} albums`
                         : ''}
-                      {' -- '}
+                      {' - '}
                       {counts.matchedMbid} MBID, {counts.matchedNameExact} exact,{' '}
                       {counts.matchedNameAnchored} anchored, {counts.matchedDisambiguated}{' '}
                       disambiguated, {unreconciled} unreconciled

--- a/src/web/components/monitoring-options.tsx
+++ b/src/web/components/monitoring-options.tsx
@@ -47,7 +47,7 @@ export function MonitoringOptions({ onApprove, onOpenAlbumPicker, loading }: Pro
 
   return (
     <div className="relative inline-flex">
-      {/* Primary approve button -- defaults to 'all' */}
+      {/* Primary approve button - defaults to 'all' */}
       <Button
         size="sm"
         variant="outline"

--- a/src/web/components/mood-prompt-bar.tsx
+++ b/src/web/components/mood-prompt-bar.tsx
@@ -41,7 +41,7 @@ export function MoodPromptBar({
     try {
       await quickDiscover(artistName)
       toast.success(t('discover.moodAddedSuccess').replace('{0}', artistName))
-      // Seed artist is stored async on the backend -- poll for it to appear
+      // Seed artist is stored async on the backend - poll for it to appear
       setTimeout(onQueued, 2000)
       setTimeout(onQueued, 5000)
     } catch {

--- a/src/web/components/playlist-card.tsx
+++ b/src/web/components/playlist-card.tsx
@@ -136,7 +136,7 @@ export function PlaylistCard({ playlist, onEdit, onRefetch }: PlaylistCardProps)
   }
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: intentional div[role=button] -- action buttons nested inside prevent using <button>
+    // biome-ignore lint/a11y/useSemanticElements: intentional div[role=button] - action buttons nested inside prevent using <button>
     <div
       role="button"
       tabIndex={0}

--- a/src/web/components/playlist-form.tsx
+++ b/src/web/components/playlist-form.tsx
@@ -147,7 +147,7 @@ export function PlaylistForm({ playlist, onSave, onCancel }: PlaylistFormProps) 
             >
               {STRATEGIES.map((s) => (
                 <option key={s.value} value={s.value}>
-                  {t(s.labelKey)} -- {t(s.descriptionKey)}
+                  {t(s.labelKey)} - {t(s.descriptionKey)}
                 </option>
               ))}
             </select>

--- a/src/web/components/recommendation-card.tsx
+++ b/src/web/components/recommendation-card.tsx
@@ -608,7 +608,7 @@ export function RecommendationCard({
           />
         </button>
       )}
-      {/* Hover edge buttons -- desktop only, pending cards, not when expanded */}
+      {/* Hover edge buttons - desktop only, pending cards, not when expanded */}
       {!bulkMode && isPending && !expanded && (
         <>
           {/* Left edge: reject */}
@@ -666,7 +666,7 @@ export function RecommendationCard({
           </button>
         </>
       )}
-      {/* biome-ignore lint/a11y/useSemanticElements: intentional div[role=button] -- nesting <button> inside <button> is invalid HTML */}
+      {/* biome-ignore lint/a11y/useSemanticElements: intentional div[role=button] - nesting <button> inside <button> is invalid HTML */}
       <div
         role="button"
         tabIndex={0}
@@ -780,7 +780,7 @@ export function RecommendationCard({
 
           {rec.artist.mbid && <LibraryAlbumCoverageBadge artistMbid={rec.artist.mbid} />}
 
-          {/* Action buttons -- compact mode only, hidden in bulk mode */}
+          {/* Action buttons - compact mode only, hidden in bulk mode */}
           {!expanded && (
             <>
               <ActionButtons
@@ -931,7 +931,7 @@ export function RecommendationCard({
               />
             )}
 
-            {/* Action buttons (re-shown in expanded too) -- hidden in bulk mode */}
+            {/* Action buttons (re-shown in expanded too) - hidden in bulk mode */}
             <div className="px-4">
               <ActionButtons
                 rec={rec}

--- a/src/web/components/subscription-form.tsx
+++ b/src/web/components/subscription-form.tsx
@@ -382,7 +382,7 @@ export function SubscriptionForm({
                 >
                   {SOURCE_TYPES.map((sourceTypeOption) => (
                     <option key={sourceTypeOption.value} value={sourceTypeOption.value}>
-                      {t(sourceTypeOption.labelKey)} -- {t(sourceTypeOption.descriptionKey)}
+                      {t(sourceTypeOption.labelKey)} - {t(sourceTypeOption.descriptionKey)}
                     </option>
                   ))}
                 </select>
@@ -576,7 +576,7 @@ export function SubscriptionForm({
                       initial.sourceType ?? '',
                       initial.sourceConfig as Record<string, unknown>,
                     )
-                    return detail ? ` -- ${detail}` : null
+                    return detail ? ` - ${detail}` : null
                   })()}
               </div>
               <p className="text-xs text-muted mt-1">{t('subscriptionForm.sourceLockedHelp')}</p>

--- a/src/web/components/swipe-card.tsx
+++ b/src/web/components/swipe-card.tsx
@@ -76,7 +76,7 @@ export function SwipeCard({ onSwipeLeft, onSwipeRight, enabled = true, children 
 
   return (
     <div ref={ref} className={cn('relative rounded-lg', swiping && 'overflow-hidden')}>
-      {/* Tint overlay -- stays in place, card slides over it */}
+      {/* Tint overlay - stays in place, card slides over it */}
       {enabled && swiping && (
         <div
           className={cn(

--- a/src/web/components/todays-pick.tsx
+++ b/src/web/components/todays-pick.tsx
@@ -139,7 +139,7 @@ export function TodaysPick({
 
   return (
     <div className="bg-surface border border-border rounded-lg overflow-hidden flex flex-col">
-      {/* Banner -- fills ~40% of card height */}
+      {/* Banner - fills ~40% of card height */}
       <div className="relative shrink-0 h-72" style={bannerStyle}>
         {hasImage && (
           <img

--- a/src/web/hooks/use-preview.ts
+++ b/src/web/hooks/use-preview.ts
@@ -154,7 +154,7 @@ export function usePreview() {
           setStateAndRef((s) => ({ ...s, playing: true }))
           return
         }
-        // For embeds, just flip playing flag -- iframe handles playback
+        // For embeds, just flip playing flag - iframe handles playback
         setStateAndRef((s) => ({ ...s, playing: true }))
         return
       }
@@ -198,7 +198,7 @@ export function usePreview() {
           setStateAndRef((s) => ({ ...s, source, loading: false, playing: true }))
         } catch {
           setStateAndRef(() => INITIAL_STATE)
-          toast.error('Playback blocked by browser -- try clicking again')
+          toast.error('Playback blocked by browser - try clicking again')
         }
         return
       }

--- a/src/web/hooks/use-swipe.ts
+++ b/src/web/hooks/use-swipe.ts
@@ -56,7 +56,7 @@ export function useSwipe(options: UseSwipeOptions) {
     const dx = touch.clientX - startXRef.current
     const dy = touch.clientY - startYRef.current
 
-    // Vertical dominates -- let the page scroll, bail out
+    // Vertical dominates - let the page scroll, bail out
     if (!swipingRef.current && Math.abs(dy) > Math.abs(dx)) return
 
     // Commit to horizontal swipe once past 10px

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -411,6 +411,7 @@ export type LibrarySyncCounts = {
   unreconciledNoCandidate: number
   cacheHits: number
   mbApiCalls: number
+  mbApiCallsFailed?: number
   estimatedSecondsRemaining?: number
   albumsSynced?: number
 }

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -34,7 +34,7 @@ export function getStoredToken(): string | null {
   return localStorage.getItem(AUTH_TOKEN_KEY)
 }
 
-// SPA session tokens require client-side storage -- cookies would need
+// SPA session tokens require client-side storage - cookies would need
 // server-side session management. Token is never logged or transmitted
 // except via Authorization header or query param (SSE/audio fallback).
 export function setStoredToken(token: string): void {
@@ -68,13 +68,13 @@ function extractApiErrorMessage(status: number, data: unknown): string {
   return `API Error ${status}`
 }
 
-// Fired when any fetchApi call gets 401 -- AuthGate listens and shows login
+// Fired when any fetchApi call gets 401 - AuthGate listens and shows login
 export const AUTH_EXPIRED_EVENT = 'digarr:auth-expired'
 
 async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
   const headers: Record<string, string> = {}
   headers['X-Digarr-Locale'] = getRequestLocale()
-  // Skip Content-Type for FormData -- browser sets it with the correct boundary
+  // Skip Content-Type for FormData - browser sets it with the correct boundary
   if (!(options?.body instanceof FormData)) {
     headers['Content-Type'] = 'application/json'
   }
@@ -141,7 +141,7 @@ export async function getCurrentUser(): Promise<UserProfile | null> {
         'X-Digarr-Locale': getRequestLocale(),
       },
     })
-    if (!res.ok) return null // Legacy token users have no userId -- don't trigger auth-expired
+    if (!res.ok) return null // Legacy token users have no userId - don't trigger auth-expired
     return res.json() as Promise<UserProfile>
   } catch {
     return null
@@ -400,7 +400,7 @@ export const warmArtists = (mbids: string[]) =>
   })
 
 // Library sync
-// LibrarySyncCounts mirrors src/db/schema.ts -- redeclared here to avoid pulling drizzle into the web bundle
+// LibrarySyncCounts mirrors src/db/schema.ts - redeclared here to avoid pulling drizzle into the web bundle
 export type LibrarySyncCounts = {
   total: number
   matchedMbid: number
@@ -827,7 +827,7 @@ export const importCsvFile = async (file: File) => {
   }>('/subscriptions/import/csv', {
     method: 'POST',
     body: formData,
-    // Do NOT set Content-Type -- browser sets it with boundary for FormData
+    // Do NOT set Content-Type - browser sets it with boundary for FormData
   })
 }
 

--- a/src/web/pages/dashboard.tsx
+++ b/src/web/pages/dashboard.tsx
@@ -299,7 +299,7 @@ export function Dashboard() {
   const [actedIds, setActedIds] = useState<Set<number>>(new Set())
   const [listenRange, setListenRange] = useState<'week' | 'month'>('month')
 
-  // Pending pick -- fetch 10 so skip has runway
+  // Pending pick - fetch 10 so skip has runway
   const { data: pickData, isLoading: pickLoading } = useQuery({
     queryKey: ['dashboard-pick'],
     queryFn: () => getRecommendations({ status: 'pending', sort: 'score_desc', limit: '10' }),

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -497,7 +497,7 @@ export function DiscoverPage() {
     }
   }, [undoEntry, refetch, t])
 
-  // Count per filter for tab badges -- fetch all counts independently
+  // Count per filter for tab badges - fetch all counts independently
   const { data: allCountData } = useQuery({
     queryKey: ['recommendations', 'count', 'all'],
     queryFn: () => getRecommendations({ limit: '1' }),
@@ -535,7 +535,7 @@ export function DiscoverPage() {
         setApproveDialogState({ recId: id, monitorOption: option })
         return
       }
-      // 'selected' flow -- album picker already ran, call API directly
+      // 'selected' flow - album picker already ran, call API directly
       setActingIds((prev) => new Set([...prev, id]))
       try {
         await approveRecommendation(id, {
@@ -862,7 +862,7 @@ export function DiscoverPage() {
               ))}
             </div>
 
-            {/* Approve All Above + Select -- hidden in stack mode */}
+            {/* Approve All Above + Select - hidden in stack mode */}
             {viewMode !== 'stack' && (
               <>
                 <select
@@ -1254,7 +1254,7 @@ export function DiscoverPage() {
         </div>
       )}
 
-      {/* FAB: Run Scan -- mobile only, above bottom nav */}
+      {/* FAB: Run Scan - mobile only, above bottom nav */}
       {!bulkMode && (
         <button
           type="button"

--- a/src/web/pages/genres.tsx
+++ b/src/web/pages/genres.tsx
@@ -136,7 +136,7 @@ export function GenresPage() {
         </div>
       )}
 
-      {/* FAB: Seed Genres -- mobile only, above bottom nav */}
+      {/* FAB: Seed Genres - mobile only, above bottom nav */}
       <button
         type="button"
         onClick={handleSeed}

--- a/src/web/pages/library-health.tsx
+++ b/src/web/pages/library-health.tsx
@@ -114,7 +114,7 @@ export function LibraryHealthPage() {
         if (data.failed === 0) {
           if (isDeferred) {
             toast.success(
-              `${t('libraryHealth.triggeredActionFor')} ${data.completed} ${artistLabel(data.completed)} -- ${t('libraryHealth.rescanningSoon')}`,
+              `${t('libraryHealth.triggeredActionFor')} ${data.completed} ${artistLabel(data.completed)} - ${t('libraryHealth.rescanningSoon')}`,
             )
           } else {
             toast.success(

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -1388,7 +1388,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
         </ServiceCard>
       </div>
 
-      {/* Lidarr Preferences -- per-user, visible to all */}
+      {/* Lidarr Preferences - per-user, visible to all */}
       {settings.lidarrUrl && <LidarrPreferencesSection />}
     </div>
   )
@@ -2101,7 +2101,7 @@ function RecommendationsTabInner({
         {t('settings.recommendationsTip')}
       </Hint>
 
-      {/* Essential -- always visible */}
+      {/* Essential - always visible */}
       <section className="space-y-4">
         <h2 className="text-sm font-semibold text-text uppercase tracking-wide">
           {t('settings.scoreThreshold')}
@@ -2117,7 +2117,7 @@ function RecommendationsTabInner({
         />
       </section>
 
-      {/* Tuning -- collapsed by default */}
+      {/* Tuning - collapsed by default */}
       <CollapsibleSection title={t('settings.scoringWeights')}>
         <div className="space-y-4 pt-2">
           <div className="flex items-center gap-3">
@@ -2230,7 +2230,7 @@ function RecommendationsTabInner({
         </div>
       </CollapsibleSection>
 
-      {/* Advanced -- collapsed by default */}
+      {/* Advanced - collapsed by default */}
       <CollapsibleSection title={t('settings.advancedSettings')}>
         <div className="space-y-6 pt-2">
           <section className="space-y-4">

--- a/tests/api-routes/pipeline.test.ts
+++ b/tests/api-routes/pipeline.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/core/spotify-auth', async (importOriginal) => {
   }
 })
 
-// resolveUserPreferences calls DB queries -- mock the whole helper.
+// resolveUserPreferences calls DB queries - mock the whole helper.
 vi.mock('@/server/helpers/preferences', async (importOriginal) => {
   const original = await importOriginal<typeof import('@/server/helpers/preferences')>()
   return {

--- a/tests/api-routes/recommendations.test.ts
+++ b/tests/api-routes/recommendations.test.ts
@@ -45,7 +45,7 @@ describe('API routes: approve/reject', () => {
       body: JSON.stringify({ status: 'rejected' }),
     })
     expect(res.status).toBe(200)
-    // Rejection calls updateRecommendationStatus with only (id, status) -- no extra arg
+    // Rejection calls updateRecommendationStatus with only (id, status) - no extra arg
     expect(deps.updateRecommendationStatus).toHaveBeenCalledWith(2, 'rejected')
   })
 

--- a/tests/core/auth.test.ts
+++ b/tests/core/auth.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { generateSessionToken, hashPassword, verifyPassword } from '@/core/auth'
 
 describe('auth helpers', () => {
-  // scrypt N=2^17 takes ~2-4s per hash -- raise timeout for the full suite
+  // scrypt N=2^17 takes ~2-4s per hash - raise timeout for the full suite
   describe('hashPassword / verifyPassword', { timeout: 30_000 }, () => {
     it('verifies a correct password', () => {
       const hash = hashPassword('hunter2')

--- a/tests/core/clients/bandcamp.test.ts
+++ b/tests/core/clients/bandcamp.test.ts
@@ -207,12 +207,12 @@ describe('createBandcampClient', () => {
   })
 
   describe('rate limiting', () => {
-    it('uses p-queue (concurrency 1) -- sequential calls do not interleave', async () => {
+    it('uses p-queue (concurrency 1) - sequential calls do not interleave', async () => {
       // This is a structural test: just verifying the client can make multiple calls
       // without throwing (the queue ensures they serialize).
       const client = createBandcampClient({ baseUrl })
       const before = requestCount
-      // Fire two calls -- they will queue up
+      // Fire two calls - they will queue up
       const [r1, r2] = await Promise.all([
         client.searchArtists('portishead'),
         client.searchArtists('portishead'),

--- a/tests/core/clients/http.test.ts
+++ b/tests/core/clients/http.test.ts
@@ -45,7 +45,7 @@ beforeAll(async () => {
     const parsed = new URL(rawUrl, 'http://localhost')
     const path = parsed.pathname
 
-    // Slow endpoint for timeout test -- delays 500ms
+    // Slow endpoint for timeout test - delays 500ms
     if (path === '/slow') {
       await new Promise((r) => setTimeout(r, 500))
       sendJson(res, 200, { ok: true })
@@ -151,7 +151,7 @@ describe('createHttpClient', () => {
     })
   })
 
-  describe('4xx errors -- no retry', () => {
+  describe('4xx errors - no retry', () => {
     it('throws HttpError on 404', async () => {
       const client = createHttpClient({ baseUrl, retries: 3 })
       await expect(client.get('/notfound')).rejects.toThrow(HttpError)
@@ -206,9 +206,9 @@ describe('createHttpClient', () => {
     })
   })
 
-  describe('5xx errors -- retry with exponential backoff', () => {
+  describe('5xx errors - retry with exponential backoff', () => {
     it('retries on 500 and succeeds when server recovers', async () => {
-      // /flaky/test-recover?fails=2 -- fails first 2 hits, succeeds on 3rd
+      // /flaky/test-recover?fails=2 - fails first 2 hits, succeeds on 3rd
       const path = '/flaky/test-recover'
       const before = serverHits.get(path) ?? 0
       const client = createHttpClient({ baseUrl, retries: 3 })

--- a/tests/core/clients/jellyfin.test.ts
+++ b/tests/core/clients/jellyfin.test.ts
@@ -232,7 +232,7 @@ describe('jellyfin client.testConnection()', () => {
 
     await expect(client.testConnection()).resolves.toMatchObject({
       success: true,
-      message: 'Connected to Jellyfin "Home Media" v10.9.0 -- 0 top artist(s)',
+      message: 'Connected to Jellyfin "Home Media" v10.9.0 - 0 top artist(s)',
     })
 
     expect(mockGet).toHaveBeenNthCalledWith(

--- a/tests/core/clients/lidarr.test.ts
+++ b/tests/core/clients/lidarr.test.ts
@@ -161,7 +161,7 @@ describe('createLidarrClient', () => {
       )
     })
 
-    it('caches getRootFolders() -- only calls the API once across multiple addArtist calls', async () => {
+    it('caches getRootFolders() - only calls the API once across multiple addArtist calls', async () => {
       mockGet.mockResolvedValue(mockFolders)
       mockPost.mockResolvedValue({ id: 11 })
 

--- a/tests/core/clients/musicbrainz-lookup-recording.test.ts
+++ b/tests/core/clients/musicbrainz-lookup-recording.test.ts
@@ -102,10 +102,12 @@ describe('lookupRecording(mbid)', () => {
     })
   })
 
-  it('throws on non-404 errors', async () => {
-    mockFetch.mockResolvedValueOnce(new Response('Server Error', { status: 500 }))
+  it('throws on non-404 errors after retries are exhausted', async () => {
+    // 500 is transient: the client retries 3x before surfacing. Each attempt
+    // consumes one mocked response.
+    mockFetch.mockResolvedValue(new Response('Server Error', { status: 500 }))
 
     const client = createMusicBrainzClient()
     await expect(client.lookupRecording('bad-mbid')).rejects.toThrow(/500/)
-  })
+  }, 30_000)
 })

--- a/tests/core/clients/musicbrainz.test.ts
+++ b/tests/core/clients/musicbrainz.test.ts
@@ -362,7 +362,7 @@ describe('createMusicBrainzClient', () => {
     })
   })
 
-  describe('rate limiter -- queue integration', () => {
+  describe('rate limiter - queue integration', () => {
     it('routes lookupArtist through the p-queue', async () => {
       mockFetch.mockResolvedValueOnce(makeJsonResponse(MOCK_ARTIST_RESPONSE))
       const client = createMusicBrainzClient()

--- a/tests/core/clients/musicbrainz.test.ts
+++ b/tests/core/clients/musicbrainz.test.ts
@@ -523,4 +523,48 @@ describe('createMusicBrainzClient', () => {
       expect(types).toContain('EP')
     })
   })
+
+  describe('retry behavior on transient errors', () => {
+    it('retries on 503 and succeeds when upstream recovers', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('', { status: 503 }))
+      mockFetch.mockResolvedValueOnce(new Response('', { status: 503 }))
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ artists: [] }))
+
+      const client = createMusicBrainzClient()
+      const result = await client.searchArtist('flaky-artist')
+
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      expect(result).toEqual({ artists: [] })
+    }, 15_000)
+
+    it('gives up after max retries and throws the final error', async () => {
+      mockFetch.mockResolvedValue(new Response('', { status: 503 }))
+
+      const client = createMusicBrainzClient()
+      await expect(client.searchArtist('always-down')).rejects.toThrow(/MusicBrainz HTTP 503/)
+      // 1 initial + 3 retries = 4 total
+      expect(mockFetch).toHaveBeenCalledTimes(4)
+    }, 30_000)
+
+    it('does not retry on non-transient 4xx', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('', { status: 400 }))
+
+      const client = createMusicBrainzClient()
+      await expect(client.searchArtist('bad-query')).rejects.toThrow(/MusicBrainz HTTP 400/)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('honors Retry-After header within the cap', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response('', { status: 429, headers: { 'retry-after': '0' } }),
+      )
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ artists: [] }))
+
+      const client = createMusicBrainzClient()
+      const result = await client.searchArtist('rate-limited')
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(result).toEqual({ artists: [] })
+    })
+  })
 })

--- a/tests/core/clients/tidal.test.ts
+++ b/tests/core/clients/tidal.test.ts
@@ -132,7 +132,7 @@ describe('createTidalClient', () => {
       const before = tokenRequestCount
       await client.searchArtists('portishead')
       await client.searchArtists('massive attack')
-      // Both calls should use the same token -- only 1 fetch after `before`
+      // Both calls should use the same token - only 1 fetch after `before`
       expect(tokenRequestCount - before).toBe(1)
     })
 
@@ -198,7 +198,7 @@ describe('createTidalClient', () => {
         tokenUrl: `${authBaseUrl}/token`,
         baseUrl: 'http://127.0.0.1:1/v2',
       })
-      // Auth succeeds (real auth server), search fails -- should not throw
+      // Auth succeeds (real auth server), search fails - should not throw
       const results = await client.searchArtists('portishead')
       expect(results).toEqual([])
     })

--- a/tests/core/genre/service.test.ts
+++ b/tests/core/genre/service.test.ts
@@ -40,7 +40,7 @@ describe('GenreService', () => {
       expect(svc.slugify('Post-Punk')).toBe('post-punk')
     })
 
-    it("strips '&' -- 'R&B' becomes 'rb'", () => {
+    it("strips '&' - 'R&B' becomes 'rb'", () => {
       const svc = new GenreService({ genreQueries: makeQueries() })
       expect(svc.slugify('R&B')).toBe('rb')
     })

--- a/tests/core/library/album-reconciler.test.ts
+++ b/tests/core/library/album-reconciler.test.ts
@@ -147,4 +147,28 @@ describe('reconcileAlbumsForArtist', () => {
       titleNormalized: 'dummy',
     })
   })
+
+  it('degrades gracefully when MB getReleaseGroups throws 503', async () => {
+    const mbClient = {
+      getReleaseGroups: vi
+        .fn()
+        .mockRejectedValue(new Error('MusicBrainz HTTP 503 for /release-group?...')),
+    }
+    const onMbError = vi.fn()
+
+    const rows = await reconcileAlbumsForArtist(
+      ARTIST_MBID,
+      [album({ title: 'Stranger Things', releaseYear: 2019 })],
+      { mbClient, onMbError },
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      albumMbid: null,
+      artistMbid: ARTIST_MBID,
+      matchMethod: null,
+      releaseYear: 2019,
+    })
+    expect(onMbError).toHaveBeenCalledOnce()
+  })
 })

--- a/tests/core/library/health.test.ts
+++ b/tests/core/library/health.test.ts
@@ -664,7 +664,7 @@ describe('LibraryHealthService', () => {
 
       expect(mocks.lookupArtist).toHaveBeenCalledWith(`lidarr:${MBID}`)
       expect(mocks.cacheUpdateImageUrl).not.toHaveBeenCalled()
-      expect(progress.completed).toBe(1) // still "completed" -- just no image found
+      expect(progress.completed).toBe(1) // still "completed" - just no image found
     })
 
     it('counts failures when fix throws', async () => {
@@ -682,7 +682,7 @@ describe('LibraryHealthService', () => {
     })
 
     it('returns completed status with zero items when no cached results', async () => {
-      // Don't run runChecks first -- cachedResults is null
+      // Don't run runChecks first - cachedResults is null
       const fresh = makeService(mocks)
       mocks.updateArtist.mockResolvedValue({})
 

--- a/tests/core/library/reconciler.test.ts
+++ b/tests/core/library/reconciler.test.ts
@@ -23,6 +23,7 @@ function makeCtx(overrides: Partial<ReconcilerContext> = {}): ReconcilerContext 
       unreconciledNoCandidate: 0,
       cacheHits: 0,
       mbApiCalls: 0,
+      mbApiCallsFailed: 0,
     },
     ...overrides,
   }
@@ -313,5 +314,51 @@ describe('reconcileArtist -- Step 5 (album-overlap disambiguation)', () => {
     }
     const result = await reconcileArtist(artist, 'plex', ctx)
     expect(result.unreconciledReason).toBe('ambiguous')
+  })
+})
+
+describe('reconcileArtist -- MusicBrainz degradation', () => {
+  it('returns unreconciled "no_candidate" when searchArtist throws 503', async () => {
+    const ctx = makeCtx({
+      mbClient: {
+        searchArtist: vi
+          .fn()
+          .mockRejectedValue(new Error('MusicBrainz HTTP 503 for /artist/?query=bush&fmt=json')),
+        getReleaseGroups: vi.fn(),
+      },
+    })
+    const artist: LibraryArtist = { sourceArtistId: 'rk-1', name: 'Bush' }
+    const result = await reconcileArtist(artist, 'plex', ctx)
+    expect(result.mbid).toBeNull()
+    expect(result.unreconciledReason).toBe('no_candidate')
+    expect(ctx.counts.mbApiCallsFailed).toBe(1)
+    expect(ctx.counts.unreconciledNoCandidate).toBe(1)
+    expect(ctx.mbClient.getReleaseGroups).not.toHaveBeenCalled()
+  })
+
+  it('does not fail the reconciliation when getReleaseGroups throws during disambiguation', async () => {
+    const ctx = makeCtx({
+      mbClient: {
+        searchArtist: vi.fn().mockResolvedValue({
+          artists: [
+            { id: VALID_MBID, name: 'Bush', score: 100 },
+            { id: OTHER_MBID, name: 'Bush', score: 90 },
+          ],
+        }),
+        getReleaseGroups: vi
+          .fn()
+          .mockRejectedValue(new Error('MusicBrainz HTTP 503 for /release-group?artist=...')),
+      },
+    })
+    const artist: LibraryArtist = {
+      sourceArtistId: 'rk-1',
+      name: 'Bush',
+      knownAlbumTitles: ['Album One', 'Album Two'],
+    }
+    const result = await reconcileArtist(artist, 'plex', ctx)
+    // Both candidates score zero overlap, so disambiguation fails to decide
+    // and we fall through to 'ambiguous' without throwing.
+    expect(result.unreconciledReason).toBe('ambiguous')
+    expect(ctx.counts.mbApiCallsFailed).toBe(2)
   })
 })

--- a/tests/core/library/reconciler.test.ts
+++ b/tests/core/library/reconciler.test.ts
@@ -32,7 +32,7 @@ function makeCtx(overrides: Partial<ReconcilerContext> = {}): ReconcilerContext 
 const VALID_MBID = 'a74b1b7f-71a5-4011-9441-d0b5e4122711'
 const OTHER_MBID = '8f6bd1e4-fbe1-4f50-aa9b-94c450ec0a11'
 
-describe('reconcileArtist -- Step 0 (override)', () => {
+describe('reconcileArtist - Step 0 (override)', () => {
   it('returns matched row when override has correctMbid', async () => {
     const overrides = new Map([['plex:rk-1', { correctMbid: OTHER_MBID }]])
     const artist: LibraryArtist = { sourceArtistId: 'rk-1', name: 'Bush' }
@@ -58,7 +58,7 @@ describe('reconcileArtist -- Step 0 (override)', () => {
   })
 })
 
-describe('reconcileArtist -- Step 1 (source-provided MBID)', () => {
+describe('reconcileArtist - Step 1 (source-provided MBID)', () => {
   it('trusts source MBID when present and valid', async () => {
     const artist: LibraryArtist = { sourceArtistId: 'lid-1', name: 'Radiohead', mbid: VALID_MBID }
     const result = await reconcileArtist(artist, 'lidarr', makeCtx())
@@ -81,7 +81,7 @@ describe('reconcileArtist -- Step 1 (source-provided MBID)', () => {
   })
 })
 
-describe('reconcileArtist -- Step 2 (cache short-circuit)', () => {
+describe('reconcileArtist - Step 2 (cache short-circuit)', () => {
   it('uses cache hit when exactly one match in library_artists by normalized name', async () => {
     const ctx = makeCtx({
       cacheLookup: vi
@@ -140,7 +140,7 @@ describe('reconcileArtist -- Step 2 (cache short-circuit)', () => {
   })
 })
 
-describe('reconcileArtist -- Step 3 (anchoring)', () => {
+describe('reconcileArtist - Step 3 (anchoring)', () => {
   it('anchors when MB returns multiple candidates and one matches knownMbids', async () => {
     const ctx = makeCtx({
       knownMbids: new Set([VALID_MBID]),
@@ -178,7 +178,7 @@ describe('reconcileArtist -- Step 3 (anchoring)', () => {
     const artist: LibraryArtist = { sourceArtistId: 'rk-1', name: 'Bush' }
     const result = await reconcileArtist(artist, 'plex', ctx)
     // Will fall through to Step 5 disambiguation in Task 10. For now (Task 9),
-    // since there's no album data, expect "ambiguous" -- Task 10 may rewrite this.
+    // since there's no album data, expect "ambiguous" - Task 10 may rewrite this.
     expect(result.matchMethod).toBeNull()
     expect(result.unreconciledReason).toBe('ambiguous')
   })
@@ -203,7 +203,7 @@ describe('reconcileArtist -- Step 3 (anchoring)', () => {
   })
 })
 
-describe('reconcileArtist -- Step 5 (album-overlap disambiguation)', () => {
+describe('reconcileArtist - Step 5 (album-overlap disambiguation)', () => {
   it('picks winner when album overlap is clear', async () => {
     const ctx = makeCtx({
       mbClient: {
@@ -317,7 +317,7 @@ describe('reconcileArtist -- Step 5 (album-overlap disambiguation)', () => {
   })
 })
 
-describe('reconcileArtist -- MusicBrainz degradation', () => {
+describe('reconcileArtist - MusicBrainz degradation', () => {
   it('returns unreconciled "no_candidate" when searchArtist throws 503', async () => {
     const ctx = makeCtx({
       mbClient: {

--- a/tests/core/library/sync.test.ts
+++ b/tests/core/library/sync.test.ts
@@ -331,7 +331,7 @@ describe('createSyncOrchestrator', () => {
     expect(store.replaceLibrarySnapshot).toHaveBeenCalledWith(1, 'lidarr', expect.any(Array), [])
   })
 
-  it('fails the source sync when album reconciliation throws', async () => {
+  it('completes the sync and logs an MB error when album reconciliation throws', async () => {
     const a = sourceWithAlbums(
       'lidarr',
       [{ sourceArtistId: '1', name: 'Radiohead', mbid: 'a74b1b7f-71a5-4011-9441-d0b5e4122711' }],
@@ -364,11 +364,16 @@ describe('createSyncOrchestrator', () => {
 
     const summary = await sync.syncForUser(1, { force: true })
 
-    expect(summary.results[0]?.status).toBe('failed')
-    expect(store.replaceLibrarySnapshot).not.toHaveBeenCalled()
+    // Graceful degradation: one flaky album task no longer nukes the source.
+    // The sync completes with an empty album snapshot and an mb-failure tick.
+    expect(summary.results[0]?.status).toBe('completed')
+    expect(store.replaceLibrarySnapshot).toHaveBeenCalled()
+    if (summary.results[0]?.status === 'completed') {
+      expect(summary.results[0]?.counts.mbApiCallsFailed).toBeGreaterThanOrEqual(1)
+    }
   })
 
-  it('waits for queued album tasks to settle before returning a failure', async () => {
+  it('waits for queued album tasks to settle even when one fails', async () => {
     const albumTaskSettled: string[] = []
     const albumTaskStarted: string[] = []
     const a: LibrarySource = {
@@ -410,7 +415,10 @@ describe('createSyncOrchestrator', () => {
 
     const summary = await sync.syncForUser(1, { force: true })
 
-    expect(summary.results[0]?.status).toBe('failed')
+    // Previously this test asserted a 'failed' status. Since graceful
+    // degradation, the sync completes and only the failing album task is
+    // counted as an MB failure; the other three still settle.
+    expect(summary.results[0]?.status).toBe('completed')
     expect(albumTaskStarted).toEqual(['1', '2', '3', '4'])
     expect(albumTaskSettled).toContain('2')
     expect(albumTaskSettled).toContain('3')

--- a/tests/core/library/sync.test.ts
+++ b/tests/core/library/sync.test.ts
@@ -132,7 +132,7 @@ describe('createSyncOrchestrator', () => {
     })
     await sync.syncForUser(1)
 
-    // syncForUser only walks per-user sources -- global sources are syncGlobal's job
+    // syncForUser only walks per-user sources - global sources are syncGlobal's job
     // but Task 12 has the orchestrator order both within a single call when called from
     // the scheduler. Update test expectations once we wire the scheduler.
     expect(order).toEqual(['plex'])

--- a/tests/core/notifications.test.ts
+++ b/tests/core/notifications.test.ts
@@ -164,7 +164,7 @@ describe('sendWebhook', () => {
       })
     })
 
-    // The real timeout is 10s -- we can't wait that long in tests.
+    // The real timeout is 10s - we can't wait that long in tests.
     // Instead, verify the signal is passed to fetch.
     const promise = sendWebhook('https://hooks.example.com/webhook', makePayload())
 

--- a/tests/core/ops/backup.test.ts
+++ b/tests/core/ops/backup.test.ts
@@ -173,7 +173,7 @@ function makeMockUpsertDb(): OpsDb & {
       return { rows: [] }
     }),
     select: selectFn,
-    // Restore wraps everything in a transaction -- call the callback with `this`
+    // Restore wraps everything in a transaction - call the callback with `this`
     transaction: vi.fn().mockImplementation(async (cb: (tx: unknown) => Promise<void>) => {
       await cb(db)
     }),

--- a/tests/core/pipeline/analyze.test.ts
+++ b/tests/core/pipeline/analyze.test.ts
@@ -71,7 +71,7 @@ describe('analyze()', () => {
     const lfm = makeLfm()
     const profile = await analyze([lb, lfm])
 
-    // Radiohead appears in both -- LFM has higher play count (600 vs 500)
+    // Radiohead appears in both - LFM has higher play count (600 vs 500)
     const radiohead = profile.topArtists.find((a) => a.name.toLowerCase() === 'radiohead')
     expect(radiohead).toBeDefined()
     expect(radiohead?.playCount).toBe(600)

--- a/tests/core/pipeline/discover.test.ts
+++ b/tests/core/pipeline/discover.test.ts
@@ -104,7 +104,7 @@ describe('discover()', () => {
     expect(aiResults.length).toBeGreaterThan(0)
   })
 
-  it('isolates LB source failure -- other sources still return results', async () => {
+  it('isolates LB source failure - other sources still return results', async () => {
     const lb: DiscoverySource = {
       id: 'listenbrainz',
       name: 'ListenBrainz',
@@ -125,7 +125,7 @@ describe('discover()', () => {
     expect(results.filter((r) => r.source === 'listenbrainz').length).toBe(0)
   })
 
-  it('isolates AI source failure -- other sources still return results', async () => {
+  it('isolates AI source failure - other sources still return results', async () => {
     const lb = makeLb()
     const ai = { getRecommendations: vi.fn().mockRejectedValue(new Error('AI down')) }
 
@@ -135,7 +135,7 @@ describe('discover()', () => {
     expect(results.filter((r) => r.source === 'ai').length).toBe(0)
   })
 
-  it('respects topArtistsLimit -- skips artists beyond the limit', async () => {
+  it('respects topArtistsLimit - skips artists beyond the limit', async () => {
     const lb = makeLb()
     // Limit to 1 artist, so only Radiohead's similar artists should be fetched
     await discover(profile, { listeningSources: [lb] }, 1)
@@ -262,7 +262,7 @@ describe('discover()', () => {
     }
 
     const results = await discover(narrowProfile, { ai }, 10)
-    // "Air" is only 3 chars -- below the 4-char threshold, so no false positive
+    // "Air" is only 3 chars - below the 4-char threshold, so no false positive
     expect(results.map((r) => r.name)).toContain('Airborne Toxic Event')
   })
 

--- a/tests/core/pipeline/orchestrator.test.ts
+++ b/tests/core/pipeline/orchestrator.test.ts
@@ -526,7 +526,7 @@ describe('PipelineOrchestrator', () => {
       userId: 1,
     })
 
-    // score() is the 5th stage -- check its second argument (libraryGenres)
+    // score() is the 5th stage - check its second argument (libraryGenres)
     const scoreCall = mockScore.mock.calls[0]
     const passedGenres = scoreCall?.[1] as string[]
     expect(passedGenres).toBeDefined()
@@ -653,7 +653,7 @@ describe('PipelineOrchestrator', () => {
     const syncForUser = vi.fn(
       () =>
         new Promise((resolve) => {
-          // Never resolves during the test -- simulates a slow first sync
+          // Never resolves during the test - simulates a slow first sync
           setTimeout(() => {
             firstSyncResolved = true
             resolve({ userId: 1, results: [] })

--- a/tests/core/pipeline/resolve.test.ts
+++ b/tests/core/pipeline/resolve.test.ts
@@ -254,12 +254,12 @@ describe('resolve()', () => {
 
       const result = await resolve(discovered, mb)
 
-      // Should be dropped -- genres completely mismatch
+      // Should be dropped - genres completely mismatch
       expect(result).toHaveLength(0)
     })
 
     it('accepts artist when AI provides genres but MB candidate has no tags', async () => {
-      // MB having no tags is common for lesser-known artists -- should not reject
+      // MB having no tags is common for lesser-known artists - should not reject
       const discovered: DiscoveredArtist[] = [
         {
           name: 'Obscure Band',
@@ -283,7 +283,7 @@ describe('resolve()', () => {
 
       const result = await resolve(discovered, mb)
 
-      // Should be accepted -- no tags to contradict, not a confirmed mismatch
+      // Should be accepted - no tags to contradict, not a confirmed mismatch
       expect(result).toHaveLength(1)
       expect(result[0]?.mbid).toBe('mbid-obscure')
     })

--- a/tests/core/pipeline/store.test.ts
+++ b/tests/core/pipeline/store.test.ts
@@ -101,7 +101,7 @@ describe('store()', () => {
     )
   })
 
-  it('handles empty artists array -- creates batch with no recommendations', async () => {
+  it('handles empty artists array - creates batch with no recommendations', async () => {
     const db = makeDb(5)
 
     const batchId = await store([], db)

--- a/tests/core/pipeline/subscription-scheduler.test.ts
+++ b/tests/core/pipeline/subscription-scheduler.test.ts
@@ -48,7 +48,7 @@ describe('SubscriptionScheduler', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       // We can't trigger croner's internal callback directly without faking time,
       // but we can verify the wrapper doesn't throw by invoking the fn manually
-      // through a custom croner-aware path -- just verify schedule() itself succeeds
+      // through a custom croner-aware path - just verify schedule() itself succeeds
       // even when the fn would throw.
       scheduler.schedule('err-job', '*/5 * * * *', async () => {
         throw new Error('boom')
@@ -147,13 +147,13 @@ describe('SubscriptionScheduler', () => {
       expect(scheduler.has('b')).toBe(false)
     })
 
-    it('is idempotent -- calling twice does not throw', () => {
+    it('is idempotent - calling twice does not throw', () => {
       scheduler.schedule('once', '0 * * * *', async () => {})
       scheduler.stopAll()
       expect(() => scheduler.stopAll()).not.toThrow()
     })
 
-    it('leaves scheduler in clean state -- new jobs can be added after stopAll', () => {
+    it('leaves scheduler in clean state - new jobs can be added after stopAll', () => {
       scheduler.schedule('before', '0 * * * *', async () => {})
       scheduler.stopAll()
       scheduler.schedule('after', '0 * * * *', async () => {})

--- a/tests/core/playlists/generator.test.ts
+++ b/tests/core/playlists/generator.test.ts
@@ -321,7 +321,7 @@ describe('generatePlaylist()', () => {
     expect(result.tracks.every((t) => t.source === 'spotify')).toBe(true)
   })
 
-  it('respects size limit -- trims tracks to config.size', async () => {
+  it('respects size limit - trims tracks to config.size', async () => {
     const strategyDeps = makeStrategyDeps()
     const resolverDeps = makeResolverDeps()
 

--- a/tests/core/playlists/track-resolver.test.ts
+++ b/tests/core/playlists/track-resolver.test.ts
@@ -232,7 +232,7 @@ describe('resolveTracksForArtist()', () => {
       const tracks = await resolveTracksForArtist('Radiohead', undefined, deps, DEFAULT_CONFIG)
 
       expect(musicbrainzRecordings).not.toHaveBeenCalled()
-      // No sources available -- empty result
+      // No sources available - empty result
       expect(tracks).toHaveLength(0)
     })
   })
@@ -357,7 +357,7 @@ describe('resolveTracksForArtist()', () => {
       expect(tracks).toHaveLength(0)
     })
 
-    it('never throws -- always returns an array', async () => {
+    it('never throws - always returns an array', async () => {
       const deps: TrackResolverDeps = {
         jellyfinSearch: vi.fn().mockRejectedValue(new Error('kaboom')),
       }

--- a/tests/core/plugins/jellyfin.test.ts
+++ b/tests/core/plugins/jellyfin.test.ts
@@ -33,7 +33,7 @@ describe('createJellyfinSource()', () => {
       ]),
       testConnection: vi.fn().mockResolvedValue({
         success: true,
-        message: 'Connected to Jellyfin "MyServer" v10.9.0 -- 2 top artist(s)',
+        message: 'Connected to Jellyfin "MyServer" v10.9.0 - 2 top artist(s)',
       }),
     }
     vi.mocked(createJellyfinClient).mockReturnValue(client as never)

--- a/tests/core/providers/prompt.test.ts
+++ b/tests/core/providers/prompt.test.ts
@@ -102,7 +102,7 @@ describe('parseRecommendationResponse()', () => {
   })
 
   it('handles escaped backslashes before quotes in strings', () => {
-    // JSON: {"reasoning": "path\\"} -- literal backslash then closing quote
+    // JSON: {"reasoning": "path\\"} - literal backslash then closing quote
     const response =
       '[{"artistName":"Test","reasoning":"a path\\\\","confidence":0.8,"genres":["rock"]}]'
 

--- a/tests/core/search/multi-source.test.ts
+++ b/tests/core/search/multi-source.test.ts
@@ -124,7 +124,7 @@ describe('multiSourceSearch', () => {
     expect(unknown?.inRecommendations).toBe(false)
   })
 
-  it('handles source errors gracefully -- one fails, others succeed', async () => {
+  it('handles source errors gracefully - one fails, others succeed', async () => {
     const good = makeSource('a', [
       { name: 'Portishead', mbid: mbid1, images: [], genres: [], sourceId: 'a' },
     ])
@@ -167,7 +167,7 @@ describe('multiSourceSearch', () => {
       makeSource('a', [r1, r2]),
       makeSource('b', [r3]),
     ])
-    // Artist A appears in 2 sources, Artist B in 1 -- A should come first
+    // Artist A appears in 2 sources, Artist B in 1 - A should come first
     expect(results[0]?.name).toBe('Artist A')
     expect(results[1]?.name).toBe('Artist B')
   })

--- a/tests/core/subscriptions/adapters/lastfm-charts.test.ts
+++ b/tests/core/subscriptions/adapters/lastfm-charts.test.ts
@@ -74,7 +74,7 @@ describe('createLastfmChartsAdapter', () => {
     const adapter = createLastfmChartsAdapter({ apiKey: 'testkey' })
     const result = await adapter.fetch({})
 
-    // A, B, C -- lowercase dupe of A filtered
+    // A, B, C - lowercase dupe of A filtered
     expect(result.artists).toHaveLength(3)
     const names = result.artists.map((a) => a.name)
     expect(names).toContain('Top Artist A')

--- a/tests/core/subscriptions/adapters/lastfm-tag.test.ts
+++ b/tests/core/subscriptions/adapters/lastfm-tag.test.ts
@@ -21,7 +21,7 @@ const fixtureResponse = {
 function makeAdapter() {
   return createLastfmTagAdapter({
     apiKey: 'testkey',
-    // Patch fetch URL via global -- we'll use a custom approach instead
+    // Patch fetch URL via global - we'll use a custom approach instead
   })
 }
 
@@ -84,7 +84,7 @@ describe('createLastfmTagAdapter', () => {
     const adapter = makeAdapter()
     const result = await adapter.fetch({ tag: 'metal' })
 
-    // A, B, C -- lowercase dupe of A filtered
+    // A, B, C - lowercase dupe of A filtered
     expect(result.artists).toHaveLength(3)
     const names = result.artists.map((a) => a.name)
     expect(names).toContain('Metal Artist A')

--- a/tests/core/subscriptions/adapters/listenbrainz.test.ts
+++ b/tests/core/subscriptions/adapters/listenbrainz.test.ts
@@ -119,7 +119,7 @@ describe('createListenBrainzAdapter', () => {
       const adapter = createListenBrainzAdapter({ username: 'testuser', token: 'testtoken' })
       const result = await adapter.fetch({ feedType: 'fresh-releases' })
 
-      // One, Two, Three -- duplicate of One filtered, missing artist skipped
+      // One, Two, Three - duplicate of One filtered, missing artist skipped
       expect(result.artists).toHaveLength(3)
       const names = result.artists.map((a) => a.name)
       expect(names).toContain('Artist One')
@@ -148,7 +148,7 @@ describe('createListenBrainzAdapter', () => {
       const adapter = createListenBrainzAdapter({ username: 'testuser', token: 'testtoken' })
       const result = await adapter.fetch({ feedType: 'weekly-jams' })
 
-      // X, Y, Z -- duplicate of X filtered, missing creator skipped
+      // X, Y, Z - duplicate of X filtered, missing creator skipped
       expect(result.artists).toHaveLength(3)
       const names = result.artists.map((a) => a.name)
       expect(names).toContain('Jam Artist X')

--- a/tests/core/subscriptions/adapters/spotify-charts.test.ts
+++ b/tests/core/subscriptions/adapters/spotify-charts.test.ts
@@ -80,7 +80,7 @@ describe('createSpotifyChartsAdapter', () => {
     const adapter = createSpotifyChartsAdapter({ getToken: async () => 'tok', baseUrl })
     const result = await adapter.fetch({ region: 'global', chartType: 'top50' })
 
-    // One/Two/Three -- lowercase dupe of One filtered out
+    // One/Two/Three - lowercase dupe of One filtered out
     expect(result.artists).toHaveLength(3)
   })
 

--- a/tests/core/subscriptions/adapters/spotify-playlist.test.ts
+++ b/tests/core/subscriptions/adapters/spotify-playlist.test.ts
@@ -70,7 +70,7 @@ describe('createSpotifyPlaylistAdapter', () => {
     const adapter = createSpotifyPlaylistAdapter({ getToken: async () => 'tok', baseUrl })
     const result = await adapter.fetch({ playlistId: PLAYLIST_ID })
 
-    // Alpha, Beta, Gamma -- lowercase duplicate of Alpha filtered out
+    // Alpha, Beta, Gamma - lowercase duplicate of Alpha filtered out
     expect(result.artists).toHaveLength(3)
     const names = result.artists.map((a) => a.name)
     expect(names).toContain('Artist Alpha')

--- a/tests/core/targets/jellyfin-playlist.test.ts
+++ b/tests/core/targets/jellyfin-playlist.test.ts
@@ -90,7 +90,7 @@ describe('createJellyfinPlaylistTarget()', () => {
       mockFetch.mockImplementation(async (url: string | URL | Request, opts?: RequestInit) => {
         const urlStr = String(url)
 
-        // GET /Users/{userId}/Items -- track search
+        // GET /Users/{userId}/Items - track search
         if (urlStr.includes('/Items') && (!opts?.method || opts.method === 'GET')) {
           return ok({
             Items: [
@@ -106,7 +106,7 @@ describe('createJellyfinPlaylistTarget()', () => {
           })
         }
 
-        // POST /Playlists -- create playlist
+        // POST /Playlists - create playlist
         if (urlStr.includes('/Playlists') && opts?.method === 'POST') {
           return ok({ Id: 'jf-pl-1', Name: 'Digarr Picks' })
         }

--- a/tests/core/targets/navidrome-playlist.test.ts
+++ b/tests/core/targets/navidrome-playlist.test.ts
@@ -97,7 +97,7 @@ describe('createNavidromePlaylistTarget()', () => {
       mockFetch.mockImplementation(async (url: string | URL | Request) => {
         const urlStr = String(url)
 
-        // search3 -- track search
+        // search3 - track search
         if (urlStr.includes('/rest/search3')) {
           return okResponse({
             searchResult3: {
@@ -141,7 +141,7 @@ describe('createNavidromePlaylistTarget()', () => {
     it('skips items without trackName', async () => {
       const target = createNavidromePlaylistTarget(5, CONFIG)
       const result = await target.createPlaylist?.('Artist-only Playlist', [
-        // No trackName -- artist-level item, should be skipped
+        // No trackName - artist-level item, should be skipped
         { artistName: 'Radiohead', artistMbid: 'mbid-rh' },
       ])
 

--- a/tests/core/targets/spotify-playlist.test.ts
+++ b/tests/core/targets/spotify-playlist.test.ts
@@ -12,12 +12,12 @@ function setupMockResponses() {
   mockFetch.mockImplementation(async (url: string | URL | Request, opts?: RequestInit) => {
     const urlStr = String(url)
 
-    // GET /me -- current user
+    // GET /me - current user
     if (urlStr.includes('/v1/me') && !urlStr.includes('/playlists')) {
       return new Response(JSON.stringify({ id: 'spotify-user-1', display_name: 'Test' }))
     }
 
-    // GET /search -- artist search
+    // GET /search - artist search
     if (urlStr.includes('/v1/search')) {
       return new Response(
         JSON.stringify({
@@ -40,7 +40,7 @@ function setupMockResponses() {
       )
     }
 
-    // POST /users/{id}/playlists -- create playlist
+    // POST /users/{id}/playlists - create playlist
     if (urlStr.includes('/playlists') && opts?.method === 'POST' && !urlStr.includes('/tracks')) {
       return new Response(
         JSON.stringify({
@@ -51,7 +51,7 @@ function setupMockResponses() {
       )
     }
 
-    // POST /playlists/{id}/tracks -- add tracks
+    // POST /playlists/{id}/tracks - add tracks
     if (urlStr.includes('/tracks') && opts?.method === 'POST') {
       return new Response(JSON.stringify({ snapshot_id: 'snap-1' }))
     }

--- a/tests/db/queries/artist-metadata.test.ts
+++ b/tests/db/queries/artist-metadata.test.ts
@@ -63,7 +63,7 @@ describe('artist-metadata queries', () => {
 
   it('getCount returns row count', async () => {
     mockDb.where.mockResolvedValue(undefined)
-    // getCount uses select({total: count()}).from(...) -- mock the from chain
+    // getCount uses select({total: count()}).from(...) - mock the from chain
     mockDb.from.mockResolvedValue([{ total: 42 }])
     const result = await getCount(mockDb as never)
     expect(result).toBe(42)

--- a/tests/db/queries/genres.test.ts
+++ b/tests/db/queries/genres.test.ts
@@ -198,7 +198,7 @@ describe('searchGenres', () => {
     }
     const db = { select: vi.fn().mockReturnValue(chain) } as unknown as Database
 
-    // Should not throw -- the escape happens before ilike is called
+    // Should not throw - the escape happens before ilike is called
     await searchGenres(db, '100% _pure_')
     expect(chain.where).toHaveBeenCalledOnce()
   })

--- a/tests/server/routes/health.test.ts
+++ b/tests/server/routes/health.test.ts
@@ -151,7 +151,7 @@ describe('setup guard', () => {
 
   it('allows /api/* through when setup is complete', async () => {
     const app = createApp(makeDeps())
-    // No route registered for this path -- expect 404, not 403
+    // No route registered for this path - expect 404, not 403
     const res = await app.request('/api/something')
     expect(res.status).not.toBe(403)
   })

--- a/tests/server/routes/library.test.ts
+++ b/tests/server/routes/library.test.ts
@@ -537,7 +537,7 @@ describe('GET /api/library/warm/status', () => {
 //
 // These handlers require userId to be set on the context. Rather than fighting
 // the authSkipped+userId gap in the full createApp path, we mount libraryRoutes
-// directly with a tiny middleware that sets userId -- same pattern as jobs.test.ts.
+// directly with a tiny middleware that sets userId - same pattern as jobs.test.ts.
 // ---------------------------------------------------------------------------
 
 import { libraryRoutes } from '@/server/routes/library'

--- a/tests/server/routes/playlists.test.ts
+++ b/tests/server/routes/playlists.test.ts
@@ -71,7 +71,7 @@ function createTestApp(deps: PlaylistDeps, userId: number | undefined) {
   return app
 }
 
-// Mock playlist queries used by the route -- factory must not reference module-level vars (hoisting)
+// Mock playlist queries used by the route - factory must not reference module-level vars (hoisting)
 vi.mock('@/db/queries/playlists', () => ({
   createPlaylist: vi.fn(),
   getPlaylistsByUser: vi.fn(),

--- a/tests/server/routes/recommendations-targets.test.ts
+++ b/tests/server/routes/recommendations-targets.test.ts
@@ -32,7 +32,7 @@ function createTestApp() {
 describe('target-aware approval', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('approves without targets -- sets status to approved', async () => {
+  it('approves without targets - sets status to approved', async () => {
     mockDeps.getRecommendation.mockResolvedValue({
       id: 1,
       artist: { mbid: 'mbid-1', name: 'Radiohead' },
@@ -56,7 +56,7 @@ describe('target-aware approval', () => {
     )
   })
 
-  it('approves with Lidarr target -- adds to Lidarr and sets added_to_lidarr', async () => {
+  it('approves with Lidarr target - adds to Lidarr and sets added_to_lidarr', async () => {
     mockDeps.getRecommendation.mockResolvedValue({
       id: 1,
       artist: { mbid: 'mbid-1', name: 'Radiohead' },
@@ -89,7 +89,7 @@ describe('target-aware approval', () => {
     )
   })
 
-  it('approves with failing Lidarr target -- sets add_failed', async () => {
+  it('approves with failing Lidarr target - sets add_failed', async () => {
     mockDeps.getRecommendation.mockResolvedValue({
       id: 1,
       artist: { mbid: 'mbid-1', name: 'Radiohead' },
@@ -118,7 +118,7 @@ describe('target-aware approval', () => {
     expect(body.status).toBe('add_failed')
   })
 
-  it('approves with createPlaylist-only targets -- sets approved', async () => {
+  it('approves with createPlaylist-only targets - sets approved', async () => {
     mockDeps.getRecommendation.mockResolvedValue({
       id: 1,
       artist: { mbid: 'mbid-1', name: 'Radiohead' },

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -52,7 +52,7 @@ vi.mock('@/core/clients/listenbrainz', () => ({
     getSimilarArtists: vi.fn(async () => []),
     testConnection: vi.fn(async () => ({
       success: true,
-      message: 'Connected to ListenBrainz -- 0 listens for testuser',
+      message: 'Connected to ListenBrainz - 0 listens for testuser',
       details: { listenCount: 0 },
     })),
   })),
@@ -562,7 +562,7 @@ describe('PATCH /api/settings', () => {
 
     // Self-hosted media servers are the user's own box. Private IPs and
     // split-horizon-DNS hostnames that resolve to LAN addresses must be
-    // accepted -- that's the default deployment, not an SSRF target.
+    // accepted - that's the default deployment, not an SSRF target.
     expect(res.status).toBe(200)
     expect(mockUpdateUserConnections).toHaveBeenCalledWith(
       expect.anything(),

--- a/tests/server/routes/subscriptions.test.ts
+++ b/tests/server/routes/subscriptions.test.ts
@@ -212,7 +212,7 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
 // we need a session. Instead we test the 401 paths (no auth) and ownership (403).
 // For ownership tests, we need a way to set userId. We do this by patching
 // the app to bypass auth (getUserCount returns 0) and set userId via a custom middleware.
-// The cleanest approach is to use the existing session mechanism -- but since sessions
+// The cleanest approach is to use the existing session mechanism - but since sessions
 // are in-memory we can't easily inject one in tests. Instead we wrap createApp
 // with a pre-auth middleware that sets userId on the context.
 

--- a/tests/web/components/pipeline-progress.test.tsx
+++ b/tests/web/components/pipeline-progress.test.tsx
@@ -125,7 +125,7 @@ describe('PipelineProgress', () => {
       wrapper: createQueryWrapper(),
     })
 
-    // The component uses setTimeout(onComplete, 500) -- advance timers
+    // The component uses setTimeout(onComplete, 500) - advance timers
     await waitFor(() => {
       expect(screen.getByText('Done')).toBeInTheDocument()
     })

--- a/tests/web/pages/discover.test.tsx
+++ b/tests/web/pages/discover.test.tsx
@@ -231,7 +231,7 @@ describe('DiscoverPage', () => {
       expect(screen.getByText('Test Artist')).toBeInTheDocument()
     })
 
-    // Click the card -- AI reasoning should appear in expanded view
+    // Click the card - AI reasoning should appear in expanded view
     fireEvent.click(screen.getByText('Test Artist'))
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary

Closes #115.

Library sync no longer aborts on transient MusicBrainz failures. Two layers:

- **MB client retries** transient errors (HTTP 5xx, 429, network, timeout) up to 3 times with exponential backoff and jitter. `Retry-After` is honored when present (useful for MB's rate limiter).
- **Reconciler gracefully degrades** on exhausted retries: the affected artist or album is left unreconciled and will retry on the next sync run. A new `mbApiCallsFailed` counter surfaces in the Library Sources UI as an amber warning so the user knows some data was skipped.

Applies to all library sources (Plex, Jellyfin, Emby, Lidarr) since they share the same reconciler. Plex is the worst-case source because its default metadata agent provides no MBIDs, forcing a MB lookup per artist.

Also includes a repo-wide sweep replacing the em-dash substitute `' -- '` with a single `' - '` (296 occurrences across 128 files; scope excludes local/gitignored plans and locale catalogs).

Bumps to v0.27.12.

## Test plan

- [x] `bun run lint` green
- [x] `bun run typecheck` green
- [x] `bun run test` green (including new MB degradation tests for reconciler, album-reconciler, and the MB client retry logic)
- [x] CI passes
- [ ] Manual: trigger a Plex library sync with MB responding 503 (e.g., via mitmproxy) and confirm the sync completes with a warning instead of failing