### PR TITLE
Phase 2: SSRF hardening

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
           cat /tmp/digarr-backend.log || true
           cat /tmp/digarr-frontend.log || true
           exit 1
+        env:
+          DATABASE_URL: postgresql://test:test@postgres:5432/digarr_test
       - name: Run browser E2E tests
         run: |
           PLAYWRIGHT_SKIP_WEBSERVER=1 bun run test:e2e || {

--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           bun run tests/e2e/browser/start-backend.ts > /tmp/digarr-backend.log 2>&1 &
           bun run dev:web > /tmp/digarr-frontend.log 2>&1 &
 
-          for _ in $(seq 1 60); do
+          for _ in $(seq 1 120); do
             if bun -e "const backend = await fetch('http://127.0.0.1:3000/health').catch(() => null); const frontend = await fetch('http://127.0.0.1:5173').catch(() => null); if (backend?.ok && frontend?.ok) process.exit(0); process.exit(1);"; then
               exit 0
             fi

--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
       - name: Install Playwright
         run: bunx playwright install --with-deps chromium
       - name: Run browser E2E tests
-        run: bun run test:e2e
+        run: |
+          bun run test:e2e || {
+            rm -rf test-results playwright-report
+            bun run test:e2e
+          }
         env:
           DATABASE_URL: postgresql://test:test@postgres:5432/digarr_test

--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -91,11 +91,27 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Install Playwright
         run: bunx playwright install --with-deps chromium
+      - name: Start browser test servers
+        run: |
+          bun run tests/e2e/browser/start-backend.ts > /tmp/digarr-backend.log 2>&1 &
+          bun run dev:web > /tmp/digarr-frontend.log 2>&1 &
+
+          for _ in $(seq 1 60); do
+            if bun -e "const backend = await fetch('http://127.0.0.1:3000/health').catch(() => null); const frontend = await fetch('http://127.0.0.1:5173').catch(() => null); if (backend?.ok && frontend?.ok) process.exit(0); process.exit(1);"; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          cat /tmp/digarr-backend.log || true
+          cat /tmp/digarr-frontend.log || true
+          exit 1
       - name: Run browser E2E tests
         run: |
-          bun run test:e2e || {
-            rm -rf test-results playwright-report
-            bun run test:e2e
+          PLAYWRIGHT_SKIP_WEBSERVER=1 bun run test:e2e || {
+            cat /tmp/digarr-backend.log || true
+            cat /tmp/digarr-frontend.log || true
+            exit 1
           }
         env:
           DATABASE_URL: postgresql://test:test@postgres:5432/digarr_test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.28.5",
+  "version": "0.29.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,23 @@
 import { defineConfig } from '@playwright/test'
 
+const webServer =
+  process.env.PLAYWRIGHT_SKIP_WEBSERVER === '1'
+    ? undefined
+    : [
+        {
+          command: 'bun run tests/e2e/browser/start-backend.ts',
+          port: 3000,
+          reuseExistingServer: false,
+          timeout: 30_000,
+        },
+        {
+          command: 'bun run dev:web',
+          port: 5173,
+          reuseExistingServer: false,
+          timeout: 30_000,
+        },
+      ]
+
 export default defineConfig({
   testDir: 'tests/e2e/browser',
   timeout: 30_000,
@@ -10,18 +28,5 @@ export default defineConfig({
     headless: true,
     screenshot: 'only-on-failure',
   },
-  webServer: [
-    {
-      command: 'bun run tests/e2e/browser/start-backend.ts',
-      port: 3000,
-      reuseExistingServer: false,
-      timeout: 30_000,
-    },
-    {
-      command: 'bun run dev:web',
-      port: 5173,
-      reuseExistingServer: false,
-      timeout: 30_000,
-    },
-  ],
+  webServer,
 })

--- a/src/core/auth/oidc.ts
+++ b/src/core/auth/oidc.ts
@@ -2,21 +2,23 @@ import * as dns from 'node:dns/promises'
 import type { Configuration } from 'openid-client'
 import * as oidcClient from 'openid-client'
 import { isPrivateIp } from '@/core/notifications'
-import { errMsg } from '@/core/validation'
+import { errMsg, getLookupHostname } from '@/core/validation'
 
 const ipPinningFetch: oidcClient.CustomFetch = async (url, options) => {
   const parsedUrl = new URL(url)
-  const { address } = await dns.lookup(parsedUrl.hostname)
+  const hostname = getLookupHostname(parsedUrl)
+  const { address } = await dns.lookup(hostname)
   if (isPrivateIp(address)) {
     throw new Error('OIDC issuer resolves to a private/internal IP')
   }
 
   const headers = new Headers(options.headers)
   const init = { ...options, headers } as unknown as RequestInit
-  if (parsedUrl.protocol === 'http:' && address !== parsedUrl.hostname) {
-    const pinnedUrl = url.replace(parsedUrl.hostname, address)
-    headers.set('Host', parsedUrl.hostname)
-    return fetch(pinnedUrl, init)
+  if (parsedUrl.protocol === 'http:' && address !== hostname) {
+    const pinnedUrl = new URL(url)
+    pinnedUrl.hostname = address
+    headers.set('Host', parsedUrl.host)
+    return fetch(pinnedUrl.toString(), init)
   }
 
   return fetch(url, init)

--- a/src/core/clients/http.ts
+++ b/src/core/clients/http.ts
@@ -1,6 +1,9 @@
 import * as dns from 'node:dns/promises'
 import { isPrivateIp, isPrivateUrl } from '@/core/notifications'
 
+const REDACTED_QUERY_VALUE = '[REDACTED]'
+const SENSITIVE_QUERY_KEYS = new Set(['api_key', 'apikey', 'key', 'token', 'secret', 'password'])
+
 type HttpClientConfig = {
   baseUrl: string
   headers?: Record<string, string>
@@ -84,7 +87,7 @@ export function createHttpClient(config: HttpClientConfig) {
       }
     }
 
-    throw new Error(`Request failed after ${retries} retries: ${method} ${url}`)
+    throw new Error(`Request failed after ${retries} retries: ${method} ${redactUrlForLog(url)}`)
   }
 
   async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
@@ -152,11 +155,15 @@ export class HttpError extends Error {
   constructor(
     public status: number,
     public body: string,
-    public url: string,
+    url: string,
   ) {
-    super(`HTTP ${status} from ${url}: ${body}`)
+    const redactedUrl = redactUrlForLog(url)
+    super(`HTTP ${status} from ${redactedUrl}: ${body}`)
     this.name = 'HttpError'
+    this.url = redactedUrl
   }
+
+  public url: string
 }
 
 function sleep(ms: number): Promise<void> {
@@ -166,4 +173,25 @@ function sleep(ms: number): Promise<void> {
 async function readResponseText(res: Response): Promise<string> {
   const text = await res.text()
   return text || '(empty response body)'
+}
+
+export function redactUrlForLog(url: string): string {
+  try {
+    const absolute = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url)
+    const parsed = absolute ? new URL(url) : new URL(url, 'http://redact.invalid')
+    const redactedParams = new URLSearchParams()
+
+    for (const [key, value] of parsed.searchParams.entries()) {
+      redactedParams.append(
+        key,
+        SENSITIVE_QUERY_KEYS.has(key.toLowerCase()) ? REDACTED_QUERY_VALUE : value,
+      )
+    }
+
+    parsed.search = redactedParams.toString()
+    const serialized = parsed.toString()
+    return absolute ? serialized : serialized.replace('http://redact.invalid', '')
+  } catch {
+    return url
+  }
 }

--- a/src/core/clients/http.ts
+++ b/src/core/clients/http.ts
@@ -1,5 +1,6 @@
 import * as dns from 'node:dns/promises'
 import { isPrivateIp, isPrivateUrl } from '@/core/notifications'
+import { getLookupHostname } from '@/core/validation'
 
 const REDACTED_QUERY_VALUE = '[REDACTED]'
 const SENSITIVE_QUERY_KEYS = new Set(['api_key', 'apikey', 'key', 'token', 'secret', 'password'])
@@ -134,14 +135,17 @@ async function prepareRequest(
     }
 
     const parsedUrl = new URL(url)
-    const { address } = await dns.lookup(parsedUrl.hostname)
+    const hostname = getLookupHostname(parsedUrl)
+    const { address } = await dns.lookup(hostname)
     if (isPrivateIp(address)) {
       throw new Error('URL resolves to a private/internal IP')
     }
 
-    if (parsedUrl.protocol === 'http:' && address !== parsedUrl.hostname) {
-      fetchUrl = url.replace(parsedUrl.hostname, address)
-      headers.set('Host', parsedUrl.hostname)
+    if (parsedUrl.protocol === 'http:' && address !== hostname) {
+      const pinnedUrl = new URL(url)
+      pinnedUrl.hostname = address
+      fetchUrl = pinnedUrl.toString()
+      headers.set('Host', parsedUrl.host)
     }
   }
 

--- a/src/core/clients/http.ts
+++ b/src/core/clients/http.ts
@@ -63,7 +63,11 @@ export function createHttpClient(config: HttpClientConfig) {
 
         if (!followRedirects && res.status >= 300 && res.status < 400) {
           const location = res.headers.get('location')
-          throw new HttpError(res.status, `Redirect blocked${location ? `: ${location}` : ''}`, url)
+          throw new HttpError(
+            res.status,
+            `Redirect blocked${location ? `: ${redactUrlForLog(location)}` : ''}`,
+            url,
+          )
         }
 
         const errorBody = await readResponseText(res)

--- a/src/core/clients/http.ts
+++ b/src/core/clients/http.ts
@@ -196,6 +196,31 @@ export function redactUrlForLog(url: string): string {
     const serialized = parsed.toString()
     return absolute ? serialized : serialized.replace('http://redact.invalid', '')
   } catch {
-    return url
+    return redactQueryStringFallback(url)
   }
+}
+
+function redactQueryStringFallback(url: string): string {
+  const queryStart = url.indexOf('?')
+  if (queryStart === -1) return url
+
+  const hashStart = url.indexOf('#', queryStart)
+  const prefix = url.slice(0, queryStart + 1)
+  const query = url.slice(queryStart + 1, hashStart === -1 ? undefined : hashStart)
+  const suffix = hashStart === -1 ? '' : url.slice(hashStart)
+
+  const redactedQuery = query
+    .split('&')
+    .map((part) => {
+      const equalsIndex = part.indexOf('=')
+      if (equalsIndex === -1) return part
+
+      const key = part.slice(0, equalsIndex).toLowerCase()
+      if (!SENSITIVE_QUERY_KEYS.has(key)) return part
+
+      return `${part.slice(0, equalsIndex + 1)}${REDACTED_QUERY_VALUE}`
+    })
+    .join('&')
+
+  return `${prefix}${redactedQuery}${suffix}`
 }

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -76,26 +76,29 @@ export async function sendWebhook(url: string, payload: WebhookPayload): Promise
 
   const safeUrl = url.replace(/:\/\/[^@]*@/, '://***@')
   const body = isDiscordWebhook(url) ? formatDiscordPayload(payload) : payload
+  const fetchHeaders: Record<string, string> = { 'Content-Type': 'application/json' }
+  const fetchUrl = new URL(url)
+  fetchUrl.hostname = resolvedAddress
 
   // Pin the resolved IP to prevent DNS rebinding between check and use.
-  // For HTTPS this only works when the server accepts the IP directly;
-  // most webhook targets (Discord, Slack) use SNI so we keep the original URL
-  // for https:// and only pin for http://.
-  const fetchUrl =
-    parsedUrl.protocol === 'http:' ? url.replace(parsedUrl.hostname, resolvedAddress) : url
-  const fetchHeaders: Record<string, string> = { 'Content-Type': 'application/json' }
-  if (parsedUrl.protocol === 'http:' && resolvedAddress !== parsedUrl.hostname) {
-    fetchHeaders.Host = parsedUrl.hostname
+  // HTTPS keeps the original hostname for SNI while connecting to the pinned IP.
+  if (resolvedAddress !== parsedUrl.hostname || parsedUrl.protocol === 'https:') {
+    fetchHeaders.Host = parsedUrl.host
+  }
+
+  const fetchInit: RequestInit & { tls?: { serverName: string } } = {
+    method: 'POST',
+    headers: fetchHeaders,
+    body: JSON.stringify(body),
+    signal: controller.signal,
+    redirect: 'manual',
+  }
+  if (parsedUrl.protocol === 'https:') {
+    fetchInit.tls = { serverName: parsedUrl.hostname }
   }
 
   try {
-    const res = await fetch(fetchUrl, {
-      method: 'POST',
-      headers: fetchHeaders,
-      body: JSON.stringify(body),
-      signal: controller.signal,
-      redirect: 'manual',
-    })
+    const res = await fetch(fetchUrl.toString(), fetchInit)
     if (!res.ok) {
       console.error(`Webhook POST to ${safeUrl} failed: HTTP ${res.status}`)
     }

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -1,4 +1,5 @@
 import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
 import { isHttpUrl, isPrivateIp, isPrivateUrl } from './validation'
 
 export { isPrivateIp, isPrivateUrl }
@@ -93,7 +94,7 @@ export async function sendWebhook(url: string, payload: WebhookPayload): Promise
     signal: controller.signal,
     redirect: 'manual',
   }
-  if (parsedUrl.protocol === 'https:') {
+  if (parsedUrl.protocol === 'https:' && !isIpLiteral(parsedUrl.hostname)) {
     fetchInit.tls = { serverName: parsedUrl.hostname }
   }
 
@@ -107,4 +108,8 @@ export async function sendWebhook(url: string, payload: WebhookPayload): Promise
   } finally {
     clearTimeout(timeout)
   }
+}
+
+function isIpLiteral(hostname: string): boolean {
+  return isIP(hostname) !== 0
 }

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -1,6 +1,6 @@
 import { lookup } from 'node:dns/promises'
 import { isIP } from 'node:net'
-import { isHttpUrl, isPrivateIp, isPrivateUrl, normalizeIp } from './validation'
+import { getLookupHostname, isHttpUrl, isPrivateIp, isPrivateUrl, normalizeIp } from './validation'
 
 export { isPrivateIp, isPrivateUrl }
 
@@ -61,7 +61,7 @@ export async function sendWebhook(url: string, payload: WebhookPayload): Promise
   let parsedUrl: URL
   try {
     parsedUrl = new URL(url)
-    const { address } = await lookup(parsedUrl.hostname)
+    const { address } = await lookup(getLookupHostname(parsedUrl))
     if (isPrivateIp(address)) {
       console.error('Webhook URL resolves to a private/internal IP address')
       return

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -1,6 +1,6 @@
 import { lookup } from 'node:dns/promises'
 import { isIP } from 'node:net'
-import { isHttpUrl, isPrivateIp, isPrivateUrl } from './validation'
+import { isHttpUrl, isPrivateIp, isPrivateUrl, normalizeIp } from './validation'
 
 export { isPrivateIp, isPrivateUrl }
 
@@ -94,8 +94,9 @@ export async function sendWebhook(url: string, payload: WebhookPayload): Promise
     signal: controller.signal,
     redirect: 'manual',
   }
-  if (parsedUrl.protocol === 'https:' && !isIpLiteral(parsedUrl.hostname)) {
-    fetchInit.tls = { serverName: parsedUrl.hostname }
+  const normalizedHostname = normalizeIp(parsedUrl.hostname)
+  if (parsedUrl.protocol === 'https:' && !isIpLiteral(normalizedHostname)) {
+    fetchInit.tls = { serverName: normalizedHostname }
   }
 
   try {

--- a/src/core/url-safety.ts
+++ b/src/core/url-safety.ts
@@ -1,5 +1,11 @@
 import { lookup } from 'node:dns/promises'
-import { isCloudMetadata, isHttpUrl, isPrivateIp, isPrivateUrl } from '@/core/validation'
+import {
+  getLookupHostname,
+  isCloudMetadata,
+  isHttpUrl,
+  isPrivateIp,
+  isPrivateUrl,
+} from '@/core/validation'
 
 export type UrlValidation = { ok: true } | { ok: false; message: string }
 
@@ -15,7 +21,7 @@ export async function validatePublicServiceUrl(url: string, label: string): Prom
   }
 
   try {
-    const { address } = await lookup(new URL(url).hostname)
+    const { address } = await lookup(getLookupHostname(url))
     if (isPrivateIp(address)) {
       return { ok: false, message: `${label} resolves to a private/internal IP` }
     }

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -35,6 +35,11 @@ export function normalizeIp(address: string): string {
   return mapped
 }
 
+export function getLookupHostname(input: string | URL): string {
+  const url = typeof input === 'string' ? new URL(input) : input
+  return normalizeIp(url.hostname)
+}
+
 function parseIpv4(address: string): number | null {
   const parts = address.split('.')
   if (parts.length !== 4) return null
@@ -164,8 +169,7 @@ export function isPrivateIp(address: string): boolean {
 
 export function isPrivateUrl(urlString: string): boolean {
   try {
-    const url = new URL(urlString)
-    const hostname = normalizeIp(url.hostname)
+    const hostname = getLookupHostname(urlString)
     if (isPrivateIp(hostname)) return true
     if (hostname === 'localhost') return true
     return false

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -158,17 +158,6 @@ export function isPrivateIp(address: string): boolean {
   if (group1 >= 0xfc00 && group1 <= 0xfdff) return true
   if (group1 >= 0xfe80 && group1 <= 0xfebf) return true
   if (group1 >= 0xff00 && group1 <= 0xffff) return true
-  if (
-    group1 === 0x0064 &&
-    group2 === 0xff9b &&
-    group3 === 0 &&
-    group4 === 0 &&
-    group5 === 0 &&
-    group6 === 0
-  ) {
-    return true
-  }
-  if (group1 === 0x2001 && group2 === 0x0000) return true
   if (group1 === 0x2001 && group2 === 0x0db8) return true
   return false
 }

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -35,18 +35,119 @@ export function normalizeIp(address: string): string {
   return mapped
 }
 
+function parseIpv4(address: string): number | null {
+  const parts = address.split('.')
+  if (parts.length !== 4) return null
+
+  let value = 0
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null
+    const octet = Number.parseInt(part, 10)
+    if (octet < 0 || octet > 255) return null
+    value = (value << 8) | octet
+  }
+
+  return value >>> 0
+}
+
+function parseIpv6(address: string): number[] | null {
+  if (!address.includes(':')) return null
+
+  const halves = address.split('::')
+  if (halves.length > 2) return null
+
+  const parseHalf = (half: string): number[] | null => {
+    if (half === '') return []
+    const groups = half.split(':')
+    const parsed: number[] = []
+    for (const group of groups) {
+      if (!/^[0-9a-f]{1,4}$/i.test(group)) return null
+      parsed.push(Number.parseInt(group, 16))
+    }
+    return parsed
+  }
+
+  const left = parseHalf(halves[0] ?? '')
+  if (left === null) return null
+
+  if (halves.length === 1) {
+    return left.length === 8 ? left : null
+  }
+
+  const right = parseHalf(halves[1] ?? '')
+  if (right === null) return null
+
+  if (left.length + right.length > 8) return null
+  return [...left, ...Array(8 - left.length - right.length).fill(0), ...right]
+}
+
 export function isPrivateIp(address: string): boolean {
   const normalized = normalizeIp(address)
-  if (/^127\./.test(normalized)) return true
-  if (/^10\./.test(normalized)) return true
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(normalized)) return true
-  if (/^192\.168\./.test(normalized)) return true
-  if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(normalized)) return true
-  if (/^169\.254\./.test(normalized)) return true
-  if (normalized === '0.0.0.0') return true
-  if (normalized === '::1') return true
-  if (/^f[cd]/i.test(normalized)) return true
-  if (/^fe80/i.test(normalized)) return true
+  const ipv4 = parseIpv4(normalized)
+  if (ipv4 !== null) {
+    const octet1 = (ipv4 >>> 24) & 0xff
+    const octet2 = (ipv4 >>> 16) & 0xff
+    const octet3 = (ipv4 >>> 8) & 0xff
+
+    if (octet1 === 0) return true
+    if (octet1 === 10) return true
+    if (octet1 === 127) return true
+    if (octet1 === 100 && octet2 >= 64 && octet2 <= 127) return true
+    if (octet1 === 169 && octet2 === 254) return true
+    if (octet1 === 172 && octet2 >= 16 && octet2 <= 31) return true
+    if (octet1 === 192 && octet2 === 168) return true
+    if (octet1 === 192 && octet2 === 0 && octet3 === 2) return true
+    if (octet1 === 198 && octet2 === 18) return true
+    if (octet1 === 198 && octet2 === 19) return true
+    if (octet1 === 198 && octet2 === 51 && octet3 === 100) return true
+    if (octet1 === 203 && octet2 === 0 && octet3 === 113) return true
+    if (octet1 >= 224) return true
+    return false
+  }
+
+  const ipv6 = parseIpv6(normalized)
+  if (ipv6 === null) return false
+
+  const [group1 = 0, group2 = 0, group3 = 0, group4 = 0, group5 = 0, group6 = 0, group7 = 0, group8 = 0] = ipv6
+  if (
+    group1 === 0 &&
+    group2 === 0 &&
+    group3 === 0 &&
+    group4 === 0 &&
+    group5 === 0 &&
+    group6 === 0 &&
+    group7 === 0 &&
+    group8 === 0
+  ) {
+    return true
+  }
+  if (
+    group1 === 0 &&
+    group2 === 0 &&
+    group3 === 0 &&
+    group4 === 0 &&
+    group5 === 0 &&
+    group6 === 0 &&
+    group7 === 0 &&
+    group8 === 1
+  ) {
+    return true
+  }
+  if (group1 >= 0xfc00 && group1 <= 0xfdff) return true
+  if (group1 >= 0xfe80 && group1 <= 0xfebf) return true
+  if (group1 >= 0xff00 && group1 <= 0xffff) return true
+  if (
+    group1 === 0x0064 &&
+    group2 === 0xff9b &&
+    group3 === 0 &&
+    group4 === 0 &&
+    group5 === 0 &&
+    group6 === 0
+  ) {
+    return true
+  }
+  if (group1 === 0x2001 && group2 === 0x0000) return true
+  if (group1 === 0x2001 && group2 === 0x0db8) return true
   return false
 }
 

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -53,6 +53,19 @@ function parseIpv4(address: string): number | null {
 function parseIpv6(address: string): number[] | null {
   if (!address.includes(':')) return null
 
+  if (address.includes('.')) {
+    const lastColon = address.lastIndexOf(':')
+    if (lastColon === -1) return null
+
+    const ipv4Tail = address.slice(lastColon + 1)
+    const ipv4 = parseIpv4(ipv4Tail)
+    if (ipv4 === null) return null
+
+    const high = (ipv4 >>> 16) & 0xffff
+    const low = ipv4 & 0xffff
+    address = `${address.slice(0, lastColon + 1)}${high.toString(16)}:${low.toString(16)}`
+  }
+
   const halves = address.split('::')
   if (halves.length > 2) return null
 
@@ -108,7 +121,16 @@ export function isPrivateIp(address: string): boolean {
   const ipv6 = parseIpv6(normalized)
   if (ipv6 === null) return false
 
-  const [group1 = 0, group2 = 0, group3 = 0, group4 = 0, group5 = 0, group6 = 0, group7 = 0, group8 = 0] = ipv6
+  const [
+    group1 = 0,
+    group2 = 0,
+    group3 = 0,
+    group4 = 0,
+    group5 = 0,
+    group6 = 0,
+    group7 = 0,
+    group8 = 0,
+  ] = ipv6
   if (
     group1 === 0 &&
     group2 === 0 &&

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -8,7 +8,7 @@ import { normalizeLocale } from '@/core/i18n/locales'
 import { getMessages } from '@/core/i18n/messages'
 import { isPrivateIp, isPrivateUrl } from '@/core/notifications'
 import { clearUserSessions, createSession, deleteSession } from '@/core/sessions'
-import { isHttpUrl } from '@/core/validation'
+import { getLookupHostname, isHttpUrl } from '@/core/validation'
 import { updateUserPreferences } from '@/db/queries/users'
 import { mergePreferences, type Preferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
@@ -273,7 +273,7 @@ export function authRoutes(deps: AppDependencies) {
         return c.json({ error: 'Metadata fallback URL must not point to a private address' }, 400)
       }
       try {
-        const hostname = new URL(fallbackUrl).hostname
+        const hostname = getLookupHostname(fallbackUrl)
         const { address } = await lookup(hostname)
         if (isPrivateIp(address)) {
           return c.json({ error: 'Metadata fallback URL resolves to a private/internal IP' }, 400)

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -3,7 +3,6 @@ import { createLastFmClient } from '@/core/clients/lastfm'
 import { createLidarrClient } from '@/core/clients/lidarr'
 import { createListenBrainzClient } from '@/core/clients/listenbrainz'
 import { sendWebhook } from '@/core/notifications'
-import { validatePublicServiceUrl } from '@/core/url-safety'
 import { errMsg } from '@/core/validation'
 import { getUserConnections, updateUserConnections } from '@/db/queries/users'
 import type { Preferences } from '@/db/schema'
@@ -435,12 +434,6 @@ export function settingsRoutes(deps: AppDependencies) {
         const issuerUrl = body.issuerUrl || (stored?.oidcIssuerUrl as string) || ''
         const clientId = body.clientId || (stored?.oidcClientId as string) || ''
         const clientSecret = body.clientSecret || (stored?.oidcClientSecret as string) || ''
-        if (issuerUrl) {
-          const validation = await validatePublicServiceUrl(issuerUrl, 'OIDC issuer URL')
-          if (!validation.ok) {
-            return c.json({ success: false, message: validation.message }, 400)
-          }
-        }
         if (!issuerUrl || !clientId) {
           return c.json({ success: false, message: 'Issuer URL and Client ID are required' })
         }

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -57,6 +57,11 @@ function mergePreferenceUpdate(
   return merged
 }
 
+function sanitizeServiceTestResult(result: { success: boolean; message: string }) {
+  if (result.success) return result
+  return { success: false, message: 'Connection test failed' }
+}
+
 /** Strip global connection fields that should not leak to non-admin users. */
 function stripForNonAdmin(settings: Record<string, unknown>): SettingsResponse {
   const stripped: SettingsResponse = {}
@@ -284,21 +289,18 @@ export function settingsRoutes(deps: AppDependencies) {
       acceptLanguage: c.req.header('Accept-Language'),
     })
     const service = c.req.param('service')
+    const isAdmin = await resolveAdmin(
+      c.get('userId'),
+      deps.getUserById,
+      c.get('authSkipped'),
+      c.get('legacyTokenAuth'),
+    )
+    if (!isAdmin) {
+      return c.json({ success: false, message: messages['common.adminAccessRequired'] }, 403)
+    }
+
     const body = await c.req.json()
     const testUserId = c.get('userId')
-
-    // Admin-only services: lidarr, ai, oidc - only enforced when user sessions are active
-    if (testUserId && (service === 'lidarr' || service === 'ai' || service === 'oidc')) {
-      const isAdmin = await resolveAdmin(
-        testUserId,
-        deps.getUserById,
-        c.get('authSkipped'),
-        c.get('legacyTokenAuth'),
-      )
-      if (!isAdmin) {
-        return c.json({ success: false, message: messages['common.adminAccessRequired'] }, 403)
-      }
-    }
 
     // Fall back to stored credentials when the request sends empty keys
     const stored = await deps.getSettings()
@@ -313,7 +315,7 @@ export function settingsRoutes(deps: AppDependencies) {
         }
         const client = createLidarrClient(url, apiKey, body.skipTlsVerify)
         const result = await client.testConnection()
-        return c.json(result)
+        return c.json(sanitizeServiceTestResult(result))
       }
       case 'listenbrainz': {
         const username = body.username || userConns?.listenbrainzUsername || ''
@@ -327,7 +329,7 @@ export function settingsRoutes(deps: AppDependencies) {
           result.message +=
             ' (warning: no API token set - listening data, subscriptions, and recommendations will not work without it)'
         }
-        return c.json(result)
+        return c.json(sanitizeServiceTestResult(result))
       }
       case 'lastfm': {
         const username = body.username || userConns?.lastfmUsername || ''
@@ -340,7 +342,7 @@ export function settingsRoutes(deps: AppDependencies) {
         }
         const client = createLastFmClient(username, apiKey)
         const result = await client.testConnection()
-        return c.json(result)
+        return c.json(sanitizeServiceTestResult(result))
       }
       case 'ai': {
         try {
@@ -354,9 +356,9 @@ export function settingsRoutes(deps: AppDependencies) {
             },
           )
           const result = await provider.testConnection()
-          return c.json(result)
-        } catch (err: unknown) {
-          return c.json({ success: false, message: errMsg(err) })
+          return c.json(sanitizeServiceTestResult(result))
+        } catch (_err: unknown) {
+          return c.json({ success: false, message: 'Connection test failed' })
         }
       }
       case 'plex': {
@@ -368,7 +370,7 @@ export function settingsRoutes(deps: AppDependencies) {
         const { createPlexClient } = await import('@/core/clients/plex')
         const client = createPlexClient(url, token)
         const result = await client.testConnection()
-        return c.json(result)
+        return c.json(sanitizeServiceTestResult(result))
       }
       case 'jellyfin': {
         const url = body.url || userConns?.jellyfinUrl || ''
@@ -384,7 +386,7 @@ export function settingsRoutes(deps: AppDependencies) {
         if (result.success && !jfUserId) {
           result.message += ' (warning: no user ID set - listening data will not work without it)'
         }
-        return c.json(result)
+        return c.json(sanitizeServiceTestResult(result))
       }
       case 'emby': {
         const url = body.url || userConns?.embyUrl || ''
@@ -400,7 +402,7 @@ export function settingsRoutes(deps: AppDependencies) {
         if (result.success && !embyUserId) {
           result.message += ' (warning: no user ID set - listening data will not work without it)'
         }
-        return c.json(result)
+        return c.json(sanitizeServiceTestResult(result))
       }
       case 'discogs': {
         const token = body.token || userConns?.discogsToken || ''
@@ -414,7 +416,7 @@ export function settingsRoutes(deps: AppDependencies) {
         const { createDiscogsClient } = await import('@/core/clients/discogs')
         const client = createDiscogsClient(token, username)
         const result = await client.testConnection()
-        return c.json(result)
+        return c.json(sanitizeServiceTestResult(result))
       }
       case 'spotify': {
         const spotifyUserId = c.get('userId')
@@ -427,7 +429,7 @@ export function settingsRoutes(deps: AppDependencies) {
         const { createSpotifyClient } = await import('@/core/clients/spotify')
         const client = createSpotifyClient(oauthToken.accessToken)
         const result = await client.testConnection()
-        return c.json(result)
+        return c.json(sanitizeServiceTestResult(result))
       }
       case 'oidc': {
         const issuerUrl = body.issuerUrl || (stored?.oidcIssuerUrl as string) || ''
@@ -449,7 +451,7 @@ export function settingsRoutes(deps: AppDependencies) {
           clientSecret: clientSecret || undefined,
           scopes: 'openid',
         })
-        return c.json(await svc.testConnection())
+        return c.json(sanitizeServiceTestResult(await svc.testConnection()))
       }
       default:
         return c.json({ error: `Unknown service: ${service}` }, 400)

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -56,9 +56,12 @@ function mergePreferenceUpdate(
   return merged
 }
 
-function sanitizeServiceTestResult(result: { success: boolean; message: string }) {
+function sanitizeServiceTestResult(
+  result: { success: boolean; message: string },
+  fallbackMessage: string,
+) {
   if (result.success) return result
-  return { success: false, message: 'Connection test failed' }
+  return { success: false, message: fallbackMessage }
 }
 
 /** Strip global connection fields that should not leak to non-admin users. */
@@ -314,7 +317,7 @@ export function settingsRoutes(deps: AppDependencies) {
         }
         const client = createLidarrClient(url, apiKey, body.skipTlsVerify)
         const result = await client.testConnection()
-        return c.json(sanitizeServiceTestResult(result))
+        return c.json(sanitizeServiceTestResult(result, messages['common.unknownError']))
       }
       case 'listenbrainz': {
         const username = body.username || userConns?.listenbrainzUsername || ''
@@ -328,7 +331,7 @@ export function settingsRoutes(deps: AppDependencies) {
           result.message +=
             ' (warning: no API token set - listening data, subscriptions, and recommendations will not work without it)'
         }
-        return c.json(sanitizeServiceTestResult(result))
+        return c.json(sanitizeServiceTestResult(result, messages['common.unknownError']))
       }
       case 'lastfm': {
         const username = body.username || userConns?.lastfmUsername || ''
@@ -341,7 +344,7 @@ export function settingsRoutes(deps: AppDependencies) {
         }
         const client = createLastFmClient(username, apiKey)
         const result = await client.testConnection()
-        return c.json(sanitizeServiceTestResult(result))
+        return c.json(sanitizeServiceTestResult(result, messages['common.unknownError']))
       }
       case 'ai': {
         try {
@@ -355,9 +358,9 @@ export function settingsRoutes(deps: AppDependencies) {
             },
           )
           const result = await provider.testConnection()
-          return c.json(sanitizeServiceTestResult(result))
+          return c.json(sanitizeServiceTestResult(result, messages['common.unknownError']))
         } catch (_err: unknown) {
-          return c.json({ success: false, message: 'Connection test failed' })
+          return c.json({ success: false, message: messages['common.unknownError'] })
         }
       }
       case 'plex': {
@@ -369,7 +372,7 @@ export function settingsRoutes(deps: AppDependencies) {
         const { createPlexClient } = await import('@/core/clients/plex')
         const client = createPlexClient(url, token)
         const result = await client.testConnection()
-        return c.json(sanitizeServiceTestResult(result))
+        return c.json(sanitizeServiceTestResult(result, messages['common.unknownError']))
       }
       case 'jellyfin': {
         const url = body.url || userConns?.jellyfinUrl || ''
@@ -385,7 +388,7 @@ export function settingsRoutes(deps: AppDependencies) {
         if (result.success && !jfUserId) {
           result.message += ' (warning: no user ID set - listening data will not work without it)'
         }
-        return c.json(sanitizeServiceTestResult(result))
+        return c.json(sanitizeServiceTestResult(result, messages['common.unknownError']))
       }
       case 'emby': {
         const url = body.url || userConns?.embyUrl || ''
@@ -401,7 +404,7 @@ export function settingsRoutes(deps: AppDependencies) {
         if (result.success && !embyUserId) {
           result.message += ' (warning: no user ID set - listening data will not work without it)'
         }
-        return c.json(sanitizeServiceTestResult(result))
+        return c.json(sanitizeServiceTestResult(result, messages['common.unknownError']))
       }
       case 'discogs': {
         const token = body.token || userConns?.discogsToken || ''
@@ -415,7 +418,7 @@ export function settingsRoutes(deps: AppDependencies) {
         const { createDiscogsClient } = await import('@/core/clients/discogs')
         const client = createDiscogsClient(token, username)
         const result = await client.testConnection()
-        return c.json(sanitizeServiceTestResult(result))
+        return c.json(sanitizeServiceTestResult(result, messages['common.unknownError']))
       }
       case 'spotify': {
         const spotifyUserId = c.get('userId')
@@ -428,7 +431,7 @@ export function settingsRoutes(deps: AppDependencies) {
         const { createSpotifyClient } = await import('@/core/clients/spotify')
         const client = createSpotifyClient(oauthToken.accessToken)
         const result = await client.testConnection()
-        return c.json(sanitizeServiceTestResult(result))
+        return c.json(sanitizeServiceTestResult(result, messages['common.unknownError']))
       }
       case 'oidc': {
         const issuerUrl = body.issuerUrl || (stored?.oidcIssuerUrl as string) || ''
@@ -444,7 +447,9 @@ export function settingsRoutes(deps: AppDependencies) {
           clientSecret: clientSecret || undefined,
           scopes: 'openid',
         })
-        return c.json(sanitizeServiceTestResult(await svc.testConnection()))
+        return c.json(
+          sanitizeServiceTestResult(await svc.testConnection(), messages['common.unknownError']),
+        )
       }
       default:
         return c.json({ error: `Unknown service: ${service}` }, 400)

--- a/src/server/schemas/admin.ts
+++ b/src/server/schemas/admin.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 // Backup data table rows are shape-heterogeneous (22 tables, mixed schemas),
 // so each table is typed as an array of records. restoreBackup is the

--- a/src/server/schemas/auth.ts
+++ b/src/server/schemas/auth.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 export const usernameSchema = z
   .string()

--- a/src/server/schemas/jobs.ts
+++ b/src/server/schemas/jobs.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 export const jobTypeSchema = z.enum([
   'pipeline',

--- a/src/server/schemas/oauth.ts
+++ b/src/server/schemas/oauth.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 // Initiate body is optional overall (Deezer branch reads env config only),
 // but if any field is set for the Spotify branch, all three must be strings.

--- a/src/server/schemas/pipeline.ts
+++ b/src/server/schemas/pipeline.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 // normalizeDiscoveryModeRequest is the authoritative parser for the body
 // shape; schema here catches gross mismatches (wrong types on the top-level

--- a/src/server/schemas/playlists.ts
+++ b/src/server/schemas/playlists.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 import { cronSchema } from './subscriptions'
 
 export const playlistStrategySchema = z.enum([

--- a/src/server/schemas/recommendations.ts
+++ b/src/server/schemas/recommendations.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 // MAX_BULK_IDS caps the bulk write surface so one approve-all payload cannot
 // starve the worker. 500 matches the Spotify CSV import truncation ceiling.

--- a/src/server/schemas/settings.ts
+++ b/src/server/schemas/settings.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 // Inner preferences object. Enforces numeric ranges where they exist and
 // keeps other fields permissive enough that partial merges (the normal PATCH

--- a/src/server/schemas/setup.ts
+++ b/src/server/schemas/setup.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 
 // Setup wizard accepts a bunch of fields, most optional, with
 // conditional-require rules enforced in the handler (e.g., lidarrApiKey

--- a/src/server/schemas/subscriptions.ts
+++ b/src/server/schemas/subscriptions.ts
@@ -1,5 +1,5 @@
 import { Cron } from 'croner'
-import { z } from 'zod'
+import * as z from 'zod'
 
 // Cron string: any expression croner can parse. Validate by construction
 // attempt so the error surfaces at the schema boundary instead of later.

--- a/src/server/schemas/targets.ts
+++ b/src/server/schemas/targets.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 import { TARGET_TYPES } from '@/core/targets/types'
 
 // URL must be http(s). Private-IP / SSRF checks live in handlers and

--- a/src/server/schemas/users.ts
+++ b/src/server/schemas/users.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 import { passwordSchema, usernameSchema } from './auth'
 
 export const createUserSchema = z.object({

--- a/src/server/schemas/validator.ts
+++ b/src/server/schemas/validator.ts
@@ -1,5 +1,5 @@
 import { zValidator as zv } from '@hono/zod-validator'
-import type { z } from 'zod'
+import type * as z from 'zod'
 
 // Consistent 400 response shape for every Zod-validated route. Clients key on
 // `error` (stable machine code) and render per-field hints from `details`.

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -261,6 +261,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
   const queryClient = useQueryClient()
   const aiProviderLabel = t('settings.aiProviderTitle')
   const webhookLabel = t('settings.webhookTitle')
+  const canTestUserConnections = isAdmin
 
   function formatLabelMessage(key: MessageKey, label: string) {
     return t(key).replace('{0}', label)
@@ -872,16 +873,18 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
             </Field>
           </div>
           <div className="flex justify-end gap-2 pt-1">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={testListenbrainz}
-              disabled={tests.listenbrainz === 'testing'}
-            >
-              {tests.listenbrainz === 'testing'
-                ? t('settings.testing')
-                : t('settings.testConnection')}
-            </Button>
+            {canTestUserConnections && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={testListenbrainz}
+                disabled={tests.listenbrainz === 'testing'}
+              >
+                {tests.listenbrainz === 'testing'
+                  ? t('settings.testing')
+                  : t('settings.testConnection')}
+              </Button>
+            )}
             <Button size="sm" onClick={saveListenbrainz} disabled={saving.listenbrainz}>
               {saving.listenbrainz
                 ? t('settings.saving')
@@ -940,14 +943,16 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
             </Field>
           </div>
           <div className="flex justify-end gap-2 pt-1">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={testLastfm}
-              disabled={tests.lastfm === 'testing'}
-            >
-              {tests.lastfm === 'testing' ? t('settings.testing') : t('settings.testConnection')}
-            </Button>
+            {canTestUserConnections && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={testLastfm}
+                disabled={tests.lastfm === 'testing'}
+              >
+                {tests.lastfm === 'testing' ? t('settings.testing') : t('settings.testConnection')}
+              </Button>
+            )}
             <Button size="sm" onClick={saveLastfm} disabled={saving.lastfm}>
               {saving.lastfm
                 ? t('settings.saving')
@@ -1184,14 +1189,16 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
             </Field>
           </div>
           <div className="flex justify-end gap-2 pt-1">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={testPlex}
-              disabled={tests.plex === 'testing'}
-            >
-              {tests.plex === 'testing' ? t('settings.testing') : t('settings.testConnection')}
-            </Button>
+            {canTestUserConnections && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={testPlex}
+                disabled={tests.plex === 'testing'}
+              >
+                {tests.plex === 'testing' ? t('settings.testing') : t('settings.testConnection')}
+              </Button>
+            )}
             <Button size="sm" onClick={savePlex} disabled={saving.plex}>
               {saving.plex
                 ? t('settings.saving')
@@ -1245,14 +1252,18 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
             <p className="text-xs text-muted mt-1">{t('settings.jellyfinUserIdHelp')}</p>
           </Field>
           <div className="flex justify-end gap-2 pt-1">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={testJellyfin}
-              disabled={tests.jellyfin === 'testing'}
-            >
-              {tests.jellyfin === 'testing' ? t('settings.testing') : t('settings.testConnection')}
-            </Button>
+            {canTestUserConnections && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={testJellyfin}
+                disabled={tests.jellyfin === 'testing'}
+              >
+                {tests.jellyfin === 'testing'
+                  ? t('settings.testing')
+                  : t('settings.testConnection')}
+              </Button>
+            )}
             <Button size="sm" onClick={saveJellyfin} disabled={saving.jellyfin}>
               {saving.jellyfin
                 ? t('settings.saving')
@@ -1306,14 +1317,16 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
             <p className="text-xs text-muted mt-1">{t('settings.embyUserIdHelp')}</p>
           </Field>
           <div className="flex justify-end gap-2 pt-1">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={testEmby}
-              disabled={tests.emby === 'testing'}
-            >
-              {tests.emby === 'testing' ? t('settings.testing') : t('settings.testConnection')}
-            </Button>
+            {canTestUserConnections && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={testEmby}
+                disabled={tests.emby === 'testing'}
+              >
+                {tests.emby === 'testing' ? t('settings.testing') : t('settings.testConnection')}
+              </Button>
+            )}
             <Button size="sm" onClick={saveEmby} disabled={saving.emby}>
               {saving.emby
                 ? t('settings.saving')
@@ -1369,14 +1382,16 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
             </Field>
           </div>
           <div className="flex justify-end gap-2 pt-1">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={testDiscogs}
-              disabled={tests.discogs === 'testing'}
-            >
-              {tests.discogs === 'testing' ? t('settings.testing') : t('settings.testConnection')}
-            </Button>
+            {canTestUserConnections && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={testDiscogs}
+                disabled={tests.discogs === 'testing'}
+              >
+                {tests.discogs === 'testing' ? t('settings.testing') : t('settings.testConnection')}
+              </Button>
+            )}
             <Button size="sm" onClick={saveDiscogs} disabled={saving.discogs}>
               {saving.discogs
                 ? t('settings.saving')

--- a/tests/core/auth/oidc.test.ts
+++ b/tests/core/auth/oidc.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('node:dns/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:dns/promises')>()
+  return {
+    ...actual,
+    lookup: vi.fn(),
+  }
+})
+
 vi.mock('openid-client', () => ({
   customFetch: Symbol.for('openid-client-custom-fetch'),
   discovery: vi.fn(),
@@ -11,6 +19,7 @@ vi.mock('openid-client', () => ({
   calculatePKCECodeChallenge: vi.fn(async () => 'mock-code-challenge'),
 }))
 
+import * as dns from 'node:dns/promises'
 import * as oidcClient from 'openid-client'
 import { OidcService } from '@/core/auth/oidc'
 
@@ -82,6 +91,37 @@ describe('OidcService', () => {
       await expect(service.getAuthorizationUrl('http://localhost:3000/cb')).rejects.toThrow(
         'Network error',
       )
+    })
+
+    it('normalizes bracketed IPv6 issuer URLs before custom DNS lookup', async () => {
+      const ipv6Url = 'https://[2001:4860:4860::8888]/.well-known/openid-configuration'
+      const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+      vi.mocked(oidcClient.discovery).mockResolvedValue({} as never)
+      vi.mocked(oidcClient.buildAuthorizationUrl).mockReturnValue(
+        new URL('https://auth.example.com/authorize?state=mock-state'),
+      )
+      vi.mocked(dns.lookup).mockResolvedValue({
+        address: '2001:4860:4860::8888',
+        family: 6,
+      } as never)
+
+      await service.getAuthorizationUrl('http://localhost:3000/cb')
+
+      const discoveryCall = vi.mocked(oidcClient.discovery).mock.calls[0]
+      const options = discoveryCall?.[4]
+      const customFetch = options?.[oidcClient.customFetch] as
+        | ((url: string, init: RequestInit) => Promise<Response>)
+        | undefined
+
+      expect(customFetch).toBeDefined()
+
+      await customFetch?.(ipv6Url, { headers: {} })
+
+      expect(dns.lookup).toHaveBeenCalledWith('2001:4860:4860::8888')
+      expect(fetchMock).toHaveBeenCalledWith(ipv6Url, expect.any(Object))
+
+      vi.unstubAllGlobals()
     })
 
     it('resetDiscovery forces re-fetch on next call', async () => {

--- a/tests/core/lastfm-redaction.test.ts
+++ b/tests/core/lastfm-redaction.test.ts
@@ -8,6 +8,17 @@ let baseUrl: string
 
 beforeAll(async () => {
   server = http.createServer((_req, res) => {
+    const rawUrl = _req.url ?? '/'
+    const parsed = new URL(rawUrl, 'http://localhost')
+    if (parsed.pathname === '/redirect') {
+      res.writeHead(302, {
+        Location:
+          'https://ws.audioscrobbler.com/2.0/?method=user.getTopArtists&api_key=secret&user=test',
+      })
+      res.end()
+      return
+    }
+
     res.writeHead(404, { 'Content-Type': 'text/plain' })
     res.end('not found')
   })
@@ -69,6 +80,22 @@ describe('query redaction', () => {
       expect(error.message).not.toContain('password=sixth')
       expect(error.url).toContain('artist=Radiohead')
       expect(error.url).not.toContain('api_key=secret')
+    }
+  })
+
+  it('redacts sensitive query params from blocked redirect errors', async () => {
+    const client = createHttpClient({ baseUrl })
+
+    try {
+      await client.get('/redirect')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError)
+      const error = err as HttpError
+      expect(error.message).toContain('Redirect blocked:')
+      expect(error.message).toContain('method=user.getTopArtists')
+      expect(error.message).toContain('api_key=%5BREDACTED%5D')
+      expect(error.message).not.toContain('api_key=secret')
     }
   })
 })

--- a/tests/core/lastfm-redaction.test.ts
+++ b/tests/core/lastfm-redaction.test.ts
@@ -19,6 +19,14 @@ beforeAll(async () => {
       return
     }
 
+    if (parsed.pathname === '/redirect-malformed') {
+      res.writeHead(302, {
+        Location: 'https://example.com:abc/?api_key=secret&user=test',
+      })
+      res.end()
+      return
+    }
+
     res.writeHead(404, { 'Content-Type': 'text/plain' })
     res.end('not found')
   })
@@ -95,6 +103,22 @@ describe('query redaction', () => {
       expect(error.message).toContain('Redirect blocked:')
       expect(error.message).toContain('method=user.getTopArtists')
       expect(error.message).toContain('api_key=%5BREDACTED%5D')
+      expect(error.message).not.toContain('api_key=secret')
+    }
+  })
+
+  it('redacts sensitive query params from malformed blocked redirect errors', async () => {
+    const client = createHttpClient({ baseUrl })
+
+    try {
+      await client.get('/redirect-malformed')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError)
+      const error = err as HttpError
+      expect(error.message).toContain('Redirect blocked:')
+      expect(error.message).toContain('api_key=[REDACTED]')
+      expect(error.message).toContain('user=test')
       expect(error.message).not.toContain('api_key=secret')
     }
   })

--- a/tests/core/lastfm-redaction.test.ts
+++ b/tests/core/lastfm-redaction.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment node
+import * as http from 'node:http'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createHttpClient, HttpError, redactUrlForLog } from '@/core/clients/http'
+
+let server: http.Server
+let baseUrl: string
+
+beforeAll(async () => {
+  server = http.createServer((_req, res) => {
+    res.writeHead(404, { 'Content-Type': 'text/plain' })
+    res.end('not found')
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const addr = server.address() as { port: number }
+  baseUrl = `http://127.0.0.1:${addr.port}`
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()))
+  })
+})
+
+describe('query redaction', () => {
+  it('redacts sensitive query params from URL strings', () => {
+    const url =
+      'https://ws.audioscrobbler.com/2.0/?method=user.getTopArtists&api_key=secret&apikey=other&key=third&token=abc123&secret=hidden&password=swordfish&user=test&genre=indie'
+
+    const redacted = redactUrlForLog(url)
+
+    expect(redacted).toContain('method=user.getTopArtists')
+    expect(redacted).toContain('user=test')
+    expect(redacted).toContain('genre=indie')
+    expect(redacted).toContain('api_key=%5BREDACTED%5D')
+    expect(redacted).toContain('apikey=%5BREDACTED%5D')
+    expect(redacted).toContain('key=%5BREDACTED%5D')
+    expect(redacted).toContain('token=%5BREDACTED%5D')
+    expect(redacted).toContain('secret=%5BREDACTED%5D')
+    expect(redacted).toContain('password=%5BREDACTED%5D')
+    expect(redacted).not.toContain('api_key=secret')
+    expect(redacted).not.toContain('apikey=other')
+    expect(redacted).not.toContain('key=third')
+    expect(redacted).not.toContain('abc123')
+  })
+
+  it('redacts sensitive query params from createHttpClient failures', async () => {
+    const client = createHttpClient({ baseUrl })
+
+    try {
+      await client.get(
+        '/?api_key=secret&apikey=other&key=third&token=fourth&secret=fifth&password=sixth&artist=Radiohead',
+      )
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError)
+      const error = err as HttpError
+      expect(error.message).toContain('artist=Radiohead')
+      expect(error.message).toContain('api_key=%5BREDACTED%5D')
+      expect(error.message).not.toContain('api_key=secret')
+      expect(error.message).not.toContain('apikey=other')
+      expect(error.message).not.toContain('key=third')
+      expect(error.message).not.toContain('token=fourth')
+      expect(error.message).not.toContain('secret=fifth')
+      expect(error.message).not.toContain('password=sixth')
+      expect(error.url).toContain('artist=Radiohead')
+      expect(error.url).not.toContain('api_key=secret')
+    }
+  })
+})

--- a/tests/core/notifications-ssrf.test.ts
+++ b/tests/core/notifications-ssrf.test.ts
@@ -70,4 +70,17 @@ describe('sendWebhook HTTPS SSRF hardening', () => {
     )
     expect(init.tls).toEqual(expect.objectContaining({ serverName: 'hooks.example.com' }))
   })
+
+  it('keeps HTTPS public IP literals pinned without forcing SNI', async () => {
+    lookupMock.mockResolvedValueOnce({ address: '93.184.216.34', family: 4 })
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 })
+
+    await sendWebhook('https://93.184.216.34/webhook', makePayload())
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const call = requireCall(fetchMock.mock.calls[0], 'Expected webhook fetch call')
+    const [url, init] = call
+    expect(String(url)).toBe('https://93.184.216.34/webhook')
+    expect(init.tls).toBeUndefined()
+  })
 })

--- a/tests/core/notifications-ssrf.test.ts
+++ b/tests/core/notifications-ssrf.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendWebhook, type WebhookPayload } from '@/core/notifications'
+
+const lookupMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:dns/promises', () => ({
+  lookup: lookupMock,
+}))
+
+function makePayload(overrides?: Partial<WebhookPayload>): WebhookPayload {
+  return {
+    event: 'batch_complete',
+    batchId: 42,
+    stats: { discovered: 10, added: 10, failed: 0 },
+    message: 'Scan complete: 10 new recommendations found.',
+    timestamp: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('sendWebhook HTTPS SSRF hardening', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let consoleSpy: ReturnType<typeof vi.spyOn>
+
+  function requireCall<T>(value: T | undefined, message: string): T {
+    if (value === undefined) {
+      throw new Error(message)
+    }
+
+    return value
+  }
+
+  beforeEach(() => {
+    lookupMock.mockReset()
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('rejects HTTPS webhook targets that resolve to a private IP', async () => {
+    lookupMock.mockResolvedValueOnce({ address: '10.0.0.5', family: 4 })
+
+    await sendWebhook('https://hooks.example.com/webhook', makePayload())
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('private/internal IP address'))
+  })
+
+  it('pins HTTPS webhooks to the resolved IP while preserving SNI', async () => {
+    lookupMock.mockResolvedValueOnce({ address: '93.184.216.34', family: 4 })
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 })
+
+    await sendWebhook('https://hooks.example.com/webhook', makePayload())
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const call = requireCall(fetchMock.mock.calls[0], 'Expected webhook fetch call')
+    const [url, init] = call
+    expect(String(url)).toBe('https://93.184.216.34/webhook')
+    expect(init.headers).toEqual(
+      expect.objectContaining({
+        Host: 'hooks.example.com',
+        'Content-Type': 'application/json',
+      }),
+    )
+    expect(init.tls).toEqual(expect.objectContaining({ serverName: 'hooks.example.com' }))
+  })
+})

--- a/tests/core/notifications-ssrf.test.ts
+++ b/tests/core/notifications-ssrf.test.ts
@@ -88,7 +88,7 @@ describe('sendWebhook HTTPS SSRF hardening', () => {
     lookupMock.mockResolvedValueOnce({ address: '93.184.216.34', family: 4 })
     fetchMock.mockResolvedValueOnce({ ok: true, status: 200 })
 
-    await sendWebhook('https://[2001:db8::1]/webhook', makePayload())
+    await sendWebhook('https://[2001:4860:4860::8888]/webhook', makePayload())
 
     expect(fetchMock).toHaveBeenCalledOnce()
     const call = requireCall(fetchMock.mock.calls[0], 'Expected webhook fetch call')

--- a/tests/core/notifications-ssrf.test.ts
+++ b/tests/core/notifications-ssrf.test.ts
@@ -84,16 +84,23 @@ describe('sendWebhook HTTPS SSRF hardening', () => {
     expect(init.tls).toBeUndefined()
   })
 
-  it('keeps HTTPS IPv6 literals pinned without forcing SNI', async () => {
-    lookupMock.mockResolvedValueOnce({ address: '93.184.216.34', family: 4 })
+  it('normalizes HTTPS IPv6 literals before lookup and keeps SNI disabled', async () => {
+    lookupMock.mockResolvedValueOnce({ address: '2001:4860:4860::8888', family: 6 })
     fetchMock.mockResolvedValueOnce({ ok: true, status: 200 })
 
     await sendWebhook('https://[2001:4860:4860::8888]/webhook', makePayload())
 
+    expect(lookupMock).toHaveBeenCalledWith('2001:4860:4860::8888')
     expect(fetchMock).toHaveBeenCalledOnce()
     const call = requireCall(fetchMock.mock.calls[0], 'Expected webhook fetch call')
     const [url, init] = call
-    expect(String(url)).toBe('https://93.184.216.34/webhook')
+    expect(String(url)).toBe('https://[2001:4860:4860::8888]/webhook')
     expect(init.tls).toBeUndefined()
+    expect(init.headers).toEqual(
+      expect.objectContaining({
+        Host: '[2001:4860:4860::8888]',
+        'Content-Type': 'application/json',
+      }),
+    )
   })
 })

--- a/tests/core/notifications-ssrf.test.ts
+++ b/tests/core/notifications-ssrf.test.ts
@@ -83,4 +83,17 @@ describe('sendWebhook HTTPS SSRF hardening', () => {
     expect(String(url)).toBe('https://93.184.216.34/webhook')
     expect(init.tls).toBeUndefined()
   })
+
+  it('keeps HTTPS IPv6 literals pinned without forcing SNI', async () => {
+    lookupMock.mockResolvedValueOnce({ address: '93.184.216.34', family: 4 })
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 })
+
+    await sendWebhook('https://[2001:db8::1]/webhook', makePayload())
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const call = requireCall(fetchMock.mock.calls[0], 'Expected webhook fetch call')
+    const [url, init] = call
+    expect(String(url)).toBe('https://93.184.216.34/webhook')
+    expect(init.tls).toBeUndefined()
+  })
 })

--- a/tests/core/notifications.test.ts
+++ b/tests/core/notifications.test.ts
@@ -104,9 +104,11 @@ describe('sendWebhook', () => {
     expect(fetchMock).toHaveBeenCalledOnce()
     const call = requireCall(fetchMock.mock.calls[0], 'Expected webhook fetch call')
     const [url, init] = call
-    expect(url).toBe('https://hooks.example.com/webhook')
+    expect(url).toBe('https://93.184.216.34/webhook')
     expect(init.method).toBe('POST')
     expect(init.headers['Content-Type']).toBe('application/json')
+    expect(init.headers.Host).toBe('hooks.example.com')
+    expect(init.tls).toEqual(expect.objectContaining({ serverName: 'hooks.example.com' }))
     expect(JSON.parse(init.body)).toEqual(payload)
   })
 

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from 'vitest'
-import { isPrivateIp } from '@/core/validation'
+import { getLookupHostname, isPrivateIp } from '@/core/validation'
 
 describe('isPrivateIp', () => {
   it('rejects IPv4 reserved and documentation ranges', () => {
@@ -36,5 +36,17 @@ describe('isPrivateIp', () => {
     expect(isPrivateIp('1.1.1.1')).toBe(false)
     expect(isPrivateIp('93.184.216.34')).toBe(false)
     expect(isPrivateIp('2001:4860:4860::8888')).toBe(false)
+  })
+})
+
+describe('getLookupHostname', () => {
+  it('strips IPv6 brackets before DNS lookup', () => {
+    expect(getLookupHostname('https://[2001:4860:4860::8888]:32400/library')).toBe(
+      '2001:4860:4860::8888',
+    )
+  })
+
+  it('preserves regular hostnames for DNS lookup', () => {
+    expect(getLookupHostname('https://hooks.example.com/webhook')).toBe('hooks.example.com')
   })
 })

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { isPrivateIp } from '@/core/validation'
+
+describe('isPrivateIp', () => {
+  it('rejects IPv4 reserved and documentation ranges', () => {
+    expect(isPrivateIp('0.0.0.0')).toBe(true)
+    expect(isPrivateIp('0.12.34.56')).toBe(true)
+    expect(isPrivateIp('198.18.0.1')).toBe(true)
+    expect(isPrivateIp('198.19.255.255')).toBe(true)
+    expect(isPrivateIp('192.0.2.1')).toBe(true)
+    expect(isPrivateIp('198.51.100.1')).toBe(true)
+    expect(isPrivateIp('203.0.113.1')).toBe(true)
+    expect(isPrivateIp('224.0.0.1')).toBe(true)
+    expect(isPrivateIp('240.0.0.1')).toBe(true)
+    expect(isPrivateIp('255.255.255.255')).toBe(true)
+  })
+
+  it('rejects IPv6 reserved and documentation ranges', () => {
+    expect(isPrivateIp('::')).toBe(true)
+    expect(isPrivateIp('::1')).toBe(true)
+    expect(isPrivateIp('fc00::1')).toBe(true)
+    expect(isPrivateIp('fd12:3456:789a::1')).toBe(true)
+    expect(isPrivateIp('fe80::1')).toBe(true)
+    expect(isPrivateIp('ff02::1')).toBe(true)
+    expect(isPrivateIp('64:ff9b::1')).toBe(true)
+    expect(isPrivateIp('2001::1')).toBe(true)
+    expect(isPrivateIp('2001:db8::1')).toBe(true)
+  })
+
+  it('allows public addresses', () => {
+    expect(isPrivateIp('8.8.8.8')).toBe(false)
+    expect(isPrivateIp('1.1.1.1')).toBe(false)
+    expect(isPrivateIp('93.184.216.34')).toBe(false)
+    expect(isPrivateIp('2001:4860:4860::8888')).toBe(false)
+  })
+})

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -23,11 +23,12 @@ describe('isPrivateIp', () => {
     expect(isPrivateIp('fd12:3456:789a::1')).toBe(true)
     expect(isPrivateIp('fe80::1')).toBe(true)
     expect(isPrivateIp('ff02::1')).toBe(true)
-    expect(isPrivateIp('64:ff9b::1')).toBe(true)
-    expect(isPrivateIp('2001::1')).toBe(true)
+    expect(isPrivateIp('64:ff9b::1')).toBe(false)
+    expect(isPrivateIp('64:ff9b::192.0.2.33')).toBe(false)
+    expect(isPrivateIp('2001::1')).toBe(false)
+    expect(isPrivateIp('2001::192.0.2.33')).toBe(false)
     expect(isPrivateIp('2001:db8::1')).toBe(true)
     expect(isPrivateIp('2001:db8::192.0.2.33')).toBe(true)
-    expect(isPrivateIp('64:ff9b::192.0.2.33')).toBe(true)
   })
 
   it('allows public addresses', () => {

--- a/tests/core/validation.test.ts
+++ b/tests/core/validation.test.ts
@@ -26,6 +26,8 @@ describe('isPrivateIp', () => {
     expect(isPrivateIp('64:ff9b::1')).toBe(true)
     expect(isPrivateIp('2001::1')).toBe(true)
     expect(isPrivateIp('2001:db8::1')).toBe(true)
+    expect(isPrivateIp('2001:db8::192.0.2.33')).toBe(true)
+    expect(isPrivateIp('64:ff9b::192.0.2.33')).toBe(true)
   })
 
   it('allows public addresses', () => {

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -31,6 +31,15 @@ const { mockGetUserConnections, mockUpdateUserConnections } = vi.hoisted(() => (
   mockUpdateUserConnections: vi.fn(async () => {}),
 }))
 
+const { mockCreateEmbyClient } = vi.hoisted(() => ({
+  mockCreateEmbyClient: vi.fn(() => ({
+    testConnection: vi.fn(async () => ({
+      success: true,
+      message: 'Connected to Emby',
+    })),
+  })),
+}))
+
 vi.mock('@/db/queries/users', async () => {
   const actual = await vi.importActual<typeof import('@/db/queries/users')>('@/db/queries/users')
   return {
@@ -67,6 +76,10 @@ vi.mock('@/core/clients/lastfm', () => ({
       message: 'Connected to Last.fm as testuser',
     })),
   })),
+}))
+
+vi.mock('@/core/clients/emby', () => ({
+  createEmbyClient: mockCreateEmbyClient,
 }))
 
 const mockSettings = {
@@ -577,6 +590,118 @@ describe('PATCH /api/settings', () => {
 })
 
 describe('POST /api/settings/test/:service', () => {
+  it('requires admin access for every settings test service', async () => {
+    await clearAllSessions()
+    await createSession(7, 'non-admin-settings-test-token')
+
+    const app = createApp(
+      makeDeps({
+        getUserCount: vi.fn(async () => 1),
+        getUserById: vi.fn(async () => ({
+          id: 7,
+          username: 'user7',
+          isAdmin: false,
+          preferences: null,
+          email: null,
+          oidcSubject: null,
+          authProvider: 'local',
+          listenbrainzUsername: null,
+          listenbrainzToken: null,
+          lastfmUsername: null,
+          lastfmApiKey: null,
+          plexUrl: null,
+          plexToken: null,
+          jellyfinUrl: null,
+          jellyfinApiKey: null,
+          jellyfinUserId: null,
+          embyUrl: null,
+          embyApiKey: null,
+          embyUserId: null,
+          discogsToken: null,
+          discogsUsername: null,
+          createdAt: new Date(),
+        })),
+      }),
+    )
+
+    const services = [
+      'lidarr',
+      'listenbrainz',
+      'lastfm',
+      'ai',
+      'plex',
+      'jellyfin',
+      'emby',
+      'discogs',
+      'spotify',
+      'oidc',
+    ]
+
+    for (const service of services) {
+      const res = await app.request(`/api/settings/test/${service}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer non-admin-settings-test-token',
+        },
+        body: JSON.stringify({}),
+      })
+
+      expect(res.status, `service: ${service}`).toBe(403)
+      await expect(res.json()).resolves.toEqual({
+        success: false,
+        message: 'Admin access required',
+      })
+    }
+  })
+
+  it('allows admins to test private HTTP service URLs', async () => {
+    const app = createApp(makeDeps())
+    const res = await authedRequest(app, '/api/settings/test/emby', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'http://127.0.0.1:8096',
+        apiKey: 'key',
+        userId: 'user-1',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockCreateEmbyClient).toHaveBeenCalledWith('http://127.0.0.1:8096', 'key', 'user-1', {
+      skipTlsVerify: false,
+    })
+  })
+
+  it('sanitizes failed probe responses', async () => {
+    const providerRegistry = {
+      create: vi.fn(async () => ({
+        testConnection: vi.fn(async () => ({
+          success: false,
+          message: 'HTTP 500 <html>probe failed from 127.0.0.1</html>',
+        })),
+      })),
+    }
+
+    const app = createApp(makeDeps({ providerRegistry: providerRegistry as never }))
+    const res = await authedRequest(app, '/api/settings/test/ai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'ollama',
+        model: 'llama3',
+        baseUrl: 'http://127.0.0.1:11434',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.message).not.toContain('HTTP 500')
+    expect(body.message).not.toContain('probe failed')
+    expect(body.message).not.toContain('127.0.0.1')
+  })
+
   it('tests lidarr and returns ServiceTestResult shape', async () => {
     const app = createApp(makeDeps())
     // Client will fail to connect but must return a ServiceTestResult (not throw)

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -905,13 +905,13 @@ describe('POST /api/settings/test/:service', () => {
     })
   })
 
-  it('allows admins to test private OIDC issuer URLs', async () => {
+  it('allows admins to test OIDC issuer URLs', async () => {
     const app = createApp(makeDeps())
     const res = await authedRequest(app, '/api/settings/test/oidc', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        issuerUrl: 'http://127.0.0.1:8080',
+        issuerUrl: 'https://issuer.example',
         clientId: 'client-id',
       }),
     })

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -40,6 +40,13 @@ const { mockCreateEmbyClient } = vi.hoisted(() => ({
   })),
 }))
 
+const { mockOidcTestConnection } = vi.hoisted(() => ({
+  mockOidcTestConnection: vi.fn(async () => ({
+    success: true,
+    message: 'OIDC discovery successful',
+  })),
+}))
+
 vi.mock('@/db/queries/users', async () => {
   const actual = await vi.importActual<typeof import('@/db/queries/users')>('@/db/queries/users')
   return {
@@ -80,6 +87,12 @@ vi.mock('@/core/clients/lastfm', () => ({
 
 vi.mock('@/core/clients/emby', () => ({
   createEmbyClient: mockCreateEmbyClient,
+}))
+
+vi.mock('@/core/auth/oidc', () => ({
+  OidcService: class OidcService {
+    testConnection = mockOidcTestConnection
+  },
 }))
 
 const mockSettings = {
@@ -888,24 +901,22 @@ describe('POST /api/settings/test/:service', () => {
     })
   })
 
-  it('rejects OIDC issuers that resolve to private IPs', async () => {
-    vi.mocked(lookup).mockResolvedValue({ address: '127.0.0.1', family: 4 })
-
+  it('allows admins to test private OIDC issuer URLs', async () => {
     const app = createApp(makeDeps())
     const res = await authedRequest(app, '/api/settings/test/oidc', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        issuerUrl: 'https://oidc.example',
+        issuerUrl: 'http://127.0.0.1:8080',
         clientId: 'client-id',
       }),
     })
 
-    expect(res.status).toBe(400)
-    await expect(res.json()).resolves.toEqual({
-      success: false,
-      message: 'OIDC issuer URL resolves to a private/internal IP',
-    })
+    expect(res.status).toBe(200)
+    expect(mockOidcTestConnection).toHaveBeenCalledTimes(1)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.message).toBe('OIDC discovery successful')
   })
 })
 

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -699,7 +699,10 @@ describe('POST /api/settings/test/:service', () => {
     const app = createApp(makeDeps({ providerRegistry: providerRegistry as never }))
     const res = await authedRequest(app, '/api/settings/test/ai', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Digarr-Locale': 'de',
+      },
       body: JSON.stringify({
         provider: 'ollama',
         model: 'llama3',
@@ -713,6 +716,7 @@ describe('POST /api/settings/test/:service', () => {
     expect(body.message).not.toContain('HTTP 500')
     expect(body.message).not.toContain('probe failed')
     expect(body.message).not.toContain('127.0.0.1')
+    expect(body.message).toBe('Unbekannter Fehler')
   })
 
   it('tests lidarr and returns ServiceTestResult shape', async () => {

--- a/tests/web/components/language-switcher.test.tsx
+++ b/tests/web/components/language-switcher.test.tsx
@@ -8,6 +8,7 @@ import { App } from '@/web/App'
 import { AuthGate } from '@/web/components/auth-gate'
 import { LanguageSwitcher } from '@/web/components/language-switcher'
 import { I18nProvider } from '@/web/lib/i18n'
+import { queryClient } from '@/web/lib/query-client'
 
 vi.mock('@/web/lib/locale-storage', () => ({
   detectBrowserLocale: vi.fn(() => 'en'),
@@ -201,6 +202,7 @@ function renderWithAppShell() {
 describe('language switcher surfaces', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    queryClient.clear()
     Object.defineProperty(globalThis, 'localStorage', {
       configurable: true,
       value: {

--- a/tests/web/pages/settings.test.tsx
+++ b/tests/web/pages/settings.test.tsx
@@ -479,6 +479,35 @@ describe('SettingsPage', () => {
     })
   })
 
+  it('hides test buttons for non-admin per-user connections but keeps save actions', async () => {
+    setupMocks()
+    mockGetCurrentUser.mockResolvedValue({
+      id: 2,
+      username: 'user',
+      isAdmin: false,
+      preferredLocale: 'en',
+    })
+    mockUpdateSettings.mockResolvedValue(undefined as unknown as Record<string, unknown>)
+
+    renderWithQuery(<SettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('ListenBrainz')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('button', { name: 'Test Connection' })).not.toBeInTheDocument()
+
+    const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+    const firstSaveButton = saveButtons[0]
+    expect(firstSaveButton).toBeDefined()
+    if (!firstSaveButton) return
+    fireEvent.click(firstSaveButton)
+
+    await waitFor(() => {
+      expect(mockUpdateSettings).toHaveBeenCalled()
+    })
+  })
+
   it('shows error state when settings fail to load', async () => {
     mockGetSettings.mockRejectedValue(new Error('Network error'))
     renderWithQuery(<SettingsPage />)


### PR DESCRIPTION
## Summary
- harden webhook delivery against SSRF, including HTTPS IP pinning with preserved Host/SNI behavior
- admin-gate and sanitize settings connection tests without blocking normal local self-hosted media service usage
- expand reserved IP detection, redact sensitive URLs in shared HTTP errors, and normalize bracketed host lookups before DNS resolution

## Testing
- bun run lint
- bun run typecheck
- bun run test