### PR TITLE
audit(phase-3): correctness fixes and hono CVE bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.29.3",
+  "version": "0.30.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/core/csv/cell-safe.ts
+++ b/src/core/csv/cell-safe.ts
@@ -1,0 +1,57 @@
+const DANGEROUS_PREFIX = /^[=+\-@\t\r]+/
+
+export function cellSafe(value: string): string {
+  const stripped = value.replace(DANGEROUS_PREFIX, '')
+  const needsQuote = /["\n\r,]/.test(stripped)
+  if (!needsQuote) return stripped
+  const escaped = stripped.replace(/"/g, '""')
+  return `"${escaped}"`
+}
+
+export function parseCell(raw: string): string {
+  let value = raw
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    value = value.slice(1, -1).replace(/""/g, '"')
+  }
+  return value.replace(DANGEROUS_PREFIX, '')
+}
+
+export function parseCsvRow(row: string): string[] {
+  const fields: string[] = []
+  let current = ''
+  let inQuotes = false
+  let i = 0
+  while (i < row.length) {
+    const ch = row[i]
+    if (inQuotes) {
+      if (ch === '"') {
+        if (row[i + 1] === '"') {
+          current += '"'
+          i += 2
+          continue
+        }
+        inQuotes = false
+        i += 1
+        continue
+      }
+      current += ch
+      i += 1
+      continue
+    }
+    if (ch === '"') {
+      inQuotes = true
+      i += 1
+      continue
+    }
+    if (ch === ',') {
+      fields.push(current.replace(DANGEROUS_PREFIX, ''))
+      current = ''
+      i += 1
+      continue
+    }
+    current += ch
+    i += 1
+  }
+  fields.push(current.replace(DANGEROUS_PREFIX, ''))
+  return fields
+}

--- a/src/core/oauth.ts
+++ b/src/core/oauth.ts
@@ -71,6 +71,11 @@ export async function getValidToken(
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? token.refreshToken,
     expiresAt,
+    // Preserve credentials and scopes so the row stays whole after refresh.
+    // decryptOAuthRow has already decrypted these on the read path.
+    clientId: token.clientId,
+    clientSecret: token.clientSecret,
+    scopes: token.scopes,
   })
 
   return data.access_token

--- a/src/core/pipeline/auto-approve.ts
+++ b/src/core/pipeline/auto-approve.ts
@@ -68,7 +68,11 @@ export async function autoApprove(
 
     const targetActions: Record<string, unknown> = {}
     let anySuccess = false
-    let lidarrResult: { externalId?: number | string; error?: string } | null = null
+    let lidarrResult: {
+      success: boolean
+      externalId?: number | string
+      error?: string
+    } | null = null
 
     for (const target of addTargets) {
       const targetJobId = deps.jobRecorder
@@ -129,7 +133,15 @@ export async function autoApprove(
       if (lidarrResult.error) extra.lidarrError = lidarrResult.error
     }
 
-    const finalStatus = anySuccess ? (hasLidarr ? 'added_to_lidarr' : 'approved') : 'add_failed'
+    const lidarrSucceeded = lidarrResult?.success === true
+    const lidarrFailed = hasLidarr && lidarrResult != null && !lidarrResult.success
+    const finalStatus = lidarrSucceeded
+      ? 'added_to_lidarr'
+      : lidarrFailed
+        ? 'add_failed'
+        : anySuccess
+          ? 'approved'
+          : 'add_failed'
 
     await deps.updateRecommendationStatus(rec.id, finalStatus, extra)
     if (anySuccess) approved++

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -475,6 +475,8 @@ export class PipelineOrchestrator extends EventEmitter {
       throw err
     } finally {
       this.running = false
+      // Drop the userId so subsequent non-pipeline emits don't inherit a stale owner
+      this._currentUserId = undefined
     }
   }
 

--- a/src/core/recommendations/statuses.ts
+++ b/src/core/recommendations/statuses.ts
@@ -1,0 +1,25 @@
+export const VALID_STATUSES = [
+  'pending',
+  'approved',
+  'rejected',
+  'added_to_lidarr',
+  'add_failed',
+  'duplicate',
+  'queued',
+] as const
+
+export type ValidStatus = (typeof VALID_STATUSES)[number]
+
+const VALID_SET: ReadonlySet<string> = new Set(VALID_STATUSES)
+
+export function isValidStatus(value: string): value is ValidStatus {
+  return VALID_SET.has(value)
+}
+
+/** Split a comma-separated status filter, trim, and drop unknown values. */
+export function parseStatusFilter(raw: string): ValidStatus[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s): s is ValidStatus => s.length > 0 && isValidStatus(s))
+}

--- a/src/core/subscriptions/adapters/csv-import.ts
+++ b/src/core/subscriptions/adapters/csv-import.ts
@@ -1,3 +1,4 @@
+import { parseCsvRow } from '@/core/csv/cell-safe'
 import type { AdapterResult, SubscriptionAdapter } from '@/core/subscriptions/types'
 
 const KNOWN_HEADERS = ['artist', 'artist_name', 'artist name', 'name']
@@ -5,19 +6,19 @@ const KNOWN_HEADERS = ['artist', 'artist_name', 'artist name', 'name']
 /**
  * Parse a CSV string and extract artist names.
  * Detects known header columns; falls back to first column or bare lines.
+ * Uses RFC 4180 row parsing and strips formula-trigger prefixes per field.
  */
 export function parseCsvArtists(csv: string, maxArtists = 500): string[] {
   const lines = csv
     .replace(/\r\n/g, '\n')
     .split('\n')
-    .map((line) => line.trim())
     .filter((line) => line.length > 0)
 
   if (lines.length === 0) return []
 
   const firstLine = lines[0] as string
-  const columns = firstLine.split(',').map((col) => col.trim())
-  const headerIdx = columns.findIndex((col) => KNOWN_HEADERS.includes(col.toLowerCase()))
+  const headerFields = parseCsvRow(firstLine).map((col) => col.trim().toLowerCase())
+  const headerIdx = headerFields.findIndex((col) => KNOWN_HEADERS.includes(col))
 
   let artistColumn: number
   let startRow: number
@@ -25,7 +26,7 @@ export function parseCsvArtists(csv: string, maxArtists = 500): string[] {
   if (headerIdx !== -1) {
     artistColumn = headerIdx
     startRow = 1
-  } else if (columns.length === 1 && !firstLine.includes(',')) {
+  } else if (headerFields.length === 1 && !firstLine.includes(',')) {
     artistColumn = 0
     startRow = 0
   } else {
@@ -37,7 +38,7 @@ export function parseCsvArtists(csv: string, maxArtists = 500): string[] {
   const artists: string[] = []
 
   for (let i = startRow; i < lines.length && artists.length < maxArtists; i++) {
-    const cols = (lines[i] as string).split(',')
+    const cols = parseCsvRow(lines[i] as string)
     const name = (cols[artistColumn] ?? '').trim()
     if (!name) continue
     const key = name.toLowerCase()

--- a/src/core/targets/export-csv.ts
+++ b/src/core/targets/export-csv.ts
@@ -1,22 +1,16 @@
+import { cellSafe } from '@/core/csv/cell-safe'
 import type { ExportableRecommendation } from './types'
-
-function escapeCsv(value: string): string {
-  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
-    return `"${value.replace(/"/g, '""')}"`
-  }
-  return value
-}
 
 export function exportToCsv(recommendations: ExportableRecommendation[]): string {
   const header = 'artist,mbid,genres,score,status,date'
   const rows = recommendations.map((r) =>
     [
-      escapeCsv(r.artistName),
-      r.artistMbid,
-      escapeCsv(r.genres.join(';')),
-      r.score.toFixed(2),
-      r.status,
-      r.createdAt,
+      cellSafe(r.artistName),
+      cellSafe(r.artistMbid),
+      cellSafe(r.genres.join(';')),
+      cellSafe(r.score.toFixed(2)),
+      cellSafe(r.status),
+      cellSafe(r.createdAt),
     ].join(','),
   )
   return [header, ...rows].join('\n')

--- a/src/core/targets/jellyfin-playlist.ts
+++ b/src/core/targets/jellyfin-playlist.ts
@@ -71,7 +71,12 @@ export function createJellyfinPlaylistTarget(
         artistName,
         trackName,
       )
-    } catch {
+    } catch (err) {
+      console.warn('[jellyfin-playlist] searchTrack transport error:', {
+        artistName,
+        trackName,
+        error: err instanceof Error ? err.message : String(err),
+      })
       return null
     }
   }

--- a/src/db/queries/artists.ts
+++ b/src/db/queries/artists.ts
@@ -21,7 +21,9 @@ export type ArtistInsert = {
 export async function upsertArtist(db: DbOrTx, artist: ArtistInsert): Promise<ArtistRow> {
   const { imageFailed, ...artistData } = artist
 
-  const imageFailedAtInsert = imageFailed ? new Date() : artist.imageUrl ? null : undefined
+  // Match the update-path priority: clear negative cache when an image is present,
+  // otherwise mark failure time; undefined leaves the column at the schema default.
+  const imageFailedAtInsert = artist.imageUrl ? null : imageFailed ? new Date() : undefined
 
   const rows = await db
     .insert(artists)

--- a/src/db/queries/batches.ts
+++ b/src/db/queries/batches.ts
@@ -7,7 +7,6 @@ export type BatchRow = typeof recommendationBatches.$inferSelect
 export type BatchStats = {
   discovered: number
   filtered: number
-  scored: number
   added: number
   failed: number
 }

--- a/src/db/queries/oauth-tokens.ts
+++ b/src/db/queries/oauth-tokens.ts
@@ -35,16 +35,18 @@ export async function upsertOAuthToken(
   db: Database,
   data: OAuthTokenInsert,
 ): Promise<OAuthTokenRow> {
-  // Don't encrypt pending tokens - they're searched by prefix and are temporary
+  // accessToken stays plaintext when it's a pending marker so the LIKE-prefix
+  // lookup in findPendingOAuthByState can match. refreshToken and clientSecret
+  // are never searched by prefix, so they must always be encrypted.
   const isPending = data.accessToken.startsWith('pending:')
-  const values = isPending
-    ? data
-    : {
-        ...data,
-        accessToken: encryptField(data.accessToken) ?? data.accessToken,
-        refreshToken: encryptField(data.refreshToken) ?? data.refreshToken,
-        clientSecret: encryptField(data.clientSecret) ?? data.clientSecret,
-      }
+  const values = {
+    ...data,
+    accessToken: isPending
+      ? data.accessToken
+      : (encryptField(data.accessToken) ?? data.accessToken),
+    refreshToken: encryptField(data.refreshToken) ?? data.refreshToken,
+    clientSecret: encryptField(data.clientSecret) ?? data.clientSecret,
+  }
   const [row] = await db
     .insert(oauthTokens)
     .values(values)

--- a/src/db/queries/recommendations.ts
+++ b/src/db/queries/recommendations.ts
@@ -1,4 +1,5 @@
 import { and, count, desc, eq, gte, inArray, sql } from 'drizzle-orm'
+import { isValidStatus, parseStatusFilter } from '@/core/recommendations/statuses'
 import type { Database, DbOrTx } from '@/db'
 import { artistMetadata, artists, recommendationBatches, recommendations } from '@/db/schema'
 
@@ -48,8 +49,11 @@ export async function listRecommendations(
   const conditions = []
   if (status !== undefined) {
     if (status.includes(',')) {
-      conditions.push(inArray(recommendations.status, status.split(',')))
-    } else {
+      const filtered = parseStatusFilter(status)
+      if (filtered.length > 0) {
+        conditions.push(inArray(recommendations.status, filtered))
+      }
+    } else if (isValidStatus(status)) {
       conditions.push(eq(recommendations.status, status))
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1086,6 +1086,8 @@ async function restartPlaylistScheduler(): Promise<void> {
 
 let librarySyncCron: Cron | null = null
 let libraryHealthCron: Cron | null = null
+let slskdCron: Cron | null = null
+let stuckDetectorCron: Cron | null = null
 
 function restartLibraryMaintenanceScheduler(intervalHours: number): void {
   librarySyncCron?.stop()
@@ -1464,7 +1466,7 @@ const server = serve({ fetch: app.fetch, port })
       .catch((err) => console.error('[boot] initial library syncGlobal failed:', err))
     libraryHealth.startScan()
     void slskdOrchestrator.warmup()
-    new Cron('*/10 * * * *', async () => {
+    slskdCron = new Cron('*/10 * * * *', async () => {
       try {
         await slskdOrchestrator.triggerSync()
       } catch (err) {
@@ -1473,7 +1475,7 @@ const server = serve({ fetch: app.fetch, port })
     })
 
     // Start stuck job detector
-    startStuckDetector(jobRecorder)
+    stuckDetectorCron = startStuckDetector(jobRecorder)
   } catch (err: unknown) {
     console.error('Failed to initialize:', err)
   }
@@ -1519,6 +1521,10 @@ for (const signal of ['SIGTERM', 'SIGINT'] as const) {
     console.log(`${signal} received, shutting down...`)
     scheduler.stopAll()
     playlistScheduler.stopAll()
+    slskdCron?.stop()
+    stuckDetectorCron?.stop()
+    librarySyncCron?.stop()
+    libraryHealthCron?.stop()
     server.close()
     // Hard deadline: exit no matter what after 30s
     const deadline = setTimeout(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,7 +232,7 @@ const storeDb: StoreDb = {
     return row
   },
   completeBatch: async (id, stats) => {
-    await completeBatch(db, id, { ...stats, filtered: 0, scored: 0 })
+    await completeBatch(db, id, { ...stats, filtered: 0 })
   },
   upsertArtist: async (data) => {
     const row = await upsertArtist(db, data)

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -368,7 +368,7 @@ export function createApp(deps: AppDependencies) {
           topArtists: [],
           topGenres: [],
           listeningPatterns: { totalListens: 0, recentTrend: 'stable' },
-          _rawPrompt: `Describe the artist "${artistName}" (genres: ${genreList}) in 2-3 sentences. First describe what they sound like and what they're known for, then explain why fans of ${genreList} might enjoy them. Return ONLY a JSON array with one element: [{"artistName":"${artistName}","reasoning":"...","confidence":0.8,"genres":${JSON.stringify(genres)}}]`,
+          _rawPrompt: `Describe the artist ${JSON.stringify(artistName)} (genres: ${genreList}) in 2-3 sentences. First describe what they sound like and what they're known for, then explain why fans of ${genreList} might enjoy them. Return ONLY a JSON array with one element: [{"artistName":${JSON.stringify(artistName)},"reasoning":"...","confidence":0.8,"genres":${JSON.stringify(genres)}}]`,
         })
         return results[0]?.reasoning ?? `${artistName} is an artist in the ${genreList} genre.`
       },

--- a/src/server/middleware/rate-limit.ts
+++ b/src/server/middleware/rate-limit.ts
@@ -2,6 +2,30 @@ import { createMiddleware } from 'hono/factory'
 import type { HonoEnv } from '@/server/types'
 
 type RateLimitBucket = { count: number; resetAt: number }
+type RateLimitStore = Map<string, RateLimitBucket>
+
+const registry: RateLimitStore[] = []
+let pruneInterval: ReturnType<typeof setInterval> | null = null
+
+function ensurePruneStarted(): void {
+  if (pruneInterval) return
+  pruneInterval = setInterval(() => {
+    const now = Date.now()
+    for (const store of registry) {
+      for (const [key, bucket] of store) {
+        if (bucket.resetAt <= now) store.delete(key)
+      }
+    }
+  }, 60_000)
+  pruneInterval.unref?.()
+}
+
+/** Exposed for tests: clear the shared prune interval and registry. */
+export function __shutdownRateLimiter(): void {
+  if (pruneInterval) clearInterval(pruneInterval)
+  pruneInterval = null
+  registry.length = 0
+}
 
 /** Extract socket-level IP (not forgeable headers). Mirrors proxy-auth.ts. */
 function getSocketIp(c: { env?: unknown }): string | null {
@@ -17,17 +41,12 @@ function getSocketIp(c: { env?: unknown }): string | null {
 /**
  * Simple in-memory rate limiter keyed by client IP.
  * Not shared across processes - sufficient for single-process deployments.
+ * All limiter instances share one prune interval via the module-level registry.
  */
 export function rateLimiter(opts: { windowMs: number; max: number; keyPrefix?: string }) {
-  const buckets = new Map<string, RateLimitBucket>()
-
-  // Prune expired buckets every 60s to avoid unbounded growth
-  setInterval(() => {
-    const now = Date.now()
-    for (const [key, bucket] of buckets) {
-      if (bucket.resetAt <= now) buckets.delete(key)
-    }
-  }, 60_000).unref()
+  const buckets: RateLimitStore = new Map()
+  registry.push(buckets)
+  ensurePruneStarted()
 
   return createMiddleware<HonoEnv>(async (c, next) => {
     // Use socket IP to prevent bypass via forged X-Forwarded-For headers.

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -11,6 +11,7 @@ import {
 } from '@/core/ops/hygiene'
 import type { BackupFile, OpsDb } from '@/core/ops/types'
 import { getPendingMigrations } from '@/core/ops/upgrade'
+import { isValidStatus } from '@/core/recommendations/statuses'
 import { mergePreferences, type Preferences } from '@/db/schema'
 import { backupFileSchema } from '@/server/schemas/admin'
 import type { HonoEnv } from '@/server/types'
@@ -23,15 +24,6 @@ export interface AdminDeps {
   getSettings: () => Promise<{ preferences?: Partial<Preferences> | null } | null>
   generateReasoning?: (artistName: string, genres: string[]) => Promise<string>
 }
-
-const VALID_STATUSES = new Set([
-  'pending',
-  'approved',
-  'rejected',
-  'added_to_lidarr',
-  'add_failed',
-  'duplicate',
-])
 
 export function adminRoutes(deps: AdminDeps) {
   const router = new Hono<HonoEnv>()
@@ -59,6 +51,16 @@ export function adminRoutes(deps: AdminDeps) {
   // restoreBackup touches the DB.
   router.post('/api/admin/restore', async (c) => {
     const force = c.req.query('force') === 'true'
+    const confirm = c.req.query('confirm') === 'true'
+    if (!confirm) {
+      return c.json(
+        {
+          error: 'Restore overwrites existing data. Re-submit with ?confirm=true to acknowledge.',
+          code: 'confirmation_required' as const,
+        },
+        400,
+      )
+    }
     const contentType = c.req.header('content-type') ?? ''
 
     let raw: unknown
@@ -156,7 +158,7 @@ export function adminRoutes(deps: AdminDeps) {
     const user = await deps.getUserById(userId)
     const prefs = mergePreferences(user?.preferences)
     const statusParam = c.req.query('status') ?? 'pending'
-    const statuses = statusParam.split(',').filter((s) => VALID_STATUSES.has(s))
+    const statuses = statusParam.split(',').filter((s) => isValidStatus(s))
     if (statuses.length === 0) {
       return c.json({ error: 'No valid status values provided' }, 400)
     }

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -17,6 +17,12 @@ import { changePasswordSchema, registerSchema } from '@/server/schemas/auth'
 import { zJson } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
+// Pre-computed at module load so "username not found" still pays the scrypt
+// cost during login, preventing a timing-based user enumeration oracle.
+const DUMMY_PASSWORD_HASH = hashPassword(
+  'digarr-login-dummy-hash-input-never-matches-any-real-user',
+)
+
 const ALLOWED_PREF_KEYS = new Set([
   'scoreThreshold',
   'scoringWeights',
@@ -133,7 +139,12 @@ export function authRoutes(deps: AppDependencies) {
     }
 
     const user = await deps.getUserByUsername(username)
-    if (!user || !verifyPassword(password, user.passwordHash)) {
+    // Always run scrypt once to equalize response time between "user missing"
+    // and "user exists but password wrong". Without this, a username enumeration
+    // oracle exists via timing.
+    const hashToVerify = user?.passwordHash ?? DUMMY_PASSWORD_HASH
+    const passwordOk = verifyPassword(password, hashToVerify)
+    if (!user || !passwordOk) {
       return c.json({ error: messages['auth.invalidCredentials'] }, 401)
     }
 

--- a/src/server/schemas/admin.ts
+++ b/src/server/schemas/admin.ts
@@ -7,24 +7,25 @@ import * as z from 'zod'
 // types) before restore logic runs.
 const tableArray = z.array(z.record(z.string(), z.unknown()))
 
-export const backupDataSchema = z
-  .object({
-    settings: tableArray,
-    users: tableArray,
-    oauthTokens: tableArray,
-    oidcTokens: tableArray,
-    targets: tableArray,
-    subscriptions: tableArray,
-    jobRuns: tableArray,
-    recommendationBatches: tableArray,
-    recommendations: tableArray,
-    playlists: tableArray,
-    playlistTracks: tableArray,
-    artists: tableArray.optional(),
-    genres: tableArray.optional(),
-    artistMetadata: tableArray.optional(),
-  })
-  .passthrough()
+// Locked to the known table names. Unknown keys are rejected so a crafted
+// backup can't smuggle a prototype-pollution payload through a field
+// restoreBackup doesn't filter.
+export const backupDataSchema = z.strictObject({
+  settings: tableArray,
+  users: tableArray,
+  oauthTokens: tableArray,
+  oidcTokens: tableArray,
+  targets: tableArray,
+  subscriptions: tableArray,
+  jobRuns: tableArray,
+  recommendationBatches: tableArray,
+  recommendations: tableArray,
+  playlists: tableArray,
+  playlistTracks: tableArray,
+  artists: tableArray.optional(),
+  genres: tableArray.optional(),
+  artistMetadata: tableArray.optional(),
+})
 
 export const backupFileSchema = z.object({
   version: z.number().int().positive(),

--- a/tests/core/csv/cell-safe.test.ts
+++ b/tests/core/csv/cell-safe.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { cellSafe, parseCell, parseCsvRow } from '@/core/csv/cell-safe'
+
+describe('cellSafe (export-side sanitization)', () => {
+  it('strips leading formula-trigger characters', () => {
+    expect(cellSafe('=HYPERLINK(...)')).toBe('HYPERLINK(...)')
+    expect(cellSafe('+SUM(...)')).toBe('SUM(...)')
+    expect(cellSafe('-1,2,3')).toBe('"1,2,3"')
+    expect(cellSafe('@evil')).toBe('evil')
+    expect(cellSafe('\tevil')).toBe('evil')
+    expect(cellSafe('\revil')).toBe('evil')
+  })
+
+  it('strips repeated formula-trigger prefixes', () => {
+    expect(cellSafe('==bad')).toBe('bad')
+    expect(cellSafe('=+@bad')).toBe('bad')
+  })
+
+  it('quotes cells containing comma, quote, or newline', () => {
+    expect(cellSafe('a, b')).toBe('"a, b"')
+    expect(cellSafe('line1\nline2')).toBe('"line1\nline2"')
+    expect(cellSafe('has "quote"')).toBe('"has ""quote"""')
+  })
+
+  it('passes through safe input unchanged', () => {
+    expect(cellSafe('Artist Name')).toBe('Artist Name')
+    expect(cellSafe('')).toBe('')
+    expect(cellSafe('simple123')).toBe('simple123')
+  })
+})
+
+describe('parseCell (import-side sanitization)', () => {
+  it('unquotes and de-escapes RFC 4180 quoted fields', () => {
+    expect(parseCell('"a, b"')).toBe('a, b')
+    expect(parseCell('"a ""b"" c"')).toBe('a "b" c')
+    expect(parseCell('"line1\nline2"')).toBe('line1\nline2')
+  })
+
+  it('strips formula-trigger prefixes after unquoting', () => {
+    expect(parseCell('=bad')).toBe('bad')
+    expect(parseCell('"=HYPERLINK(evil)"')).toBe('HYPERLINK(evil)')
+    expect(parseCell('+risk')).toBe('risk')
+  })
+
+  it('passes through plain fields', () => {
+    expect(parseCell('Radiohead')).toBe('Radiohead')
+    expect(parseCell('')).toBe('')
+  })
+})
+
+describe('parseCsvRow (RFC 4180)', () => {
+  it('splits simple comma-separated fields', () => {
+    expect(parseCsvRow('a,b,c')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('respects quoted commas', () => {
+    expect(parseCsvRow('"a,b",c')).toEqual(['a,b', 'c'])
+  })
+
+  it('handles escaped quotes in quoted fields', () => {
+    expect(parseCsvRow('"a ""b"" c",d')).toEqual(['a "b" c', 'd'])
+  })
+
+  it('strips formula prefix on each field', () => {
+    expect(parseCsvRow('=evil,safe')).toEqual(['evil', 'safe'])
+  })
+})
+
+describe('CSV round-trip with hostile input', () => {
+  it('strips formula injection on import and does not regenerate it on export', async () => {
+    const { parseCsvArtists } = await import('@/core/subscriptions/adapters/csv-import')
+    const { exportToCsv } = await import('@/core/targets/export-csv')
+
+    const hostile = '=HYPERLINK("http://evil","click")'
+    const csvIn = `artist,notes\n"${hostile.replace(/"/g, '""')}",ok\n`
+    const imported = parseCsvArtists(csvIn)
+    expect(imported).toHaveLength(1)
+    const first = imported[0]
+    if (!first) throw new Error('expected at least one imported artist')
+    expect(first.startsWith('=')).toBe(false)
+    expect(first).toBe('HYPERLINK("http://evil","click")')
+
+    const exported = exportToCsv([
+      {
+        artistName: first,
+        artistMbid: 'mbid-1',
+        genres: [],
+        score: 0.5,
+        status: 'approved',
+        streamingUrls: {},
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ])
+    const dataRow = exported.split('\n')[1]
+    if (!dataRow) throw new Error('expected exported row')
+    expect(dataRow.startsWith('=')).toBe(false)
+    expect(dataRow.startsWith('+')).toBe(false)
+    expect(dataRow.startsWith('-')).toBe(false)
+    expect(dataRow.startsWith('@')).toBe(false)
+  })
+})

--- a/tests/core/oauth.test.ts
+++ b/tests/core/oauth.test.ts
@@ -105,25 +105,34 @@ describe('getValidToken()', () => {
     expect(upsertOAuthToken).not.toHaveBeenCalled()
   })
 
-  it('refreshes token when expired', async () => {
+  it('refreshes token when expired and preserves clientId, clientSecret, scopes', async () => {
     const pastDate = new Date(Date.now() - 60 * 1000) // 1 minute ago
     vi.mocked(getOAuthToken).mockResolvedValue({
       accessToken: 'expired-token',
       refreshToken: 'my-refresh-token',
       expiresAt: pastDate,
+      clientId: 'stored-client-id',
+      clientSecret: 'stored-client-secret',
+      scopes: 'read write',
     } as never)
     vi.mocked(upsertOAuthToken).mockResolvedValue(undefined as never)
 
     const result = await getValidToken(mockDb, 1, 'spotify', refreshConfig)
 
     expect(result).toBe('new-access-token')
-    expect(upsertOAuthToken).toHaveBeenCalledWith(mockDb, {
-      userId: 1,
-      provider: 'spotify',
-      accessToken: 'new-access-token',
-      refreshToken: 'new-refresh-token',
-      expiresAt: expect.any(Date),
-    })
+    expect(upsertOAuthToken).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        userId: 1,
+        provider: 'spotify',
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiresAt: expect.any(Date),
+        clientId: 'stored-client-id',
+        clientSecret: 'stored-client-secret',
+        scopes: 'read write',
+      }),
+    )
   })
 
   it('refreshes token when within 5-minute buffer', async () => {

--- a/tests/core/pipeline/auto-approve.test.ts
+++ b/tests/core/pipeline/auto-approve.test.ts
@@ -140,4 +140,145 @@ describe('autoApprove()', () => {
     expect(result.approved).toBe(1)
     expect(result.failed).toBe(1)
   })
+
+  it('marks add_failed when Lidarr target exists but addArtist failed', async () => {
+    const deps = makeDeps({
+      getEnabledTargets: vi.fn().mockResolvedValue([
+        {
+          id: 'lidarr-1',
+          name: 'Lidarr',
+          type: 'lidarr',
+          capabilities: ['addArtist'],
+          addArtist: vi.fn().mockResolvedValue({
+            success: false,
+            targetType: 'lidarr',
+            targetId: 1,
+            error: 'connection refused',
+          }),
+          testConnection: vi.fn(),
+        },
+      ]),
+      getRecommendationsByBatch: vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, score: 0.9, status: 'pending', artist: { mbid: 'mbid-1', name: 'A' } },
+        ]),
+    })
+    const result = await autoApprove(
+      1,
+      {
+        threshold: 0.5,
+        monitorOption: 'all',
+        qualityProfileId: 1,
+        metadataProfileId: 1,
+        rootFolderId: 1,
+      },
+      deps,
+    )
+    expect(result.approved).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(deps.updateRecommendationStatus).toHaveBeenCalledWith(
+      1,
+      'add_failed',
+      expect.objectContaining({ lidarrError: 'connection refused' }),
+    )
+  })
+
+  it('sets added_to_lidarr only when the Lidarr target actually succeeded', async () => {
+    // Regression guard: prior code keyed final status off `hasLidarr` (target presence),
+    // so a succeeding non-Lidarr target alongside a failing Lidarr target could yield
+    // `added_to_lidarr`. With Lidarr failing, the status must NOT be `added_to_lidarr`.
+    const deps = makeDeps({
+      getEnabledTargets: vi.fn().mockResolvedValue([
+        {
+          id: 'lidarr-1',
+          name: 'Lidarr',
+          type: 'lidarr',
+          capabilities: ['addArtist'],
+          addArtist: vi.fn().mockResolvedValue({
+            success: false,
+            targetType: 'lidarr',
+            targetId: 1,
+            error: 'lidarr down',
+          }),
+          testConnection: vi.fn(),
+        },
+        {
+          id: 'emby-1',
+          name: 'Emby',
+          type: 'emby',
+          capabilities: ['addArtist'],
+          addArtist: vi.fn().mockResolvedValue({
+            success: true,
+            targetType: 'emby',
+            targetId: 2,
+            externalId: 'emby-artist-1',
+          }),
+          testConnection: vi.fn(),
+        },
+      ]),
+      getRecommendationsByBatch: vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, score: 0.9, status: 'pending', artist: { mbid: 'mbid-1', name: 'A' } },
+        ]),
+    })
+    await autoApprove(
+      1,
+      {
+        threshold: 0.5,
+        monitorOption: 'all',
+        qualityProfileId: 1,
+        metadataProfileId: 1,
+        rootFolderId: 1,
+      },
+      deps,
+    )
+    // Lidarr is authoritative: if its add failed, status must NOT be added_to_lidarr
+    // even when a secondary target succeeded. Caller treats this as a failure.
+    const mock = deps.updateRecommendationStatus as ReturnType<typeof vi.fn>
+    const firstCall = mock.mock.calls[0]
+    if (!firstCall) throw new Error('expected updateRecommendationStatus to be called')
+    const finalStatus = firstCall[1]
+    expect(finalStatus).not.toBe('added_to_lidarr')
+    expect(finalStatus).toBe('add_failed')
+  })
+
+  it('uses approved status when no Lidarr target is configured', async () => {
+    const deps = makeDeps({
+      getEnabledTargets: vi.fn().mockResolvedValue([
+        {
+          id: 'emby-1',
+          name: 'Emby',
+          type: 'emby',
+          capabilities: ['addArtist'],
+          addArtist: vi.fn().mockResolvedValue({
+            success: true,
+            targetType: 'emby',
+            targetId: 2,
+            externalId: 'emby-artist-1',
+          }),
+          testConnection: vi.fn(),
+        },
+      ]),
+      getRecommendationsByBatch: vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, score: 0.9, status: 'pending', artist: { mbid: 'mbid-1', name: 'A' } },
+        ]),
+    })
+    const result = await autoApprove(
+      1,
+      {
+        threshold: 0.5,
+        monitorOption: 'all',
+        qualityProfileId: 1,
+        metadataProfileId: 1,
+        rootFolderId: 1,
+      },
+      deps,
+    )
+    expect(result.approved).toBe(1)
+    expect(deps.updateRecommendationStatus).toHaveBeenCalledWith(1, 'approved', expect.any(Object))
+  })
 })

--- a/tests/core/recommendations/statuses.test.ts
+++ b/tests/core/recommendations/statuses.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { isValidStatus, parseStatusFilter, VALID_STATUSES } from '@/core/recommendations/statuses'
+
+describe('parseStatusFilter', () => {
+  it('accepts known statuses', () => {
+    expect(parseStatusFilter('approved,rejected')).toEqual(['approved', 'rejected'])
+  })
+
+  it('trims whitespace per token', () => {
+    expect(parseStatusFilter('approved , rejected ')).toEqual(['approved', 'rejected'])
+  })
+
+  it('drops unknown tokens including SQL-looking payloads', () => {
+    expect(parseStatusFilter('approved,injection; DROP TABLE,rejected')).toEqual([
+      'approved',
+      'rejected',
+    ])
+  })
+
+  it('returns empty when nothing is valid', () => {
+    expect(parseStatusFilter('nope,alsonope')).toEqual([])
+  })
+
+  it('ignores empty tokens from repeated commas', () => {
+    expect(parseStatusFilter('approved,,rejected,')).toEqual(['approved', 'rejected'])
+  })
+})
+
+describe('isValidStatus', () => {
+  it('accepts every listed status', () => {
+    for (const status of VALID_STATUSES) {
+      expect(isValidStatus(status)).toBe(true)
+    }
+  })
+
+  it('rejects unknown values', () => {
+    expect(isValidStatus('in_progress')).toBe(false)
+    expect(isValidStatus('')).toBe(false)
+  })
+})

--- a/tests/db/queries/oauth-tokens.test.ts
+++ b/tests/db/queries/oauth-tokens.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { initEncryption } from '@/core/crypto'
+import type { Database } from '@/db'
+import { upsertOAuthToken } from '@/db/queries/oauth-tokens'
+
+const TEST_KEY = 'oauth-tokens-test-key-do-not-reuse'
+
+beforeAll(() => {
+  initEncryption(TEST_KEY)
+})
+
+afterAll(() => {
+  initEncryption(undefined)
+})
+
+type UpsertCapture = {
+  insertValues?: Record<string, unknown>
+  updateSet?: Record<string, unknown>
+}
+
+function makeDb(capture: UpsertCapture): Database {
+  const chain = {
+    values: vi.fn((values: Record<string, unknown>) => {
+      capture.insertValues = values
+      return chain
+    }),
+    onConflictDoUpdate: vi.fn((args: { set: Record<string, unknown> }) => {
+      capture.updateSet = args.set
+      return chain
+    }),
+    returning: vi.fn().mockResolvedValue([
+      {
+        id: 1,
+        userId: 1,
+        provider: 'spotify',
+        accessToken: capture.insertValues?.accessToken ?? '',
+        refreshToken: capture.insertValues?.refreshToken ?? null,
+        expiresAt: new Date(),
+        scopes: capture.insertValues?.scopes ?? null,
+        clientId: capture.insertValues?.clientId ?? null,
+        clientSecret: capture.insertValues?.clientSecret ?? null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]),
+  }
+  return { insert: vi.fn().mockReturnValue(chain) } as unknown as Database
+}
+
+describe('upsertOAuthToken encryption', () => {
+  it('encrypts clientSecret even when accessToken is a pending marker', async () => {
+    const capture: UpsertCapture = {}
+    const db = makeDb(capture)
+
+    await upsertOAuthToken(db, {
+      userId: 1,
+      provider: 'spotify',
+      accessToken: 'pending:1:state-token',
+      refreshToken: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      clientId: 'client-id-plain',
+      clientSecret: 'client-secret-plain',
+      scopes: 'read',
+    })
+
+    const values = capture.insertValues
+    expect(values).toBeDefined()
+    // Access token must remain plaintext for LIKE-prefix lookup
+    expect(values?.accessToken).toBe('pending:1:state-token')
+    // Client secret must be encrypted even during the pending window
+    expect(values?.clientSecret).toEqual(expect.stringMatching(/^enc:v1:/))
+    expect(values?.clientSecret).not.toBe('client-secret-plain')
+  })
+
+  it('encrypts clientSecret on non-pending upsert', async () => {
+    const capture: UpsertCapture = {}
+    const db = makeDb(capture)
+
+    await upsertOAuthToken(db, {
+      userId: 1,
+      provider: 'spotify',
+      accessToken: 'real-access-token',
+      refreshToken: 'real-refresh-token',
+      expiresAt: new Date(Date.now() + 3600_000),
+      clientId: 'client-id-plain',
+      clientSecret: 'client-secret-plain',
+      scopes: 'read write',
+    })
+
+    const values = capture.insertValues
+    expect(values?.accessToken).toEqual(expect.stringMatching(/^enc:v1:/))
+    expect(values?.refreshToken).toEqual(expect.stringMatching(/^enc:v1:/))
+    expect(values?.clientSecret).toEqual(expect.stringMatching(/^enc:v1:/))
+  })
+})

--- a/tests/server/routes/analytics.test.ts
+++ b/tests/server/routes/analytics.test.ts
@@ -201,7 +201,7 @@ describe('GET /api/analytics/batches', () => {
           id: 1,
           created_at: '2024-06-01T00:00:00Z',
           status: 'completed',
-          stats: { discovered: 20, filtered: 5, scored: 15, added: 15, failed: 0 },
+          stats: { discovered: 20, filtered: 5, added: 15, failed: 0 },
           total: 15,
           approved: 5,
           rejected: 3,

--- a/tests/server/routes/validation.test.ts
+++ b/tests/server/routes/validation.test.ts
@@ -356,9 +356,21 @@ describe('validation: quick-discover', () => {
 })
 
 describe('validation: admin restore', () => {
-  it('rejects POST /api/admin/restore with missing data section', async () => {
+  it('rejects POST /api/admin/restore without confirm=true', async () => {
     const { app, headers } = await authedApp()
     const res = await app.request('/api/admin/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('confirmation_required')
+  })
+
+  it('rejects POST /api/admin/restore with missing data section', async () => {
+    const { app, headers } = await authedApp()
+    const res = await app.request('/api/admin/restore?confirm=true', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({
@@ -377,7 +389,7 @@ describe('validation: admin restore', () => {
 
   it('rejects POST /api/admin/restore when a table is not an array', async () => {
     const { app, headers } = await authedApp()
-    const res = await app.request('/api/admin/restore', {
+    const res = await app.request('/api/admin/restore?confirm=true', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...headers },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
Phase 3 of the deep-audit remediation plan: 15 correctness bugs fixed across pipeline, OAuth, scheduler, backup, recommendations, rate limit, plus hono upgrade past CVE.

Layered as 6 thematic subphase commits on top of Phase 2, shipping as v0.30.5.

## Audit tasks closed (3.1-3.15 minus 3.16)

- **3.1** Auto-approve `added_to_lidarr` now keyed off `lidarrResult.success`, not target presence (`src/core/pipeline/auto-approve.ts`). Lidarr remains authoritative: its failure surfaces as `add_failed` even when a secondary target succeeded.
- **3.2** Shared CSV formula-injection guard (`src/core/csv/cell-safe.ts`) applied to both import and export. `parseCsvRow` adds proper RFC 4180 row tokenization.
- **3.3** `hono` pinned >=4.12.14 (CVE).
- **3.4** OAuth `clientSecret` now always encrypted, including during the pending-token window. Only `accessToken` stays plaintext when pending (required for the LIKE-prefix state lookup).
- **3.5** OAuth refresh preserves `clientId`, `clientSecret`, `scopes` -- previously nulled on every token refresh.
- **3.6** Slskd cron, library sync/health crons, and stuck-detector cron handles are now captured and stopped in SIGTERM/SIGINT.
- **3.7** `imageFailedAt` insert/update priority aligned (image presence beats failure flag in both paths).
- **3.8** `artistName` interpolated via `JSON.stringify` in the reasoning prompt.
- **3.9** `PipelineOrchestrator._currentUserId` reset in `finally` so subsequent emits don't inherit a stale owner.
- **3.10** `status.split(',')` filters allowlisted against `VALID_STATUSES`. Shared module at `src/core/recommendations/statuses.ts`.
- **3.11** Jellyfin `searchTrack` logs transport errors instead of swallowing them silently.
- **3.12** Rate-limit middleware shares one prune `setInterval` via module-level registry. Adds `__shutdownRateLimiter()` helper.
- **3.13** Login pays scrypt cost for missing users too (pre-computed `DUMMY_PASSWORD_HASH` at module load) -- closes timing oracle for user enumeration.
- **3.14** `backupDataSchema` switched from `.passthrough()` to `.strictObject()`; restore route now requires `?confirm=true`.
- **3.15** Vestigial `BatchStats.scored` removed (already unused by orchestrator/webhook/jobs/web layers).

**Deferred:** 3.16 (rejection cooldown boundary test) covered in Phase 12.1.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` -- 1925 passed, 22 skipped (added 21 new tests: auto-approve regression, CSV round-trip, OAuth encryption + refresh preservation, status allowlist, restore confirmation gate)
- [ ] Verify CI green on both forges before merge