### PR TITLE
audit(phase-7): Docker hardening, BuildKit cache, secrets migration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ dist/
 .forgejo/
 docs/
 deploy/
+!deploy/docker/healthcheck.sh
 CLAUDE.md
 AGENTS.md
 SECURITY-AUDIT.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,14 @@ SECURITY-AUDIT.md
 .worktrees/
 *.md
 !README.md
+tests/
+.planning/
+docs/local/
+backups/
+playwright.config.ts
+mempalace.yaml
+entities.json
+coverage/
+.vitest-cache/
+*.tsbuildinfo
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ docs/local/
 .planning/
 mempalace.yaml
 entities.json
+
+# Compose secrets -- example files tracked, real values ignored
+deploy/docker/secrets/*
+!deploy/docker/secrets/*.example

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -14,6 +14,13 @@ RUN bun run build
 
 # Runtime stage -- override RUNTIME_IMAGE for alpine variant
 FROM ${RUNTIME_IMAGE}
+
+LABEL org.opencontainers.image.source="https://github.com/iuliandita/digarr"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.title="digarr"
+LABEL org.opencontainers.image.description="Music discovery and recommendation pipeline"
+LABEL org.opencontainers.image.vendor="iuliandita"
+
 WORKDIR /app
 
 # Non-root user (bun base image ships with bun:bun at UID/GID 1000)
@@ -24,6 +31,9 @@ RUN bun install --frozen-lockfile --production \
 
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/drizzle ./drizzle
+
+RUN mkdir -p /app/backups && chown bun:bun /app/backups
+VOLUME ["/app/backups"]
 
 ENV NODE_ENV=production
 ENV PORT=3000

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,18 +1,31 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
 
 # Global ARG -- must be before any FROM to use in FROM instructions
 ARG RUNTIME_IMAGE=oven/bun:1.3.12-slim@sha256:d3c7094c144dd3975d183a4dbc4ec0a764223995bff73290d983edb47043a75f
 
-# Build stage -- always Debian for consistent toolchain
-FROM oven/bun:1.3.12@sha256:8956c7667fa17beb6e3c664115e66bdacfe502da5d99603626e74c197bdef160 AS builder
+# Deps stage -- all deps (dev + prod) for the builder. Cache-mount accelerates rebuilds.
+FROM oven/bun:1.3.12@sha256:8956c7667fa17beb6e3c664115e66bdacfe502da5d99603626e74c197bdef160 AS deps
 WORKDIR /app
 COPY package.json bun.lock* ./
-RUN bun install --frozen-lockfile
+RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \
+    bun install --frozen-lockfile
+
+# Build stage -- reuses deps, produces dist/.
+FROM oven/bun:1.3.12@sha256:8956c7667fa17beb6e3c664115e66bdacfe502da5d99603626e74c197bdef160 AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NODE_ENV=production
 RUN bun run build
 
-# Runtime stage -- override RUNTIME_IMAGE for alpine variant
+# Deps-prod stage -- production-only deps, shared cache id.
+FROM oven/bun:1.3.12@sha256:8956c7667fa17beb6e3c664115e66bdacfe502da5d99603626e74c197bdef160 AS deps-prod
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \
+    bun install --frozen-lockfile --production
+
+# Runtime stage -- override RUNTIME_IMAGE for alpine variant.
 FROM ${RUNTIME_IMAGE}
 
 LABEL org.opencontainers.image.source="https://github.com/iuliandita/digarr"
@@ -25,10 +38,8 @@ WORKDIR /app
 
 # Non-root user (bun base image ships with bun:bun at UID/GID 1000)
 
-COPY package.json bun.lock* ./
-RUN bun install --frozen-lockfile --production \
-    && rm -rf /tmp/* /home/bun/.bun/install/cache
-
+COPY --from=deps-prod /app/package.json /app/bun.lock ./
+COPY --from=deps-prod /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/drizzle ./drizzle
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -42,6 +42,8 @@ COPY --from=deps-prod /app/package.json /app/bun.lock ./
 COPY --from=deps-prod /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/drizzle ./drizzle
+COPY deploy/docker/healthcheck.sh /app/healthcheck.sh
+RUN chmod +x /app/healthcheck.sh
 
 RUN mkdir -p /app/backups && chown bun:bun /app/backups
 VOLUME ["/app/backups"]
@@ -50,8 +52,8 @@ ENV NODE_ENV=production
 ENV PORT=3000
 EXPOSE 3000
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
-  CMD bun -e "fetch('http://localhost:3000/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD ["/app/healthcheck.sh"]
 
 USER bun
 CMD ["bun", "dist/server/index.js"]

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,0 +1,42 @@
+# Docker deployment
+
+This directory contains the Docker Compose stack for running Digarr in
+production or local development.
+
+## Production
+
+```
+cd deploy/docker
+cp secrets/postgres_password.example secrets/postgres_password
+cp secrets/database_url.example      secrets/database_url
+# edit both files with real values
+docker compose up -d
+```
+
+Services run on an isolated internal `backend` network; only `app` is exposed
+on the host via `frontend`. Pull the image at a specific tag or swap in the
+alpine variant by editing `docker-compose.yml`.
+
+## Development with compose
+
+Start dev stack (builds image from local source, exposes postgres on the host):
+
+```
+docker compose \
+  -f deploy/docker/docker-compose.yml \
+  -f deploy/docker/docker-compose.dev.yml up
+```
+
+The dev override is additive -- only keys that differ from production are
+defined there (build context, postgres port publish). Everything else
+(secrets, networks, healthchecks, resource limits) comes from the base file.
+
+## Secrets
+
+Both compose files use the `_FILE` env convention. The app reads
+`DATABASE_URL_FILE`; Postgres reads `POSTGRES_PASSWORD_FILE`. See
+`secrets/*.example` for the expected format.
+
+If you need env-var-only deployment (e.g. platforms without Compose secrets),
+set `DATABASE_URL` and `DB_PASS` directly in `.env` -- the app falls back to
+direct env vars when the `_FILE` variant is unset.

--- a/deploy/docker/docker-compose.dev.yml
+++ b/deploy/docker/docker-compose.dev.yml
@@ -1,38 +1,20 @@
+# Dev override -- additive layer on top of docker-compose.yml.
+# Only keys that differ from production live here.
+#
+# Usage:
+#   docker compose -f deploy/docker/docker-compose.yml \
+#                  -f deploy/docker/docker-compose.dev.yml up
+#
+# Prerequisites (one-time):
+#   cp deploy/docker/secrets/postgres_password.example deploy/docker/secrets/postgres_password
+#   cp deploy/docker/secrets/database_url.example      deploy/docker/secrets/database_url
+
 services:
   app:
     build:
       context: ../..
       dockerfile: deploy/docker/Dockerfile
-    env_file:
-      - path: .env
-        required: false
-    environment:
-      - DATABASE_URL=postgresql://${DB_USER:-digarr}:${DB_PASS:?DB_PASS is required -- set it in .env}@postgres:5432/${DB_NAME:-digarr}
-      - PORT=3000
-    ports:
-      - "${PORT:-3000}:3000"
-    depends_on:
-      postgres:
-        condition: service_healthy
-    restart: unless-stopped
 
   postgres:
-    image: postgres:17-alpine
-    env_file:
-      - path: .env
-        required: false
-    environment:
-      - POSTGRES_USER=${DB_USER:-digarr}
-      - POSTGRES_PASSWORD=${DB_PASS:?DB_PASS is required -- set it in .env}
-      - POSTGRES_DB=${DB_NAME:-digarr}
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-digarr}"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-    restart: unless-stopped
-
-volumes:
-  pgdata:
+    ports:
+      - "5432:5432"

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -3,19 +3,28 @@
 #   volumes:
 #     - pgdata:/var/lib/postgresql/data:Z
 
+secrets:
+  postgres_password:
+    file: ./secrets/postgres_password
+  database_url:
+    file: ./secrets/database_url
+
 services:
   app:
-    image: docker.io/iuliandita/digarr:0.32
+    image: docker.io/iuliandita/digarr:0.34
     # Pin to a patch version for full stability:
-    # image: docker.io/iuliandita/digarr:0.32.3
+    # image: docker.io/iuliandita/digarr:0.34.4
     # Alpine variant (smaller image, musl libc):
-    # image: docker.io/iuliandita/digarr:0.32.3-alpine
+    # image: docker.io/iuliandita/digarr:0.34.4-alpine
+    user: "1000:1000"
     env_file:
       - path: .env
         required: false
     environment:
-      - DATABASE_URL=postgresql://${DB_USER:-digarr}:${DB_PASS:?DB_PASS is required -- set it in .env}@postgres:5432/${DB_NAME:-digarr}
       - PORT=3000
+      - DATABASE_URL_FILE=/run/secrets/database_url
+    secrets:
+      - database_url
     ports:
       - "${PORT:-3000}:3000"
     depends_on:
@@ -53,14 +62,16 @@ services:
     restart: unless-stopped
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:17-alpine@sha256:6f30057d31f5861b66f3545d4821f987aacf1dd920765f0acadea0c58ff975b1
     env_file:
       - path: .env
         required: false
     environment:
       - POSTGRES_USER=${DB_USER:-digarr}
-      - POSTGRES_PASSWORD=${DB_PASS:?DB_PASS is required -- set it in .env}
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
       - POSTGRES_DB=${DB_NAME:-digarr}
+    secrets:
+      - postgres_password
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -9,6 +9,11 @@ secrets:
   database_url:
     file: ./secrets/database_url
 
+networks:
+  frontend:
+  backend:
+    internal: true
+
 services:
   app:
     image: docker.io/iuliandita/digarr:0.34
@@ -17,6 +22,9 @@ services:
     # Alpine variant (smaller image, musl libc):
     # image: docker.io/iuliandita/digarr:0.34.4-alpine
     user: "1000:1000"
+    networks:
+      - frontend
+      - backend
     env_file:
       - path: .env
         required: false
@@ -31,14 +39,10 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          'bun -e "fetch(''http://localhost:3000/health'').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"',
-        ]
+      test: ["CMD", "/app/healthcheck.sh"]
       interval: 30s
       timeout: 5s
-      start_period: 15s
+      start_period: 30s
       retries: 3
     read_only: true
     volumes:
@@ -63,6 +67,8 @@ services:
 
   postgres:
     image: postgres:17-alpine@sha256:6f30057d31f5861b66f3545d4821f987aacf1dd920765f0acadea0c58ff975b1
+    networks:
+      - backend
     env_file:
       - path: .env
         required: false

--- a/deploy/docker/healthcheck.sh
+++ b/deploy/docker/healthcheck.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Shared container healthcheck -- invoked by both Dockerfile HEALTHCHECK and
+# compose `healthcheck.test`. Uses bun (always present in the runtime image)
+# so the same script works on slim (Debian, no wget/curl) and alpine (musl).
+set -eu
+PORT="${PORT:-3000}"
+exec bun -e "fetch('http://localhost:${PORT}/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"

--- a/deploy/docker/secrets/database_url.example
+++ b/deploy/docker/secrets/database_url.example
@@ -1,0 +1,1 @@
+postgres://digarr:changeme@postgres:5432/digarr

--- a/deploy/docker/secrets/postgres_password.example
+++ b/deploy/docker/secrets/postgres_password.example
@@ -1,0 +1,1 @@
+changeme

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.33.6",
+  "version": "0.34.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,8 +1,26 @@
+import { readFileSync } from 'node:fs'
 import { assertCidr } from '@/core/auth/cidr'
 
 function env(key: string): string | undefined {
   const val = process.env[key]
   return val || undefined
+}
+
+/**
+ * Read an env var, falling back to the file referenced by `${key}_FILE`.
+ * Enables the Docker / Compose secrets convention without forcing users to
+ * inline sensitive values in shell env. Returns undefined if both miss.
+ */
+function envOrFile(key: string): string | undefined {
+  const direct = env(key)
+  if (direct) return direct
+  const filePath = env(`${key}_FILE`)
+  if (!filePath) return undefined
+  try {
+    return readFileSync(filePath, 'utf8').trim() || undefined
+  } catch {
+    return undefined
+  }
 }
 
 function envBool(key: string, fallback = false): boolean {
@@ -31,11 +49,11 @@ const DB_SSL_MODES = ['disable', 'require', 'no-verify'] as const
 
 export const envConfig = {
   // Database
-  databaseUrl: env('DATABASE_URL'),
+  databaseUrl: envOrFile('DATABASE_URL'),
   dbHost: env('DB_HOST'),
   dbPort: envInt('DB_PORT'),
   dbUser: env('DB_USER'),
-  dbPass: env('DB_PASS'),
+  dbPass: envOrFile('DB_PASS'),
   dbName: env('DB_NAME'),
   dbPoolMax: envInt('DB_POOL_MAX'),
   dbConnectTimeoutMs: envInt('DB_CONNECT_TIMEOUT_MS'),


### PR DESCRIPTION
## Summary
Phase 7 of the deep-audit plan — Docker / OCI hardening. Five subphases committed one-per-version from v0.34.0 → v0.34.4.

- **7a** `chore(docker): backups volume, OCI labels, expanded dockerignore` — declares `/app/backups` VOLUME, bakes `org.opencontainers.image.*` labels into the Dockerfile, expands `.dockerignore` to exclude tests, planning, coverage, and other build-context noise.
- **7b** `perf(docker): BuildKit cache mount and dep dedup between stages` — splits into 4 stages (deps, builder, deps-prod, runtime) with `--mount=type=cache,target=/root/.bun/install/cache`. Rebuilds hit cache, second build is instant.
- **7c** `chore(docker): pin Postgres digest and migrate to secrets` — compose now pins `postgres:17-alpine@sha256:6f30057d…` (matches Forgejo CI pin), adds explicit `user: "1000:1000"` on app, migrates `POSTGRES_PASSWORD` / `DATABASE_URL` to Compose secrets with `_FILE` convention. `src/config/env.ts` gains `envOrFile()` helper so the app transparently reads either env vars or `${KEY}_FILE` paths.
- **7d** `chore(docker): network split, healthcheck alignment, shared healthcheck script` — splits `frontend` / `backend(internal: true)` networks (postgres backend-only); extracts healthcheck to `deploy/docker/healthcheck.sh` (uses `bun -e` since slim has no wget/curl); aligns Dockerfile + compose healthcheck params (`--start-period=30s`, `--retries=3`).
- **7e** `chore(docker): fold dev compose into additive override` — strips redundant keys from `docker-compose.dev.yml`, leaving only `build:` and postgres port publish. Adds `deploy/docker/README.md` documenting the secrets flow and dev override usage.

Audit tasks ticked: 7.1 – 7.11.

## Verification
- `bun run lint`, `typecheck`, `test` green (1929 passed, 25 skipped)
- `hadolint deploy/docker/Dockerfile` clean
- `docker build` + `docker compose config` succeed with new structure
- `docker compose up -d` smoke test: both services report healthy, network split verified (`docker_backend` internal=true, `docker_frontend` internal=false)
- `trivy image --severity HIGH,CRITICAL`: parity with v0.33.6 (CVE-2025-69720, CVE-2026-28390, CVE-2026-29111 — all in base debian-slim, no new findings)

## Test Plan
- [ ] CI (lint/typecheck/test/api-route/browser) green on both Forgejo and GitHub
- [ ] Release workflow produces v0.34.4 image with new labels visible in `docker image inspect`
- [ ] Compose smoke on a clean host with only the `.example` secrets copied