### PR TITLE
audit(phase-8): CI hardening, permissions, concurrency, CODEOWNERS

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -9,9 +9,35 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened]
 
 jobs:
+  # Fail-closed gate for fork PRs. The primary control is the Forgejo repo
+  # setting "Require approval for first-time contributors"; this job is
+  # defense-in-depth + visibly logged. Step-level `if:` ensures the job runs
+  # trivially on push events so downstream `needs: guard` chains cleanly.
+  guard:
+    runs-on: docker
+    # Reuse the pinned bun image already warm on the runner cache -- cheap and
+    # avoids juggling an extra digest in the mirror policy comment.
+    container:
+      image: oven/bun:1.3.12@sha256:8956c7667fa17beb6e3c664115e66bdacfe502da5d99603626e74c197bdef160
+    steps:
+      - name: Reject fork PRs until approved
+        if: github.event_name == 'pull_request'
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          if [ "$HEAD_REPO" != "$REPO" ]; then
+            echo "Fork PR from $HEAD_REPO - CI blocked."
+            echo "Fork runs must be approved in Forgejo repo settings."
+            exit 1
+          fi
+
   lint-typecheck-test:
+    needs: guard
     runs-on: docker
     container:
       image: oven/bun:1.3.12@sha256:8956c7667fa17beb6e3c664115e66bdacfe502da5d99603626e74c197bdef160
@@ -74,6 +100,7 @@ jobs:
           DATABASE_URL: postgresql://test:test@postgres:5432/digarr_test
 
   helm-drift:
+    needs: guard
     runs-on: docker
     container:
       image: oven/bun:1.3.12@sha256:8956c7667fa17beb6e3c664115e66bdacfe502da5d99603626e74c197bdef160

--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       image: oven/bun:1.3.12@sha256:8956c7667fa17beb6e3c664115e66bdacfe502da5d99603626e74c197bdef160
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git > /dev/null
+        run: apt-get update -qq && apt-get install -y -qq git > /dev/null && rm -rf /var/lib/apt/lists/*
       # mirror: .github/workflows/ci.yml `lint-typecheck-test` -> actions/checkout
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -61,7 +61,7 @@ jobs:
     needs: lint-typecheck-test
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git > /dev/null
+        run: apt-get update -qq && apt-get install -y -qq git > /dev/null && rm -rf /var/lib/apt/lists/*
       # mirror: .github/workflows/ci.yml `build` -> actions/checkout
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -88,7 +88,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git > /dev/null
+        run: apt-get update -qq && apt-get install -y -qq git > /dev/null && rm -rf /var/lib/apt/lists/*
       # mirror: .github/workflows/ci.yml `api-route-test` -> actions/checkout
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -109,7 +109,7 @@ jobs:
       HELM_SHA256: fc307327959aa38ed8f9f7e66d45492bb022a66c3e5da6063958254b9767d179
     steps:
       - name: Install git and curl
-        run: apt-get update -qq && apt-get install -y -qq git curl ca-certificates > /dev/null
+        run: apt-get update -qq && apt-get install -y -qq git curl ca-certificates > /dev/null && rm -rf /var/lib/apt/lists/*
       - name: Install Helm
         run: |
           set -euo pipefail
@@ -151,7 +151,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git > /dev/null
+        run: apt-get update -qq && apt-get install -y -qq git > /dev/null && rm -rf /var/lib/apt/lists/*
       # mirror: .github/workflows/ci.yml `browser-test` -> actions/checkout
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owner for everything in the repo. Picked up by GitHub for
+# automatic review requests and by protected-branch rules that require
+# CODEOWNERS approval.
+* @iuliandita

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -9,6 +9,9 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: compat-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -6,8 +6,9 @@ name: Dependabot bun.lock sync
 #
 # Security: pull_request_target runs with write token from the base repo.
 # Guarded to only run on dependabot[bot] PRs from the same repo (never forks).
-# Bun does not execute lifecycle scripts by default, so running `bun install`
-# on PR-supplied package.json is safe without --ignore-scripts.
+# Bun does not execute lifecycle scripts by default today, but we pass
+# --ignore-scripts as defense-in-depth so this stays safe if bun flips the
+# default or introduces new install-time hooks.
 #
 # Re-triggering CI: pushing with GITHUB_TOKEN does NOT fire new workflow runs,
 # so auto-merge would stall. Set repo secret DEPENDABOT_SYNC_TOKEN to a
@@ -43,7 +44,7 @@ jobs:
           bun-version: "1.3.12"
 
       - name: Regenerate bun.lock
-        run: bun install
+        run: bun install --ignore-scripts
 
       - name: Commit and push if changed
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,12 @@ jobs:
           TAG: ${{ steps.tag.outputs.value }}
           REPO: ${{ github.repository }}
         run: |
-          gh release create "$TAG" --repo "$REPO" --title "$TAG" --generate-notes 2>/dev/null || true
+          set -euo pipefail
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "release $TAG already exists; skipping create"
+          else
+            gh release create "$TAG" --repo "$REPO" --title "$TAG" --generate-notes
+          fi
           gh release upload "$TAG" sbom-container.spdx.json sbom-source.spdx.json --clobber
 
   verify-digest-sync:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ on:
         description: "Tag to release (e.g. v0.12.13)"
         required: true
 
+# Workflow baseline is read-only. Jobs that need more (docker) escalate per-job.
+permissions:
+  contents: read
+
+# Serialize releases on the same ref; never cancel a release mid-flight.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,10 +29,16 @@ jobs:
           restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - name: Dependency audit
+        # Structured JSON output + jq filter avoids the fragile grep that would
+        # match 'high'/'critical' anywhere in the text (e.g. inside package
+        # names or advisory titles).
         run: |
-          output=$(bun audit 2>&1) || true
-          echo "$output"
-          if echo "$output" | grep -qi "high\|critical"; then
+          set -euo pipefail
+          report=$(bun audit --json 2>/dev/null || true)
+          echo "$report"
+          count=$(printf '%s' "$report" | jq '[.vulnerabilities[]? | select(.severity == "high" or .severity == "critical")] | length')
+          echo "High/critical vulnerabilities: $count"
+          if [ "$count" -gt 0 ]; then
             echo "::error::High or critical vulnerabilities found"
             exit 1
           fi
@@ -51,7 +57,9 @@ jobs:
           severity: HIGH,CRITICAL
           format: sarif
           output: trivy-fs.sarif
-          exit-code: "1"
+          # advisory-only: findings surface in code scanning (SARIF upload).
+          # Revisit once we have a baseline + `.trivyignore` with dated entries.
+          exit-code: "0"
           # Pin binary version; v0.69.4-v0.69.6 contained credential-stealing malware (CVE-2026-33634)
           trivy-version: "0.69.3"
       - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -206,7 +206,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:7fe81a93dedc27d73e0e4f3710be88c72b7bbd6a01c9d958f3ba1e9d35871d98"
+          image: "ghcr.io/iuliandita/digarr@sha256:cdc684ae7fd6f8e0c126fb4f745484c728bf39fdff32f4bc6685003605f99fff"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.34.4",
+  "version": "0.35.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Phase 8 of the deep-audit closes the CI/CD gaps.

- **v0.35.0** -- Replace fragile `bun audit` grep with a `jq` filter over `bun audit --json`; demote `trivy-fs` to advisory (`exit-code: "0"`) so findings still land in code scanning without blocking until a dated `.trivyignore` baseline exists.
- **v0.35.1** -- Top-level `permissions: contents: read` and `concurrency: { group: release-<ref>, cancel-in-progress: false }` on `release.yml`; `contents: read` on `compatibility.yml`.
- **v0.35.2** -- Forgejo CI `guard` job fails closed on fork PRs; `lint-typecheck-test` and `helm-drift` chain through it so the rest follow transitively. Dependabot lockfile regen now runs `bun install --ignore-scripts` as defense-in-depth.
- **v0.35.3** -- `.github/CODEOWNERS` defaults to `@iuliandita`; release workflow probes with `gh release view` before calling `gh release create` so real failures surface; every Forgejo `apt-get install` appends `rm -rf /var/lib/apt/lists/*`.

Auto-ticks audit task 13.19 (CODEOWNERS).

## Manual follow-up required

The workflow-level fork guard is defense-in-depth; the primary control is the Forgejo repo setting **Require approval for first-time contributors** -- verify it's enabled on `git.ditas.cc/ditas.cc/digarr` settings before relying on this.

## Test Plan

- [x] `bun run lint`, `bun run typecheck`, `bun run test` green after each subphase
- [x] `yamllint` clean on every touched workflow
- [ ] GitHub Actions CI green on this PR
- [ ] Forgejo CI green on this PR