### PR TITLE
ci(dependabot): auto-regenerate bun.lock on npm PRs

### DIFF
--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -1,0 +1,60 @@
+name: Dependabot bun.lock sync
+
+# Dependabot updates package.json but can't regenerate bun.lock (bun's native
+# lockfile format). This workflow runs bun install on its PRs and pushes the
+# refreshed bun.lock so CI's --frozen-lockfile check passes.
+#
+# Security: pull_request_target runs with write token from the base repo.
+# Guarded to only run on dependabot[bot] PRs from the same repo (never forks).
+# Bun does not execute lifecycle scripts by default, so running `bun install`
+# on PR-supplied package.json is safe without --ignore-scripts.
+#
+# Re-triggering CI: pushing with GITHUB_TOKEN does NOT fire new workflow runs,
+# so auto-merge would stall. Set repo secret DEPENDABOT_SYNC_TOKEN to a
+# fine-grained PAT with "Contents: write" on this repo to retrigger CI on push.
+# Without it, the lockfile still gets updated but you'll need to close/reopen
+# the PR (or push an empty commit) to retrigger checks.
+
+on:
+  pull_request_target:
+    paths:
+      - "package.json"
+
+permissions:
+  contents: read
+
+jobs:
+  sync-lockfile:
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.DEPENDABOT_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.12"
+
+      - name: Regenerate bun.lock
+        run: bun install
+
+      - name: Commit and push if changed
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if git diff --quiet bun.lock; then
+            echo "bun.lock already up to date"
+            exit 0
+          fi
+          git config user.name "iuliandita"
+          git config user.email "iulian.dita@gmail.com"
+          git add bun.lock
+          git commit -m "chore: regenerate bun.lock"
+          git push origin HEAD:"$HEAD_REF"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependabot-bun-lockfile.yml` that runs `bun install` on Dependabot PRs touching `package.json` and pushes the refreshed `bun.lock`.
- Removes the "lockfile had changes but lockfile is frozen" CI failure that every npm bump currently hits.

## Why
Dependabot patches `package.json` using npm semantics; bun's lockfile is its own binary format and needs `bun install` to regenerate. Without this, every npm bump needs manual lockfile regen before it can merge.

## Security
- Uses `pull_request_target` (needed for write token on Dependabot PRs) but guarded by `actor == 'dependabot[bot]'` + `head.repo.full_name == github.repository` — never runs on forks.
- Bun doesn't execute lifecycle scripts by default (no `trustedDependencies` in this repo), so `bun install` on PR-supplied `package.json` is safe.

## Setup required
To make CI retrigger after the lockfile push (and auto-merge actually complete), create a repo secret `DEPENDABOT_SYNC_TOKEN` containing a **fine-grained PAT** with `Contents: write` scoped to this repo. Without it, the workflow still updates the lockfile but you'll need to close/reopen the PR (or push an empty commit) to kick CI.

## Test plan
- [ ] Next Dependabot npm PR automatically gets a `chore: regenerate bun.lock` commit
- [ ] CI turns green after the lockfile update