### PR TITLE
audit(phase-4): database indexes, pool defaults, upsert races, N+1 batching, key rotation

### DIFF
--- a/docs/runbooks/encryption-key-rotation.md
+++ b/docs/runbooks/encryption-key-rotation.md
@@ -1,0 +1,108 @@
+# Encryption Key Rotation
+
+`DIGARR_ENCRYPTION_KEY` is used to encrypt sensitive columns (API keys,
+tokens, passwords) at rest. Rotate it periodically so key compromise has a
+bounded blast radius.
+
+The app supports a dual-key mode via `DIGARR_ENCRYPTION_KEY_NEXT`: when set,
+`decryptField` tries the primary key first, then falls back to the next key,
+then to the legacy SHA-256 key. Writes always use the primary. This lets
+rotation happen with zero downtime at the cost of two deploys plus one
+data-migration pass.
+
+## Encrypted sites
+
+Rotation touches these columns:
+
+- `settings.lidarr_api_key`, `settings.ai_api_key`, `settings.oidc_client_secret`
+- `settings.preferences.fanartApiKey` (nested in jsonb)
+- `users.listenbrainz_token`, `users.lastfm_api_key`, `users.plex_token`, `users.jellyfin_api_key`, `users.emby_api_key`, `users.discogs_token`
+- `oauth_tokens.access_token`, `oauth_tokens.refresh_token`, `oauth_tokens.client_secret`
+- `oidc_tokens.access_token`, `oidc_tokens.refresh_token`, `oidc_tokens.id_token`
+- `targets.config` (any `enc:v1:`-prefixed string values)
+
+## Procedure
+
+1. **Generate a new key.**
+
+   ```sh
+   openssl rand -base64 32
+   ```
+
+2. **Deploy with both keys set (primary unchanged, NEXT = new).**
+
+   ```sh
+   DIGARR_ENCRYPTION_KEY=<old>
+   DIGARR_ENCRYPTION_KEY_NEXT=<new>
+   ```
+
+   The app still writes with the old key. Existing ciphertext continues to
+   decrypt through the primary. NEXT is unused yet but the binary is now
+   capable of reading values encrypted with either key.
+
+3. **Deploy again with the roles swapped (primary = new, NEXT = old).**
+
+   ```sh
+   DIGARR_ENCRYPTION_KEY=<new>
+   DIGARR_ENCRYPTION_KEY_NEXT=<old>
+   ```
+
+   New writes land under the new key. Old ciphertext still decrypts via the
+   NEXT fallback. There's a window here where the DB has a mix of
+   old-encrypted and new-encrypted values.
+
+4. **Run the rotation script.** (Point `DATABASE_URL` at the target DB.)
+
+   ```sh
+   DATABASE_URL=postgresql://... \
+   DIGARR_ENCRYPTION_KEY=<new> \
+   DIGARR_ENCRYPTION_KEY_NEXT=<old> \
+   bun scripts/rotate-encryption-key.ts
+   ```
+
+   The script reads every `enc:v1:` value, decrypts through the
+   primary/next/legacy chain, and re-encrypts under the primary (new key).
+   Safe to re-run; idempotent because every write uses a fresh IV.
+
+5. **Deploy a third time to drop NEXT.**
+
+   ```sh
+   DIGARR_ENCRYPTION_KEY=<new>
+   # DIGARR_ENCRYPTION_KEY_NEXT unset
+   ```
+
+   The old key is now retired. If a stale encrypted value from before step 4
+   survived, decryption will now fail loudly instead of silently falling back
+   to the old key.
+
+## Verification
+
+After step 5, sample a few sensitive columns and confirm:
+
+```sh
+DATABASE_URL=postgresql://... \
+DIGARR_ENCRYPTION_KEY=<new> \
+bun -e "
+  import { decryptField, initEncryption } from './src/core/crypto'
+  import { db, pool } from './src/db'
+  import { sql } from 'drizzle-orm'
+  initEncryption(process.env.DIGARR_ENCRYPTION_KEY)
+  const r = await db.execute(sql\`SELECT id, lastfm_api_key FROM users WHERE lastfm_api_key IS NOT NULL LIMIT 5\`)
+  for (const row of r.rows) console.log(row.id, '->', decryptField(row.lastfm_api_key))
+  await pool.end()
+"
+```
+
+Every row should decrypt cleanly. A `Decryption failed` throw means the
+rotation pass missed a row - re-run step 4 with NEXT still set to the old
+key, then retry step 5.
+
+## Rollback
+
+If any step fails before step 5, revert by re-setting
+`DIGARR_ENCRYPTION_KEY` to the old key and deleting
+`DIGARR_ENCRYPTION_KEY_NEXT`. All data remains readable because nothing is
+re-encrypted until step 4 runs successfully.
+
+After step 5 completes, rollback requires restoring a pre-rotation backup
+(see the Backup & Restore guide).

--- a/drizzle/0027_fk_indexes.sql
+++ b/drizzle/0027_fk_indexes.sql
@@ -1,0 +1,26 @@
+-- Add missing indexes on foreign-key columns. Postgres does NOT auto-index FK
+-- columns; without these, cascading updates/deletes and joins against the
+-- parent tables degrade to sequential scans once row counts grow.
+--
+-- Note: we use plain CREATE INDEX (not CONCURRENTLY) because drizzle-orm's
+-- migrator wraps the batch in a transaction and CONCURRENTLY cannot run inside
+-- a transaction. Digarr is a single-process self-hosted app and deploys are
+-- already downtime events (Recreate strategy), so the brief table lock is
+-- acceptable.
+CREATE INDEX IF NOT EXISTS genres_parent_genre_id_idx
+  ON genres(parent_genre_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS recommendation_batches_subscription_id_idx
+  ON recommendation_batches(subscription_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS job_runs_user_id_idx
+  ON job_runs(user_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS job_runs_batch_id_idx
+  ON job_runs(batch_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS slskd_jobs_target_id_idx
+  ON slskd_jobs(target_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS slskd_jobs_recommendation_id_idx
+  ON slskd_jobs(recommendation_id);

--- a/drizzle/0028_library_natural_keys_nulls_not_distinct.sql
+++ b/drizzle/0028_library_natural_keys_nulls_not_distinct.sql
@@ -1,0 +1,23 @@
+-- library_sync_state, library_match_overrides, and library_album_match_overrides
+-- use (user_id, source[, source_*_id]) as their natural upsert key, but user_id
+-- is nullable (shared/global sync cursor == NULL). By default Postgres unique
+-- indexes treat NULL values as distinct, which means ON CONFLICT cannot match
+-- an existing NULL-user_id row and would insert duplicates on retry.
+--
+-- Postgres 15+ supports NULLS NOT DISTINCT on unique indexes. Replace each
+-- natural-key index with a NULLS NOT DISTINCT variant so upserts are
+-- race-safe for both null and non-null user_id.
+DROP INDEX IF EXISTS library_sync_state_natural_key_idx;
+--> statement-breakpoint
+CREATE UNIQUE INDEX library_sync_state_natural_key_idx
+  ON library_sync_state (user_id, source) NULLS NOT DISTINCT;
+--> statement-breakpoint
+DROP INDEX IF EXISTS library_match_overrides_natural_key_idx;
+--> statement-breakpoint
+CREATE UNIQUE INDEX library_match_overrides_natural_key_idx
+  ON library_match_overrides (user_id, source, source_artist_id) NULLS NOT DISTINCT;
+--> statement-breakpoint
+DROP INDEX IF EXISTS library_album_match_overrides_natural_key_idx;
+--> statement-breakpoint
+CREATE UNIQUE INDEX library_album_match_overrides_natural_key_idx
+  ON library_album_match_overrides (user_id, source, source_album_id) NULLS NOT DISTINCT;

--- a/drizzle/0029_artists_gin_indexes.sql
+++ b/drizzle/0029_artists_gin_indexes.sql
@@ -1,0 +1,13 @@
+-- GIN indexes on artist genre/tag arrays. getArtistsByGenre and similar
+-- queries do `lower(g) = lower(genreName)` via unnest today, which the
+-- planner cannot satisfy from a plain btree. A GIN index on the array
+-- columns enables index-only containment checks (genres @> ARRAY['indie']).
+--
+-- 4.8 (recommendations(user_id, status)) is already covered by
+-- recommendations_user_status_score_idx, so only the 4.9 GIN indexes are
+-- added here.
+CREATE INDEX IF NOT EXISTS artists_genres_gin_idx
+  ON artists USING GIN (genres);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS artists_tags_gin_idx
+  ON artists USING GIN (tags);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1776509648892,
       "tag": "0027_fk_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1776509887445,
+      "tag": "0028_library_natural_keys_nulls_not_distinct",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1776456510416,
       "tag": "0026_single_admin_partial_index",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1776509648892,
+      "tag": "0027_fk_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1776509887445,
       "tag": "0028_library_natural_keys_nulls_not_distinct",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1776510950630,
+      "tag": "0029_artists_gin_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.30.5",
+  "version": "0.31.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.31.6",
+  "version": "0.31.7",
   "type": "module",
   "private": true,
   "scripts": {

--- a/scripts/rotate-encryption-key.ts
+++ b/scripts/rotate-encryption-key.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env bun
+
+/**
+ * Re-encrypt every encrypted column with the current primary key.
+ *
+ * Expected use flow (see docs/runbooks/encryption-key-rotation.md):
+ *   1. Deploy with DIGARR_ENCRYPTION_KEY=<old> DIGARR_ENCRYPTION_KEY_NEXT=<new>
+ *   2. Deploy with DIGARR_ENCRYPTION_KEY=<new> DIGARR_ENCRYPTION_KEY_NEXT=<old>
+ *   3. Run this script. It reads every enc:v1 column, decrypts through the
+ *      primary/next/legacy chain, and re-encrypts with the primary key so
+ *      all ciphertext is readable by the primary alone.
+ *   4. Deploy with DIGARR_ENCRYPTION_KEY=<new> (NEXT unset).
+ *
+ * Safe to re-run: values already readable by the primary are still
+ * re-encrypted (fresh IV each pass).
+ *
+ * Usage: bun scripts/rotate-encryption-key.ts
+ */
+
+import { sql } from 'drizzle-orm'
+import { buildDatabaseUrl, envConfig } from '../src/config/env'
+
+// Import env/crypto via side effects before instantiating the DB pool so the
+// key derivation runs with whatever env is set at invocation.
+import { decryptField, encryptField, initEncryption } from '../src/core/crypto'
+import { db, pool } from '../src/db'
+
+initEncryption(envConfig.encryptionKey, envConfig.encryptionKeyNext)
+
+if (!envConfig.encryptionKey) {
+  console.error('DIGARR_ENCRYPTION_KEY must be set to rotate keys')
+  process.exit(1)
+}
+console.log(`using database ${new URL(buildDatabaseUrl()).host}`)
+
+type Site = { table: string; column: string }
+
+// Covers every column currently passed through encryptFields/encryptField in
+// the codebase. Extend when a new encrypted column lands (grep for
+// SENSITIVE_* and SENSITIVE_PREF_KEYS to confirm).
+const COLUMN_SITES: Site[] = [
+  { table: 'settings', column: 'lidarr_api_key' },
+  { table: 'settings', column: 'ai_api_key' },
+  { table: 'settings', column: 'oidc_client_secret' },
+  { table: 'users', column: 'listenbrainz_token' },
+  { table: 'users', column: 'lastfm_api_key' },
+  { table: 'users', column: 'plex_token' },
+  { table: 'users', column: 'jellyfin_api_key' },
+  { table: 'users', column: 'emby_api_key' },
+  { table: 'users', column: 'discogs_token' },
+  { table: 'oauth_tokens', column: 'access_token' },
+  { table: 'oauth_tokens', column: 'refresh_token' },
+  { table: 'oauth_tokens', column: 'client_secret' },
+  { table: 'oidc_tokens', column: 'access_token' },
+  { table: 'oidc_tokens', column: 'refresh_token' },
+  { table: 'oidc_tokens', column: 'id_token' },
+]
+
+// JSONB nested paths - these require read/mutate/write on the whole jsonb blob.
+const NESTED_SITES: Array<{ table: string; column: string; path: string[] }> = [
+  { table: 'settings', column: 'preferences', path: ['fanartApiKey'] },
+]
+
+// `targets.config` is a jsonb with variable shape. Each row may have any
+// combination of encrypted-looking keys (apiKey/password/token/secret). Handle
+// it by walking the blob and re-encrypting any string value that starts with
+// the `enc:v1:` prefix.
+async function rotateTargetsConfig(): Promise<{ scanned: number; rewritten: number }> {
+  const rows = (await db.execute(sql`SELECT id, config FROM targets`)).rows as Array<{
+    id: number
+    config: Record<string, unknown> | null
+  }>
+  let rewritten = 0
+  for (const row of rows) {
+    if (!row.config || typeof row.config !== 'object') continue
+    let changed = false
+    const next: Record<string, unknown> = { ...row.config }
+    for (const [k, v] of Object.entries(row.config)) {
+      if (typeof v === 'string' && v.startsWith('enc:v1:')) {
+        try {
+          const plain = decryptField(v)
+          if (plain == null) continue
+          const re = encryptField(plain)
+          if (re !== v) {
+            next[k] = re
+            changed = true
+          }
+        } catch (err) {
+          console.error(`  skip targets.config id=${row.id} key=${k}: ${(err as Error).message}`)
+        }
+      }
+    }
+    if (changed) {
+      await db.execute(sql`UPDATE targets SET config = ${next} WHERE id = ${row.id}`)
+      rewritten++
+    }
+  }
+  return { scanned: rows.length, rewritten }
+}
+
+async function rotateColumn(site: Site): Promise<{ scanned: number; rewritten: number }> {
+  const rows = (
+    await db.execute(
+      sql.raw(
+        `SELECT id, "${site.column}" AS v FROM "${site.table}" WHERE "${site.column}" LIKE 'enc:v1:%'`,
+      ),
+    )
+  ).rows as Array<{ id: number; v: string }>
+  let rewritten = 0
+  for (const row of rows) {
+    try {
+      const plain = decryptField(row.v)
+      if (plain == null) continue
+      const re = encryptField(plain)
+      if (re !== row.v) {
+        await db.execute(
+          sql`UPDATE ${sql.identifier(site.table)}
+              SET ${sql.identifier(site.column)} = ${re}
+              WHERE id = ${row.id}`,
+        )
+        rewritten++
+      }
+    } catch (err) {
+      console.error(`  skip ${site.table}.${site.column} id=${row.id}: ${(err as Error).message}`)
+    }
+  }
+  return { scanned: rows.length, rewritten }
+}
+
+async function rotateNested(site: {
+  table: string
+  column: string
+  path: string[]
+}): Promise<{ scanned: number; rewritten: number }> {
+  const rows = (
+    await db.execute(
+      sql.raw(
+        `SELECT id, "${site.column}" AS blob FROM "${site.table}" WHERE "${site.column}" IS NOT NULL`,
+      ),
+    )
+  ).rows as Array<{ id: number; blob: Record<string, unknown> | null }>
+  let rewritten = 0
+  for (const row of rows) {
+    if (!row.blob || typeof row.blob !== 'object') continue
+    let cursor: Record<string, unknown> = row.blob
+    for (let i = 0; i < site.path.length - 1; i++) {
+      const seg = site.path[i]
+      if (!seg) break
+      const sub = cursor[seg]
+      if (!sub || typeof sub !== 'object') {
+        cursor = {}
+        break
+      }
+      cursor = sub as Record<string, unknown>
+    }
+    const leaf = site.path[site.path.length - 1]
+    if (!leaf) continue
+    const v = cursor[leaf]
+    if (typeof v !== 'string' || !v.startsWith('enc:v1:')) continue
+    try {
+      const plain = decryptField(v)
+      if (plain == null) continue
+      const re = encryptField(plain)
+      if (re !== v) {
+        cursor[leaf] = re
+        await db.execute(
+          sql`UPDATE ${sql.identifier(site.table)}
+              SET ${sql.identifier(site.column)} = ${row.blob}
+              WHERE id = ${row.id}`,
+        )
+        rewritten++
+      }
+    } catch (err) {
+      console.error(
+        `  skip ${site.table}.${site.column}.${site.path.join('.')} id=${row.id}: ${(err as Error).message}`,
+      )
+    }
+  }
+  return { scanned: rows.length, rewritten }
+}
+
+async function main(): Promise<void> {
+  let totalScanned = 0
+  let totalRewritten = 0
+  for (const site of COLUMN_SITES) {
+    process.stdout.write(`${site.table}.${site.column} ... `)
+    const { scanned, rewritten } = await rotateColumn(site)
+    console.log(`${scanned} scanned, ${rewritten} rewritten`)
+    totalScanned += scanned
+    totalRewritten += rewritten
+  }
+  for (const site of NESTED_SITES) {
+    const label = `${site.table}.${site.column}.${site.path.join('.')}`
+    process.stdout.write(`${label} ... `)
+    const { scanned, rewritten } = await rotateNested(site)
+    console.log(`${scanned} scanned, ${rewritten} rewritten`)
+    totalScanned += scanned
+    totalRewritten += rewritten
+  }
+  process.stdout.write('targets.config ... ')
+  const { scanned, rewritten } = await rotateTargetsConfig()
+  console.log(`${scanned} scanned, ${rewritten} rewritten`)
+  totalScanned += scanned
+  totalRewritten += rewritten
+
+  console.log(
+    `\nrotation complete: ${totalRewritten} of ${totalScanned} encrypted values rewritten with primary key`,
+  )
+  await pool.end()
+}
+
+main().catch(async (err) => {
+  console.error(err)
+  await pool.end()
+  process.exit(1)
+})

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -76,6 +76,9 @@ export const envConfig = {
 
   // Encryption (optional - encrypts API keys and tokens at rest in the DB)
   encryptionKey: env('DIGARR_ENCRYPTION_KEY'),
+  // Secondary key for rotation. When set, decryptField falls back to this
+  // key if the primary key fails. See docs/runbooks/encryption-key-rotation.md.
+  encryptionKeyNext: env('DIGARR_ENCRYPTION_KEY_NEXT'),
 
   // Registration control
   disableRegistration: envBool('DIGARR_DISABLE_REGISTRATION', true),

--- a/src/core/crypto.ts
+++ b/src/core/crypto.ts
@@ -6,18 +6,37 @@ const PREFIX = 'enc:v1:'
 
 let derivedKey: Buffer | null = null
 let legacyKey: Buffer | null = null
+let nextKey: Buffer | null = null
 
-/** Initialize encryption with a key string. Call once at startup. */
-export function initEncryption(keyInput: string | undefined): void {
+function deriveHkdfKey(input: string): Buffer {
+  return Buffer.from(hkdfSync('sha256', input, '', 'digarr-field-encryption', 32))
+}
+
+/**
+ * Initialize encryption with a key string. Call once at startup.
+ *
+ * `nextKeyInput` enables dual-key mode for rotation: during rotation the
+ * operator sets a second key so decrypts fall through to it, then swaps the
+ * roles across two deploys with a re-encryption pass in between. See
+ * docs/runbooks/encryption-key-rotation.md.
+ */
+export function initEncryption(
+  keyInput: string | undefined,
+  nextKeyInput?: string | undefined,
+): void {
   if (!keyInput) {
     derivedKey = null
     legacyKey = null
+    nextKey = null
     return
   }
   // HKDF-derived key (current)
-  derivedKey = Buffer.from(hkdfSync('sha256', keyInput, '', 'digarr-field-encryption', 32))
+  derivedKey = deriveHkdfKey(keyInput)
   // SHA-256 key (legacy - kept for decrypting pre-migration values)
   legacyKey = createHash('sha256').update(keyInput).digest()
+  // Optional second HKDF key for rotation. decryptField tries primary first
+  // and falls back to this key on auth-tag failure.
+  nextKey = nextKeyInput ? deriveHkdfKey(nextKeyInput) : null
 }
 
 export function isEncryptionEnabled(): boolean {
@@ -71,19 +90,28 @@ export function decryptField(value: string | null | undefined): typeof value {
   const [ivStr, encStr, tagStr] = value.slice(PREFIX.length).split('.')
   if (!ivStr || !encStr || !tagStr) return value // malformed
 
-  // Try HKDF key first, then fall back to legacy SHA-256 key for pre-migration values
+  // Try primary HKDF key, then rotation NEXT key, then legacy SHA-256.
+  // AES-GCM auth-tag verification is cheap so trial decryption is fine.
   try {
     return decryptWithKey(ivStr, encStr, tagStr, derivedKey)
   } catch {
-    if (legacyKey) {
-      try {
-        return decryptWithKey(ivStr, encStr, tagStr, legacyKey)
-      } catch {
-        // Both keys failed
-      }
-    }
-    throw new Error('Decryption failed - check DIGARR_ENCRYPTION_KEY')
+    // fall through
   }
+  if (nextKey) {
+    try {
+      return decryptWithKey(ivStr, encStr, tagStr, nextKey)
+    } catch {
+      // fall through
+    }
+  }
+  if (legacyKey) {
+    try {
+      return decryptWithKey(ivStr, encStr, tagStr, legacyKey)
+    } catch {
+      // fall through
+    }
+  }
+  throw new Error('Decryption failed - check DIGARR_ENCRYPTION_KEY')
 }
 
 /** Encrypt specific string fields in an object. */

--- a/src/core/library/store.ts
+++ b/src/core/library/store.ts
@@ -375,16 +375,12 @@ export function createLibrarySyncStore(database: Db): LibrarySyncStore {
     getLibrarySyncState,
 
     async upsertLibrarySyncState(userId, source, patch) {
-      const existing = await getLibrarySyncState(userId, source)
-      if (existing) {
-        const userClause =
-          userId === null ? isNull(librarySyncState.userId) : eq(librarySyncState.userId, userId)
-        await database
-          .update(librarySyncState)
-          .set(patch)
-          .where(and(userClause, eq(librarySyncState.source, source)))
-      } else {
-        await database.insert(librarySyncState).values({
+      // Atomic upsert on the (user_id, source) natural key. The unique index
+      // is NULLS NOT DISTINCT so the ON CONFLICT target matches both null and
+      // non-null user_id rows without the old check-then-write race.
+      await database
+        .insert(librarySyncState)
+        .values({
           userId,
           source,
           lastSyncStartedAt: patch.lastSyncStartedAt ?? null,
@@ -393,7 +389,10 @@ export function createLibrarySyncStore(database: Db): LibrarySyncStore {
           lastSyncError: patch.lastSyncError ?? null,
           lastSyncCounts: patch.lastSyncCounts ?? null,
         })
-      }
+        .onConflictDoUpdate({
+          target: [librarySyncState.userId, librarySyncState.source],
+          set: patch,
+        })
     },
 
     async clearRunningSyncStates() {
@@ -423,27 +422,23 @@ export function createLibrarySyncStore(database: Db): LibrarySyncStore {
     },
 
     async upsertOverride(userId, source, sourceArtistId, correctMbid, note) {
-      const existing = await getOverride(userId, source, sourceArtistId)
-      if (existing) {
-        await database
-          .update(libraryMatchOverrides)
-          .set({ correctMbid, note: note ?? null, updatedAt: new Date() })
-          .where(
-            and(
-              eq(libraryMatchOverrides.userId, userId),
-              eq(libraryMatchOverrides.source, source),
-              eq(libraryMatchOverrides.sourceArtistId, sourceArtistId),
-            ),
-          )
-      } else {
-        await database.insert(libraryMatchOverrides).values({
+      await database
+        .insert(libraryMatchOverrides)
+        .values({
           userId,
           source,
           sourceArtistId,
           correctMbid,
           note: note ?? null,
         })
-      }
+        .onConflictDoUpdate({
+          target: [
+            libraryMatchOverrides.userId,
+            libraryMatchOverrides.source,
+            libraryMatchOverrides.sourceArtistId,
+          ],
+          set: { correctMbid, note: note ?? null, updatedAt: new Date() },
+        })
     },
 
     async deleteOverride(userId, source, sourceArtistId) {
@@ -459,38 +454,23 @@ export function createLibrarySyncStore(database: Db): LibrarySyncStore {
     },
 
     async upsertAlbumOverride(userId, source, sourceAlbumId, correctAlbumMbid, note) {
-      const existing = await database
-        .select({ id: libraryAlbumMatchOverrides.id })
-        .from(libraryAlbumMatchOverrides)
-        .where(
-          and(
-            eq(libraryAlbumMatchOverrides.userId, userId),
-            eq(libraryAlbumMatchOverrides.source, source),
-            eq(libraryAlbumMatchOverrides.sourceAlbumId, sourceAlbumId),
-          ),
-        )
-        .limit(1)
-
-      if (existing[0]) {
-        await database
-          .update(libraryAlbumMatchOverrides)
-          .set({ correctAlbumMbid, note: note ?? null, updatedAt: new Date() })
-          .where(
-            and(
-              eq(libraryAlbumMatchOverrides.userId, userId),
-              eq(libraryAlbumMatchOverrides.source, source),
-              eq(libraryAlbumMatchOverrides.sourceAlbumId, sourceAlbumId),
-            ),
-          )
-      } else {
-        await database.insert(libraryAlbumMatchOverrides).values({
+      await database
+        .insert(libraryAlbumMatchOverrides)
+        .values({
           userId,
           source,
           sourceAlbumId,
           correctAlbumMbid,
           note: note ?? null,
         })
-      }
+        .onConflictDoUpdate({
+          target: [
+            libraryAlbumMatchOverrides.userId,
+            libraryAlbumMatchOverrides.source,
+            libraryAlbumMatchOverrides.sourceAlbumId,
+          ],
+          set: { correctAlbumMbid, note: note ?? null, updatedAt: new Date() },
+        })
     },
 
     async deleteAlbumOverride(userId, source, sourceAlbumId) {

--- a/src/core/ops/backup.ts
+++ b/src/core/ops/backup.ts
@@ -177,16 +177,28 @@ function createRestoreSpec<TTable extends BackupTable>(
       await tx.delete(table)
     },
     async restore(tx, rows) {
+      if (rows.length === 0) return
       const target = conflictTarget ?? getDefaultConflictTarget(table)
-      for (const row of rows) {
-        const safeRow = filterToSchemaColumns(table, row) as TTable['$inferInsert']
+      const columns = getTableColumns(table)
+      // Build an excluded.* set clause once per table so the batched upsert
+      // copies every inserted value onto existing rows. Drop `id` so the
+      // original primary key is not overwritten with itself (harmless, but
+      // noisier EXPLAIN output).
+      const setClause: Record<string, ReturnType<typeof sql>> = {}
+      for (const [jsName, col] of Object.entries(columns) as [string, AnyPgColumn][]) {
+        if (jsName === 'id') continue
+        setClause[jsName] = sql.raw(`excluded.${col.name}`)
+      }
+      const safeRows = rows.map((row) => filterToSchemaColumns(table, row))
+      // Postgres caps bind parameters at 65535. Keep chunks well below that:
+      // assume up to ~30 cols per row, so 1000 rows = ~30k params with headroom.
+      const CHUNK = 1000
+      for (let i = 0; i < safeRows.length; i += CHUNK) {
+        const chunk = safeRows.slice(i, i + CHUNK)
         await tx
           .insert(table)
-          .values(safeRow as never)
-          .onConflictDoUpdate({
-            target,
-            set: safeRow as never,
-          })
+          .values(chunk as never)
+          .onConflictDoUpdate({ target, set: setClause as never })
       }
     },
     async resetSequence(tx) {

--- a/src/core/ops/backup.ts
+++ b/src/core/ops/backup.ts
@@ -123,8 +123,12 @@ export async function createBackup(db: OpsDb, options: BackupOptions = {}): Prom
 
 // ── Restore ────────────────────────────────────
 
+// Flags for the detectEncryptionMismatch warning. Entries may be top-level
+// column names (e.g. 'lidarrApiKey') or nested jsonb paths in dotted form
+// (e.g. 'preferences.fanartApiKey'). The detector only uses these labels for
+// the surfaced error message, so dotted paths are a pure string contract.
 const ENCRYPTED_FIELD_MAP: Record<string, readonly string[]> = {
-  settings: SENSITIVE_SETTINGS,
+  settings: [...SENSITIVE_SETTINGS, 'preferences.fanartApiKey'],
   users: SENSITIVE_USER_CONNECTIONS,
   oauthTokens: SENSITIVE_OAUTH,
   oidcTokens: SENSITIVE_OIDC,

--- a/src/core/ops/hygiene.ts
+++ b/src/core/ops/hygiene.ts
@@ -119,20 +119,30 @@ export async function rebuildGenres(db: OpsDb): Promise<HygieneResult> {
   // Clear and rebuild
   await db.delete(genres)
 
-  for (const [name, count] of genreCounts) {
-    await db
-      .insert(genres)
-      .values({
-        name,
-        slug: slugify(name),
-        source: 'rebuild',
-        artistCount: count,
-        cachedAt: new Date(),
-      })
-      .onConflictDoUpdate({
-        target: genres.slug,
-        set: { artistCount: count, cachedAt: new Date(), source: 'rebuild' },
-      })
+  if (genreCounts.size > 0) {
+    const rows = Array.from(genreCounts, ([name, count]) => ({
+      name,
+      slug: slugify(name),
+      source: 'rebuild',
+      artistCount: count,
+      cachedAt: new Date(),
+    }))
+    // genres has ~6 columns; 2000 rows = ~12k params, safely under the 65535 cap.
+    const CHUNK = 2000
+    for (let i = 0; i < rows.length; i += CHUNK) {
+      const chunk = rows.slice(i, i + CHUNK)
+      await db
+        .insert(genres)
+        .values(chunk)
+        .onConflictDoUpdate({
+          target: genres.slug,
+          set: {
+            artistCount: sql`excluded.artist_count`,
+            cachedAt: sql`excluded.cached_at`,
+            source: sql`excluded.source`,
+          },
+        })
+    }
   }
 
   const elapsed = ((Date.now() - start) / 1000).toFixed(1)
@@ -185,20 +195,39 @@ export async function rescoreRecommendations(
     .innerJoin(artists, eq(recommendations.artistId, artists.id))
     .where(inArray(recommendations.status, statusFilter))
 
-  let rescored = 0
-  for (const rec of recs) {
-    const allGenres = [...(rec.artistGenres ?? []), ...(rec.artistTags ?? [])]
-    const newScore = rescoreOne(rec.sources ?? {}, allGenres, libraryGenres, weights)
-
-    await db
-      .update(recommendations)
-      .set({ score: newScore })
-      .where(eq(recommendations.id, rec.recId))
-
-    rescored++
+  if (recs.length === 0) {
+    return { tool: 'rescore', rescored: 0, weightProfile: weights }
   }
 
-  return { tool: 'rescore', rescored, weightProfile: weights }
+  // Compute all new scores in memory, then flush via one UPDATE ... FROM
+  // unnest(ids, scores) per chunk instead of one UPDATE per row. unnest
+  // collapses the variadic payload to two array parameters, so Postgres'
+  // 65535 bind-param limit applies to the arrays (not row*column) and we can
+  // run large chunks without risk.
+  const updates = recs.map((rec) => ({
+    id: rec.recId,
+    score: rescoreOne(
+      rec.sources ?? {},
+      [...(rec.artistGenres ?? []), ...(rec.artistTags ?? [])],
+      libraryGenres,
+      weights,
+    ),
+  }))
+
+  const CHUNK = 5000
+  for (let i = 0; i < updates.length; i += CHUNK) {
+    const chunk = updates.slice(i, i + CHUNK)
+    const ids = chunk.map((u) => u.id)
+    const scores = chunk.map((u) => u.score)
+    await db.execute(sql`
+      UPDATE ${recommendations}
+      SET score = v.score
+      FROM unnest(${ids}::int[], ${scores}::real[]) AS v(id, score)
+      WHERE ${recommendations.id} = v.id
+    `)
+  }
+
+  return { tool: 'rescore', rescored: updates.length, weightProfile: weights }
 }
 
 // ── AI Reasoning Audit ──────────────────────────

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -12,8 +12,13 @@ const ssl =
 
 const pool = new pg.Pool({
   connectionString: buildDatabaseUrl(),
-  max: envConfig.dbPoolMax,
+  max: envConfig.dbPoolMax ?? 20,
+  idleTimeoutMillis: 30_000,
   connectionTimeoutMillis: envConfig.dbConnectTimeoutMs,
+  // Cap any single query at 30s server-side. Protects against runaway
+  // reports/hygiene scans hogging a connection. Override per-query via
+  // `SET LOCAL statement_timeout` when a longer budget is required.
+  statement_timeout: 30_000,
   ssl,
 })
 

--- a/src/db/queries/dashboard.ts
+++ b/src/db/queries/dashboard.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNotNull } from 'drizzle-orm'
+import { and, desc, eq, inArray, isNotNull, sql } from 'drizzle-orm'
 import type { Database } from '@/db'
 import {
   artists,
@@ -20,34 +20,37 @@ export async function getTopGenresForUser(
   userId: number | undefined,
   limit = 5,
 ): Promise<TasteGenre[]> {
-  const statusFilter = inArray(recommendations.status, [
-    'approved',
-    'added_to_lidarr',
-    'add_failed',
-  ])
-  const where = userId ? and(statusFilter, eq(recommendations.userId, userId)) : statusFilter
+  // Push genre tallying into Postgres. unnest() explodes each artist's genres
+  // array into rows so we can GROUP BY genre. A correlated subquery over the
+  // same CTE yields the total tag count on every returned row, letting us
+  // compute the percentage without a second roundtrip.
+  const userClause = userId ? sql`AND r.user_id = ${userId}` : sql``
+  const result = await db.execute(sql`
+    WITH tags AS (
+      SELECT unnest(a.genres) AS genre
+      FROM recommendations r
+      JOIN artists a ON a.id = r.artist_id
+      WHERE r.status IN ('approved', 'added_to_lidarr', 'add_failed')
+        AND a.genres IS NOT NULL
+        ${userClause}
+    )
+    SELECT
+      genre,
+      COUNT(*)::int AS count,
+      (SELECT COUNT(*)::int FROM tags) AS total_tags
+    FROM tags
+    GROUP BY genre
+    ORDER BY count DESC
+    LIMIT ${limit}
+  `)
 
-  const rows = await db
-    .select({ genres: artists.genres })
-    .from(recommendations)
-    .innerJoin(artists, eq(recommendations.artistId, artists.id))
-    .where(where)
-
-  const genreCounts = new Map<string, number>()
-  let totalGenreTags = 0
-  for (const row of rows) {
-    for (const genre of row.genres ?? []) {
-      genreCounts.set(genre, (genreCounts.get(genre) ?? 0) + 1)
-      totalGenreTags++
-    }
-  }
-
-  const sorted = [...genreCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, limit)
-
-  return sorted.map(([genre, count]) => ({
-    genre,
-    count,
-    percentage: totalGenreTags > 0 ? Math.round((count / totalGenreTags) * 100) : 0,
+  const rows = result.rows as Array<{ genre: string; count: number; total_tags: number }>
+  if (rows.length === 0) return []
+  const total = rows[0]?.total_tags ?? 0
+  return rows.map((row) => ({
+    genre: row.genre,
+    count: row.count,
+    percentage: total > 0 ? Math.round((row.count / total) * 100) : 0,
   }))
 }
 

--- a/src/db/queries/recommendations.ts
+++ b/src/db/queries/recommendations.ts
@@ -153,28 +153,25 @@ export async function bulkUpdateStatus(db: Database, ids: number[], status: stri
 export async function getGenreFeedbackHistory(
   db: Database,
 ): Promise<Map<string, { approved: number; total: number }>> {
-  // Query all acted-upon recommendations joined with artists
-  const rows = await db
-    .select({
-      genres: artists.genres,
-      status: recommendations.status,
-    })
-    .from(recommendations)
-    .innerJoin(artists, eq(recommendations.artistId, artists.id))
-    .where(sql`${recommendations.actedOnAt} is not null`)
+  // Pushing the per-genre tally into SQL via unnest lets Postgres do the
+  // hash-aggregate work - JS side only walks the reduced result.
+  const result = await db.execute(sql`
+    SELECT
+      genre,
+      COUNT(*)::int AS total,
+      COUNT(CASE WHEN r.status IN ('approved', 'added_to_lidarr') THEN 1 END)::int AS approved
+    FROM recommendations r
+    JOIN artists a ON a.id = r.artist_id
+    CROSS JOIN LATERAL unnest(a.genres) AS genre
+    WHERE r.acted_on_at IS NOT NULL
+      AND a.genres IS NOT NULL
+    GROUP BY genre
+  `)
 
   const genreMap = new Map<string, { approved: number; total: number }>()
-
-  for (const row of rows) {
-    if (!row.genres) continue
-    for (const genre of row.genres) {
-      const entry = genreMap.get(genre) ?? { approved: 0, total: 0 }
-      entry.total += 1
-      if (row.status === 'approved' || row.status === 'added_to_lidarr') entry.approved += 1
-      genreMap.set(genre, entry)
-    }
+  for (const row of result.rows as Array<{ genre: string; total: number; approved: number }>) {
+    genreMap.set(row.genre, { approved: row.approved, total: row.total })
   }
-
   return genreMap
 }
 
@@ -299,7 +296,9 @@ export async function getGenreArtists(
     })
     .from(recommendations)
     .innerJoin(artists, eq(recommendations.artistId, artists.id))
-    .leftJoin(artistMetadata, sql`lower(${artistMetadata.nameNormalized}) = lower(${artists.name})`)
+    // artistMetadata.nameNormalized is already lowercased at write time; the
+    // extra lower() wrapper would defeat any btree index on the column.
+    .leftJoin(artistMetadata, sql`${artistMetadata.nameNormalized} = lower(${artists.name})`)
     .where(
       and(
         genreCondition,

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,9 +177,13 @@ import { resolveUserPreferences } from './server/helpers/preferences'
 let jobRecorder: import('./core/jobs/types').JobRecorder
 
 // Initialize encryption before any DB operations.
-initEncryption(envConfig.encryptionKey)
+initEncryption(envConfig.encryptionKey, envConfig.encryptionKeyNext)
 if (isEncryptionEnabled()) {
-  console.log('Field-level encryption enabled')
+  if (envConfig.encryptionKeyNext) {
+    console.log('Field-level encryption enabled (dual-key rotation mode)')
+  } else {
+    console.log('Field-level encryption enabled')
+  }
 } else if (process.env.NODE_ENV === 'production') {
   console.warn(
     'WARNING: DIGARR_ENCRYPTION_KEY is not set - API keys and tokens are stored as plaintext in the database. Set this variable for production security.',

--- a/src/server/schemas/settings.ts
+++ b/src/server/schemas/settings.ts
@@ -1,9 +1,10 @@
 import * as z from 'zod'
 
 // Inner preferences object. Enforces numeric ranges where they exist and
-// keeps other fields permissive enough that partial merges (the normal PATCH
-// pattern) still pass. Passthrough catches any legacy key still in flight --
-// the merge in handlers is the authoritative filter.
+// keeps every field optional so partial PATCH merges stay ergonomic. Strict
+// shape (no passthrough) rejects unknown keys up front so a hostile or buggy
+// admin client cannot inflate the preferences jsonb with arbitrary garbage.
+// Every key here must stay in lockstep with Preferences in src/db/schema.ts.
 const scoringWeightsSchema = z
   .object({
     consensus: z.number().min(0).max(1).optional(),
@@ -13,7 +14,7 @@ const scoringWeightsSchema = z
     feedbackBoost: z.number().min(0).max(1).optional(),
     popularity: z.number().min(0).max(1).optional(),
   })
-  .partial()
+  .strict()
 
 const preferencesSchema = z
   .object({
@@ -39,7 +40,7 @@ const preferencesSchema = z
     fanartApiKey: z.string().optional(),
     metadataFallbackUrl: z.string().optional(),
   })
-  .passthrough()
+  .strict()
 
 // PATCH body for /api/settings. Every field optional - it's a partial update.
 // Unknown top-level keys are silently stripped (matches the existing allowlist

--- a/tests/core/crypto.test.ts
+++ b/tests/core/crypto.test.ts
@@ -97,6 +97,34 @@ describe('crypto', () => {
     })
   })
 
+  describe('dual-key rotation mode', () => {
+    it('decryptField falls back to NEXT key when primary cannot decrypt', () => {
+      initEncryption('old-key')
+      const enc = encryptField('rotated-value')
+
+      // Simulate the post-swap state: new key is primary, old key is NEXT.
+      initEncryption('new-key', 'old-key')
+      expect(decryptField(enc)).toBe('rotated-value')
+    })
+
+    it('encryptField always uses the primary key even in dual-key mode', () => {
+      initEncryption('primary-key', 'fallback-key')
+      const enc = encryptField('value') as string
+
+      // Dropping NEXT, primary alone must still decrypt what we just wrote.
+      initEncryption('primary-key')
+      expect(decryptField(enc)).toBe('value')
+    })
+
+    it('throws when neither key can decrypt', () => {
+      initEncryption('old-key')
+      const enc = encryptField('value')
+
+      initEncryption('wrong-primary', 'wrong-next')
+      expect(() => decryptField(enc)).toThrow(/Decryption failed/)
+    })
+  })
+
   describe('encryptFields / decryptFields', () => {
     it('encrypts and decrypts the named sensitive fields only', () => {
       const row = {

--- a/tests/core/library/store.test.ts
+++ b/tests/core/library/store.test.ts
@@ -548,10 +548,7 @@ describe.skipIf(!SHOULD_RUN)('LibrarySyncStore', () => {
       store.upsertLibrarySyncState(userId, PLEX_SOURCE, { lastSyncStatus: 'completed' }),
       store.upsertLibrarySyncState(userId, PLEX_SOURCE, { lastSyncStatus: 'running' }),
     ])
-    const rows = await db
-      .select()
-      .from(librarySyncState)
-      .where(eq(librarySyncState.userId, userId))
+    const rows = await db.select().from(librarySyncState).where(eq(librarySyncState.userId, userId))
     expect(rows).toHaveLength(1)
   })
 

--- a/tests/core/library/store.test.ts
+++ b/tests/core/library/store.test.ts
@@ -537,4 +537,57 @@ describe.skipIf(!SHOULD_RUN)('LibrarySyncStore', () => {
       },
     ])
   })
+
+  // Regression: check-then-write upserts could insert duplicate rows when two
+  // sync cycles overlapped. Now uses INSERT ... ON CONFLICT DO UPDATE with
+  // NULLS NOT DISTINCT so concurrent callers resolve to a single row.
+  it('upsertLibrarySyncState concurrent calls do not duplicate', async () => {
+    const store = createLibrarySyncStore(db)
+    await Promise.all([
+      store.upsertLibrarySyncState(userId, PLEX_SOURCE, { lastSyncStatus: 'running' }),
+      store.upsertLibrarySyncState(userId, PLEX_SOURCE, { lastSyncStatus: 'completed' }),
+      store.upsertLibrarySyncState(userId, PLEX_SOURCE, { lastSyncStatus: 'running' }),
+    ])
+    const rows = await db
+      .select()
+      .from(librarySyncState)
+      .where(eq(librarySyncState.userId, userId))
+    expect(rows).toHaveLength(1)
+  })
+
+  it('upsertOverride concurrent calls do not duplicate', async () => {
+    const store = createLibrarySyncStore(db)
+    await Promise.all([
+      store.upsertOverride(userId, PLEX_SOURCE, 'artist-1', 'aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+      store.upsertOverride(userId, PLEX_SOURCE, 'artist-1', 'bbbb2222-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    ])
+    const rows = await db
+      .select()
+      .from(libraryMatchOverrides)
+      .where(eq(libraryMatchOverrides.userId, userId))
+    expect(rows).toHaveLength(1)
+  })
+
+  it('upsertAlbumOverride concurrent calls do not duplicate', async () => {
+    const store = createLibrarySyncStore(db)
+    await Promise.all([
+      store.upsertAlbumOverride(
+        userId,
+        PLEX_SOURCE,
+        'album-1',
+        'aaaa1111-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      ),
+      store.upsertAlbumOverride(
+        userId,
+        PLEX_SOURCE,
+        'album-1',
+        'bbbb2222-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      ),
+    ])
+    const rows = await db
+      .select()
+      .from(libraryAlbumMatchOverrides)
+      .where(eq(libraryAlbumMatchOverrides.userId, userId))
+    expect(rows).toHaveLength(1)
+  })
 })

--- a/tests/core/ops/hygiene.test.ts
+++ b/tests/core/ops/hygiene.test.ts
@@ -122,6 +122,7 @@ describe('rescoreRecommendations', () => {
           where: vi.fn().mockResolvedValue({ rowCount: 1 }),
         }),
       }),
+      execute: vi.fn().mockResolvedValue({ rowCount: 1 }),
     }
 
     const weights = {

--- a/tests/db/queries/recommendations.test.ts
+++ b/tests/db/queries/recommendations.test.ts
@@ -47,15 +47,27 @@ function collectParamValues(node: unknown): unknown[] {
   return values
 }
 
+// Aggregation moved into SQL (unnest + GROUP BY), so the unit tests now mock
+// pre-aggregated execute() rows. The SQL correctness is covered by the
+// integration tests that run against Postgres.
+function makeExecuteMock(rows: unknown[]): Database {
+  return {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    transaction: vi.fn(),
+    execute: vi.fn().mockResolvedValue({ rows }),
+  } as unknown as Database
+}
+
 describe('getGenreFeedbackHistory', () => {
   it('returns correct approved/total counts per genre', async () => {
-    const rows = [
-      { genres: ['rock', 'metal'], status: 'approved' },
-      { genres: ['rock'], status: 'rejected' },
-      { genres: ['jazz'], status: 'approved' },
-      { genres: ['metal'], status: 'approved' },
-    ]
-    const db = makeMockDb(rows)
+    const db = makeExecuteMock([
+      { genre: 'rock', total: 2, approved: 1 },
+      { genre: 'metal', total: 2, approved: 2 },
+      { genre: 'jazz', total: 1, approved: 1 },
+    ])
 
     const result = await getGenreFeedbackHistory(db)
 
@@ -65,20 +77,9 @@ describe('getGenreFeedbackHistory', () => {
   })
 
   it('returns empty map when no acted-upon recommendations', async () => {
-    const db = makeMockDb([])
+    const db = makeExecuteMock([])
     const result = await getGenreFeedbackHistory(db)
     expect(result.size).toBe(0)
-  })
-
-  it('skips rows with null genres', async () => {
-    const rows = [
-      { genres: null, status: 'approved' },
-      { genres: ['pop'], status: 'approved' },
-    ]
-    const db = makeMockDb(rows)
-    const result = await getGenreFeedbackHistory(db)
-    expect(result.size).toBe(1)
-    expect(result.get('pop')).toEqual({ approved: 1, total: 1 })
   })
 })
 


### PR DESCRIPTION
## Summary

Phase 4 of the deep audit lands eight subphase commits addressing 11 database-layer findings, bumping through `v0.31.0` -> `v0.31.7`. Each commit corresponds to a discrete subphase (4a-4h) with its own `package.json` bump for rollback precision.

### Subphases

| Ver | Task(s) | Change |
|-----|---------|--------|
| 0.31.0 | 4.1 | Add 6 missing FK indexes (genres, recommendation_batches, job_runs x2, slskd_jobs x2). Plain `CREATE INDEX IF NOT EXISTS` because drizzle-orm's runtime migrator wraps the batch in a transaction and `CONCURRENTLY` is incompatible. Single-process deploy model makes brief lock acceptable. |
| 0.31.1 | 4.2 | `pg.Pool` defaults: `max=20`, `idleTimeoutMillis=30s`, server-side `statement_timeout=30s`. |
| 0.31.2 | 4.3 | Rewrote three check-then-write upserts (`upsertLibrarySyncState`, `upsertOverride`, `upsertAlbumOverride`) as atomic `INSERT ... ON CONFLICT DO UPDATE`. Migrated the three natural-key unique indexes to `NULLS NOT DISTINCT` so conflict matching works for nullable `user_id`. Added regression tests firing concurrent upserts. |
| 0.31.3 | 4.4 | Batched N+1 loops in `backup.ts` restore (per-row ON CONFLICT -> chunked insert with `excluded.*` set clause) and `hygiene.ts` rebuildGenres / rescoreRecommendations (latter uses `UPDATE ... FROM unnest(ids, scores)` for parameter-efficient bulk updates). |
| 0.31.4 | 4.5, 4.6 | Dropped redundant `lower(nameNormalized)` in `getGenreArtists` (column is pre-normalized). Pushed `getTopGenresForUser` + `getGenreFeedbackHistory` aggregations into SQL via `unnest` + `GROUP BY`. |
| 0.31.5 | 4.10, 4.11 | Replaced `preferencesSchema.passthrough()` with `.strict()` (blocks arbitrary-key inflation). Flagged `settings.preferences.fanartApiKey` in `ENCRYPTED_FIELD_MAP` for backup key-mismatch detection. |
| 0.31.6 | 4.8, 4.9 | 4.8 skipped - existing `recommendations_user_status_score_idx` already covers that query pattern. 4.9 adds GIN indexes on `artists.genres` and `artists.tags`. |
| 0.31.7 | 4.7 | `DIGARR_ENCRYPTION_KEY_NEXT` dual-key rotation mode + `scripts/rotate-encryption-key.ts` re-encryption tool + `docs/runbooks/encryption-key-rotation.md` 3-deploy runbook with verification and rollback. Smoke-tested end-to-end. |

### Migrations added

- `0027_fk_indexes.sql`
- `0028_library_natural_keys_nulls_not_distinct.sql`
- `0029_artists_gin_indexes.sql`

### Plan-vs-reality deviations (for reviewer awareness)

- Plan specified `CREATE INDEX CONCURRENTLY`; drizzle-orm's migrator wraps the batch in a transaction so CONCURRENTLY is impossible. Dropped to plain `IF NOT EXISTS` because the single-process deploy model already implies brief downtime. `breakpoints: true` splits statements but does not remove the outer transaction.
- Plan's Task 2 snippet used `postgres.js`; codebase uses `pg.Pool`. Adapted to pg's option names (`max`, `idleTimeoutMillis`, `statement_timeout`).
- Plan's Task 3 step 3 was optional (unique constraints check). Constraints existed but used default `NULLS DISTINCT`; since `userId` is nullable, ON CONFLICT would not match shared-cursor rows - added `NULLS NOT DISTINCT` migration.
- Plan's Task 8 original runbook self-identified a bug in step 3 ordering; shipped the corrected 3-deploy procedure only.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] `bun run test` green (1927 passed / 25 skipped) in CI-matching env (`DATABASE_URL` unset)
- [x] `bun run db:migrate` applies cleanly to a fresh DB (all 3 new migrations)
- [x] Upsert race tests exercise the new ON CONFLICT paths
- [x] Rotation script smoke-tested: plant -> rotate -> verify with primary only
- [x] `getTopGenresForUser` spot-check against populated DB returns expected shape
- [ ] CI green on both GitHub and Forgejo

## Audit mark-off

`4.1 - 4.11` all ticked. Phase 4 complete.

See `docs/local/plans/2026-04-17-audit-phase-04-database.md` for the source plan.