### PR TITLE
chore(deps): run dependabot daily across all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
     open-pull-requests-limit: 10
     groups:
       production:
@@ -49,9 +48,9 @@ updates:
   - package-ecosystem: docker
     directory: /deploy/docker
     schedule:
-      interval: weekly
+      interval: daily
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily


### PR DESCRIPTION
## Summary
- Flip npm, docker, and github-actions schedules from `weekly` to `daily`
- Drop the `day: monday` pin on npm (moot with daily)

## Why
Moving fast — catch base-image CVE-fix digests and security advisories the day they land instead of batching weekly. Risk: more PR noise; mitigated by existing grouping for npm.

## Test plan
- [ ] Dependabot config parses (validated implicitly on next run)