### PR TITLE
audit(phase-9): API hygiene, problem+json, SSE, OpenAPI, 404-hide

### DIFF
--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: digarr
 type: application
 description: Music discovery and recommendation pipeline for Lidarr, Plex, Jellyfin, Emby, and Navidrome.
-version: 0.35.3
-appVersion: "0.35.3"
+version: 0.36.6
+appVersion: "0.36.6"
 kubeVersion: ">=1.29.0"
 sources:
   - https://github.com/iuliandita/digarr

--- a/deploy/helm/digarr/Chart.yaml
+++ b/deploy/helm/digarr/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: digarr
 type: application
 description: Music discovery and recommendation pipeline for Lidarr, Plex, Jellyfin, Emby, and Navidrome.
-version: 0.36.6
-appVersion: "0.36.6"
+version: 0.35.3
+appVersion: "0.35.3"
 kubeVersion: ">=1.29.0"
 sources:
   - https://github.com/iuliandita/digarr

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,9 +2,9 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.36.6"
+  tag: "0.35.3"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
-  digest: ""
+  digest: "sha256:876565322c44bc14a8c2542900ab28c1ce6f95b0b685cbc9241e29ddb2c3a277"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -2,9 +2,9 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/iuliandita/digarr
-  tag: "0.35.3"
+  tag: "0.36.6"
   # Pin the digest after publishing the release image. The digest comes from the published registry artifact.
-  digest: "sha256:876565322c44bc14a8c2542900ab28c1ce6f95b0b685cbc9241e29ddb2c3a277"
+  digest: ""
   pullPolicy: Always
 
 podSecurityContext:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.36.2",
+  "version": "0.36.3",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.36.5",
+  "version": "0.36.6",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.35.3",
+  "version": "0.36.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digarr",
-  "version": "0.36.4",
+  "version": "0.36.5",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -1,0 +1,241 @@
+// Per-domain slices of the old AppDependencies bag. Route files that only
+// consume a subset can now import the narrower slice they need so their
+// tests can mock less scaffolding. The full AppDependencies type in
+// src/server/index.ts is an intersection of all slices and stays
+// structurally compatible - existing callers do not need to change.
+
+import type { OidcService } from '@/core/auth/oidc'
+import type { DiscoveryModeRegistry } from '@/core/discovery-modes/registry'
+import type { DiscoveryModeRequest } from '@/core/discovery-modes/request'
+import type { GenreService } from '@/core/genre/service'
+import type { SupportedLocale } from '@/core/i18n/locales'
+import type { AlbumCoverage } from '@/core/library/album-coverage'
+import type { LibraryHealthService } from '@/core/library/health'
+import type { SkyHookWarmer } from '@/core/library/skyhook-warmer'
+import type { LibrarySyncStore } from '@/core/library/store'
+import type { SyncOrchestrator } from '@/core/library/sync'
+import type { PipelineOrchestrator } from '@/core/pipeline/orchestrator'
+import type { SubscriptionScheduler } from '@/core/pipeline/subscription-scheduler'
+import type { AiProviderRegistry } from '@/core/providers/registry'
+import type { ServiceTestResult } from '@/core/types'
+import type { ArtistRow } from '@/db/queries/artists'
+import type { BatchRow } from '@/db/queries/batches'
+import type { ActivityEntry, TasteGenre } from '@/db/queries/dashboard'
+import type {
+  ListRecommendationsFilters,
+  ListRecommendationsResult,
+  RecommendationWithArtist,
+  StatusUpdateExtra,
+} from '@/db/queries/recommendations'
+import type { SettingsRow, SetupConfig } from '@/db/queries/settings'
+import type { SubscriptionInsert, SubscriptionUpdate } from '@/db/queries/subscriptions'
+import type { subscriptions } from '@/db/schema'
+
+type SubscriptionRow = typeof subscriptions.$inferSelect
+
+import type { TargetInsert, TargetRow, TargetUpdate } from '@/db/queries/targets'
+import type { UserPublic } from '@/db/queries/users'
+import type { PlaylistDeps } from './routes/playlists'
+import type { SearchDeps } from './routes/search'
+import type { DiscoveryConnectionSnapshot } from './types'
+
+// ---- DB / storage ----
+
+export interface DbDeps {
+  db: import('@/db').Database
+  storeDb: import('@/core/pipeline/store').StoreDb
+}
+
+// ---- Settings / setup ----
+
+export interface SettingsDeps {
+  isSetupComplete: () => Promise<boolean>
+  getSettings: () => Promise<SettingsRow | null>
+  updateSettings: (partial: Record<string, unknown>) => Promise<void>
+  completeSetup: (config: SetupConfig) => Promise<unknown>
+}
+
+// ---- Users / auth ----
+
+export interface UserDeps {
+  createUser: (data: {
+    username: string
+    passwordHash: string
+    isAdmin?: boolean
+  }) => Promise<UserPublic>
+  getUserByUsername: (
+    username: string,
+  ) => Promise<{ id: number; username: string; passwordHash: string; isAdmin: boolean } | null>
+  getUserById: (id: number) => Promise<UserPublic | null>
+  getUserCount: () => Promise<number>
+  updatePassword: (id: number, passwordHash: string) => Promise<void>
+  updateUserPreferredLocale: (id: number, preferredLocale: SupportedLocale | null) => Promise<void>
+  getOidcService: () => Promise<OidcService | null>
+  getUserByOidcSubject: (subject: string) => Promise<{ id: number; username: string } | null>
+  getUserByEmail: (email: string) => Promise<{ id: number; username: string } | null>
+  updateUser: (
+    id: number,
+    data: { isAdmin?: boolean; email?: string; oidcSubject?: string },
+  ) => Promise<void>
+  listUsers: () => Promise<UserPublic[]>
+  deleteUser: (id: number) => Promise<void>
+}
+
+// ---- Pipeline / scheduler / jobs ----
+
+export interface PipelineDeps {
+  orchestrator: PipelineOrchestrator
+  scheduler: SubscriptionScheduler
+  providerRegistry: AiProviderRegistry
+  getLastBatch: () => Promise<{ id: number; createdAt: Date | string; status: string } | null>
+  restartScheduler: (cron: string | null) => void
+  restartPlaylistScheduler: () => Promise<void>
+  restartLibraryMaintenanceScheduler?: (intervalHours: number) => void
+}
+
+export interface JobDeps {
+  jobRecorder: import('@/core/jobs/types').JobRecorder
+  jobQueries: {
+    listJobs: (
+      filters?: import('@/db/queries/jobs').ListJobsFilters,
+    ) => Promise<{ items: import('@/core/jobs/types').JobRunRow[]; total: number }>
+    getJobById: (id: number) => Promise<import('@/core/jobs/types').JobRunRow | null>
+    getJobHealth: (nextRun: Date | null) => Promise<import('@/db/queries/jobs').HealthSummary>
+    getJobsForSubscription: (
+      subId: number,
+      limit?: number,
+    ) => Promise<import('@/core/jobs/types').JobRunRow[]>
+  }
+}
+
+// ---- Recommendations / batches / artists ----
+
+export interface RecommendationDeps {
+  listRecommendations: (filters?: ListRecommendationsFilters) => Promise<ListRecommendationsResult>
+  getRecommendation: (id: number) => Promise<RecommendationWithArtist | null>
+  updateRecommendationStatus: (
+    id: number,
+    status: string,
+    extra?: StatusUpdateExtra,
+  ) => Promise<void>
+  bulkUpdateStatus: (ids: number[], status: string) => Promise<void>
+  filterOwnedIds: (ids: number[], userId: number | undefined) => Promise<number[]>
+  listBatches: () => Promise<BatchRow[]>
+  getBatch: (id: number) => Promise<BatchRow | null>
+  getArtistById: (id: number) => Promise<ArtistRow | null>
+  getFeedbackHistory: () => Promise<Map<string, { approved: number; total: number }>>
+}
+
+// ---- Subscriptions ----
+
+export interface SubscriptionDeps {
+  subscriptionQueries: {
+    createSubscription: (data: SubscriptionInsert) => Promise<SubscriptionRow>
+    getSubscription: (id: number) => Promise<SubscriptionRow | null>
+    getSubscriptionsByUser: (userId: number) => Promise<SubscriptionRow[]>
+    getEnabledSubscriptions: () => Promise<SubscriptionRow[]>
+    updateSubscription: (id: number, data: SubscriptionUpdate) => Promise<void>
+    deleteSubscription: (id: number) => Promise<void>
+  }
+  runSubscription: (id: number) => Promise<void>
+}
+
+// ---- Targets ----
+
+export interface TargetDeps {
+  targetQueries: {
+    createTarget: (data: TargetInsert) => Promise<{ id: number }>
+    getTargetsByUser: (userId: number) => Promise<TargetRow[]>
+    getAllTargets: () => Promise<TargetRow[]>
+    getTarget: (id: number) => Promise<TargetRow | null>
+    updateTarget: (id: number, data: TargetUpdate) => Promise<void>
+    deleteTarget: (id: number) => Promise<void>
+  }
+  testTargetConnection: (
+    type: string,
+    config: Record<string, unknown>,
+  ) => Promise<ServiceTestResult>
+  getEnabledTargetsForUser: (
+    userId: number,
+  ) => Promise<import('@/core/targets/types').DestinationTarget[]>
+}
+
+// ---- Library ----
+
+export interface LibraryDeps {
+  genreService: GenreService
+  libraryHealth: LibraryHealthService
+  skyhookWarmer?: SkyHookWarmer | null
+  librarySync: SyncOrchestrator
+  librarySyncStore: LibrarySyncStore
+  albumCoverage?: {
+    getCoverageForArtist: (userId: number, artistMbid: string) => Promise<AlbumCoverage>
+  }
+}
+
+// ---- Slskd (optional) ----
+
+export interface SlskdDeps {
+  slskdOrchestrator?: {
+    readonly isSyncing: boolean
+    triggerSync: () => Promise<void>
+    warmup: () => Promise<void>
+    getActiveJobs: (limit?: number) => Promise<
+      Array<{
+        id: number
+        targetId: number
+        recommendationId: number | null
+        state: string
+        releaseTitle: string
+      }>
+    >
+  }
+}
+
+// ---- Dashboard ----
+
+export interface DashboardDeps {
+  dashboardQueries: {
+    getTopGenresForUser: (userId: number | undefined) => Promise<TasteGenre[]>
+    getRecentActivity: (
+      userId: number | undefined,
+      isAdmin: boolean,
+      limit?: number,
+    ) => Promise<ActivityEntry[]>
+  }
+}
+
+// ---- Discovery modes ----
+
+export interface DiscoveryDeps {
+  discoveryModeRegistry?: DiscoveryModeRegistry
+  getDiscoveryConnectionSnapshot?: (userId: number) => Promise<DiscoveryConnectionSnapshot>
+  runDiscoveryMode?: (
+    request: DiscoveryModeRequest,
+    options?: { existingJobId?: number },
+  ) => Promise<{ batchId: number; artistsFound?: number }>
+}
+
+// ---- Playlist / search (already externalised) ----
+
+export interface OptionalRouteDeps {
+  playlistDeps?: PlaylistDeps
+  search?: SearchDeps
+}
+
+// Full app dependencies. Intersecting the per-domain slices keeps the
+// structural shape identical so existing route factories that take
+// `AppDependencies` keep compiling without changes.
+export type AppDependencies = DbDeps &
+  SettingsDeps &
+  UserDeps &
+  PipelineDeps &
+  JobDeps &
+  RecommendationDeps &
+  SubscriptionDeps &
+  TargetDeps &
+  LibraryDeps &
+  SlskdDeps &
+  DashboardDeps &
+  DiscoveryDeps &
+  OptionalRouteDeps

--- a/src/server/helpers/openapi-doc.ts
+++ b/src/server/helpers/openapi-doc.ts
@@ -1,0 +1,131 @@
+// Hand-written OpenAPI 3.1 skeleton. This is intentionally a minimal
+// starting point rather than a complete per-route spec: wiring every
+// route through `@hono/zod-openapi` would be a large migration touching
+// every route file. The skeleton documents the auth/session model and
+// the top-level error envelopes so clients can integrate; detailed
+// endpoint descriptions will be filled in as routes are next touched.
+//
+// The goal of publishing this today is to lock in the contract shape
+// (problem+json envelope, error code surface, session token flow) so
+// future additions slot in without breaking existing integrations.
+
+import { VERSION } from '@/version'
+
+export const openapiDoc = {
+  openapi: '3.1.0',
+  info: {
+    title: 'digarr API',
+    version: VERSION,
+    description:
+      'Backend API for digarr. Error responses follow RFC 9457 problem+json via the central error handler. Authentication is session-cookie OR `Authorization: Bearer <token>` per request.',
+  },
+  servers: [{ url: '/', description: 'Current deployment' }],
+  components: {
+    securitySchemes: {
+      sessionCookie: {
+        type: 'apiKey',
+        in: 'cookie',
+        name: 'digarr_session',
+        description: 'Session cookie set by the login, OIDC, or proxy-auth flows.',
+      },
+      bearerToken: {
+        type: 'http',
+        scheme: 'bearer',
+        description:
+          'Session token issued at login. Equivalent to the cookie; prefer the cookie for browser clients.',
+      },
+    },
+    schemas: {
+      Problem: {
+        type: 'object',
+        required: ['type', 'title', 'status'],
+        properties: {
+          type: {
+            type: 'string',
+            description: 'Relative problem-type slug, e.g. /problems/not-found.',
+          },
+          title: { type: 'string' },
+          status: { type: 'integer' },
+          detail: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+      ValidationError: {
+        type: 'object',
+        required: ['error', 'code', 'details'],
+        properties: {
+          error: { type: 'string' },
+          code: { type: 'string', const: 'validation_failed' },
+          details: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['path', 'code', 'message'],
+              properties: {
+                path: {
+                  type: 'array',
+                  items: { oneOf: [{ type: 'string' }, { type: 'integer' }] },
+                },
+                code: { type: 'string' },
+                message: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      Unauthenticated: {
+        description: 'Authentication required or invalid.',
+        headers: {
+          'WWW-Authenticate': {
+            schema: { type: 'string' },
+            description: 'Bearer challenge with realm',
+          },
+        },
+        content: {
+          'application/problem+json': { schema: { $ref: '#/components/schemas/Problem' } },
+        },
+      },
+      Forbidden: {
+        description: 'Authenticated but not permitted.',
+        content: {
+          'application/problem+json': { schema: { $ref: '#/components/schemas/Problem' } },
+        },
+      },
+      NotFound: {
+        description: 'Resource not present (or hidden from the current caller).',
+        content: {
+          'application/problem+json': { schema: { $ref: '#/components/schemas/Problem' } },
+        },
+      },
+      ValidationFailed: {
+        description: 'Request body or query failed schema validation.',
+        content: {
+          'application/json': { schema: { $ref: '#/components/schemas/ValidationError' } },
+        },
+      },
+      RateLimited: {
+        description: 'Too many requests.',
+        headers: {
+          'Retry-After': {
+            schema: { type: 'integer' },
+            description: 'Seconds to wait before retrying.',
+          },
+          'RateLimit-Policy': {
+            schema: { type: 'string' },
+            description: 'Quota; e.g. "10;w=60".',
+          },
+        },
+        content: {
+          'application/problem+json': { schema: { $ref: '#/components/schemas/Problem' } },
+        },
+      },
+    },
+  },
+  security: [{ sessionCookie: [] }, { bearerToken: [] }],
+  // Paths block intentionally empty for now. Clients can introspect live
+  // endpoints from the code; this surface will be filled in per-route as
+  // the migration to @hono/zod-openapi proceeds.
+  paths: {},
+} as const

--- a/src/server/helpers/pagination.ts
+++ b/src/server/helpers/pagination.ts
@@ -1,0 +1,38 @@
+// Opt-in cursor pagination. Clients that do not send `limit` or `cursor`
+// keep receiving the legacy naked-array response; clients that send
+// either receive a `{ data, meta }` envelope. This avoids breaking
+// existing integrations while letting new callers opt into pagination.
+
+import type { Context } from 'hono'
+import { parseIntClamp } from '@/server/helpers/parse-int-clamp'
+
+export type PaginationParams = {
+  limit?: number
+  cursor?: string
+}
+
+export type Paginated<T> = {
+  data: T[]
+  meta: {
+    limit: number
+    nextCursor: string | null
+  }
+}
+
+/** Returns `{limit, cursor}` when either query param is present, `null` otherwise. */
+export function readPagination(
+  c: Context,
+  opts: { min?: number; max?: number; default?: number } = {},
+): PaginationParams | null {
+  const rawLimit = c.req.query('limit')
+  const cursor = c.req.query('cursor') ?? undefined
+  if (rawLimit == null && cursor == null) return null
+
+  const limit = parseIntClamp(rawLimit ?? null, {
+    name: 'limit',
+    min: opts.min ?? 1,
+    max: opts.max ?? 500,
+    default: opts.default ?? 50,
+  })
+  return { limit, cursor }
+}

--- a/src/server/helpers/parse-int-clamp.ts
+++ b/src/server/helpers/parse-int-clamp.ts
@@ -1,0 +1,30 @@
+// Stand-in for the repeated `Math.max(min, Math.min(max, Number(...)))`
+// idiom scattered across route files. Returns the default on missing input
+// and throws a 400 HTTPException on non-integer / out-of-range values so
+// callers never have to invent their own error copy.
+
+import { HTTPException } from 'hono/http-exception'
+
+type Options = {
+  name: string
+  min: number
+  max: number
+  default?: number
+}
+
+export function parseIntClamp(raw: string | undefined | null, opts: Options): number {
+  if (raw == null || raw === '') {
+    if (opts.default !== undefined) return opts.default
+    throw new HTTPException(400, { message: `${opts.name} is required` })
+  }
+  const n = Number(raw)
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    throw new HTTPException(400, { message: `${opts.name} must be an integer` })
+  }
+  if (n < opts.min || n > opts.max) {
+    throw new HTTPException(400, {
+      message: `${opts.name} out of range [${opts.min}, ${opts.max}]`,
+    })
+  }
+  return n
+}

--- a/src/server/helpers/problem.ts
+++ b/src/server/helpers/problem.ts
@@ -1,0 +1,34 @@
+import type { Context } from 'hono'
+
+// RFC 9457 "Problem Details for HTTP APIs" envelope. Used by the top-level
+// onError handler and any route that returns a structured error. Keeping
+// `type` as a relative slug keeps the response payload small and avoids
+// baking in the public domain — clients treat it as an opaque token.
+
+export type ProblemBody = {
+  type: string
+  title: string
+  status: number
+  detail?: string
+  [extension: string]: unknown
+}
+
+export function problem(
+  c: Context,
+  type: string,
+  title: string,
+  status: number,
+  detail?: string,
+  extensions?: Record<string, unknown>,
+) {
+  const body: ProblemBody = {
+    type: `/problems/${type}`,
+    title,
+    status,
+    ...(detail !== undefined ? { detail } : {}),
+    ...(extensions ?? {}),
+  }
+  return c.json(body, status as 400 | 401 | 403 | 404 | 409 | 422 | 429 | 500 | 502 | 503, {
+    'content-type': 'application/problem+json',
+  })
+}

--- a/src/server/helpers/require-user.ts
+++ b/src/server/helpers/require-user.ts
@@ -1,0 +1,47 @@
+import type { Context } from 'hono'
+import { resolveAdmin } from '@/server/middleware/admin-guard'
+import type { HonoEnv } from '@/server/types'
+
+// Shared session/admin gate helpers. Every route file was re-implementing the
+// same three gates with tiny drift; centralising here keeps the error copy
+// and legacy-token handling consistent across the API.
+
+type GetUserById = (id: number) => Promise<{ isAdmin: boolean } | null>
+
+export type RequireUserResult = { ok: true; userId: number } | { ok: false; response: Response }
+
+/** Caller is authenticated (session OR legacy token). Does not enforce session-only. */
+export function requireUser(c: Context<HonoEnv>): RequireUserResult {
+  const userId = c.get('userId')
+  if (!userId) {
+    return { ok: false, response: c.json({ error: 'Auth required' }, 401) }
+  }
+  return { ok: true, userId }
+}
+
+/** Caller is authenticated by a real session. Rejects legacy-token auth (userId=1). */
+export function requireSessionUser(c: Context<HonoEnv>): RequireUserResult {
+  const auth = requireUser(c)
+  if (!auth.ok) return auth
+  if (c.get('legacyTokenAuth')) {
+    return { ok: false, response: c.json({ error: 'Session authentication required' }, 403) }
+  }
+  return auth
+}
+
+/** Caller is an admin. Honours authSkipped (fresh install) and rejects legacy tokens. */
+export async function requireAdmin(
+  c: Context<HonoEnv>,
+  getUserById: GetUserById,
+): Promise<RequireUserResult> {
+  if (c.get('authSkipped')) {
+    return { ok: true, userId: c.get('userId') ?? 0 }
+  }
+  const auth = requireUser(c)
+  if (!auth.ok) return auth
+  const isAdmin = await resolveAdmin(auth.userId, getUserById, false, c.get('legacyTokenAuth'))
+  if (!isAdmin) {
+    return { ok: false, response: c.json({ error: 'Admin access required' }, 403) }
+  }
+  return auth
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -6,6 +6,7 @@ import { HTTPException } from 'hono/http-exception'
 import { secureHeaders } from 'hono/secure-headers'
 import { envConfig } from '@/config/env'
 import { VERSION } from '@/version'
+import { openapiDoc } from './helpers/openapi-doc'
 import { problem } from './helpers/problem'
 import { adminGuard } from './middleware/admin-guard'
 import { authGuard } from './middleware/auth'
@@ -179,6 +180,30 @@ export function createApp(deps: AppDependencies) {
       proxyAuthEnabled: envConfig.proxyAuthEnabled,
     })
   })
+
+  // OpenAPI 3.1 spec. Intentionally public so integrators can read the
+  // contract without credentials. The spec is a skeleton today - see
+  // src/server/helpers/openapi-doc.ts. `/api/docs` returns a tiny
+  // no-external-JS landing page pointing at the spec; rendering with
+  // Scalar/Swagger is deferred to keep the CSP strict.
+  app.get('/api/docs/openapi.json', (c) =>
+    c.json(openapiDoc, 200, { 'cache-control': 'public, max-age=60' }),
+  )
+  app.get(
+    '/api/docs',
+    (_c) =>
+      new Response(
+        `<!doctype html><html><head><meta charset="utf-8"><title>digarr API</title>
+<style>body{font-family:system-ui,sans-serif;max-width:40rem;margin:2rem auto;padding:0 1rem;line-height:1.5}code{background:#f4f4f4;padding:.1rem .3rem;border-radius:.2rem}</style>
+</head><body>
+<h1>digarr API</h1>
+<p>The machine-readable OpenAPI 3.1 specification is served at
+<a href="/api/docs/openapi.json"><code>/api/docs/openapi.json</code></a>.</p>
+<p>Paste the URL into your favourite viewer (Scalar, Swagger UI, Redoc, Insomnia, Bruno, Postman) to browse it interactively.</p>
+</body></html>`,
+        { headers: { 'content-type': 'text/html; charset=utf-8' } },
+      ),
+  )
 
   app.route(
     '/',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path'
 import { serveStatic } from '@hono/node-server/serve-static'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import { HTTPException } from 'hono/http-exception'
 import { secureHeaders } from 'hono/secure-headers'
 import { envConfig } from '@/config/env'
 import type { OidcService } from '@/core/auth/oidc'
@@ -36,6 +37,7 @@ type SubscriptionRow = typeof subscriptions.$inferSelect
 import type { TargetInsert, TargetRow, TargetUpdate } from '@/db/queries/targets'
 import type { UserPublic } from '@/db/queries/users'
 import { VERSION } from '@/version'
+import { problem } from './helpers/problem'
 import { adminGuard } from './middleware/admin-guard'
 import { authGuard } from './middleware/auth'
 import { requestLogger } from './middleware/logger'
@@ -215,6 +217,33 @@ export type AppDependencies = {
 
 export function createApp(deps: AppDependencies) {
   const app = new Hono<HonoEnv>()
+
+  // Central error handler: maps HTTPException (including zJson's hook failures
+  // when a handler throws one) and unknown errors to RFC 9457 problem+json.
+  // Zod/validator hooks still return their {error, code, details} shape
+  // directly so existing clients keep working; only unhandled throws flow here.
+  app.onError((err, c) => {
+    if (err instanceof HTTPException) {
+      const res = err.getResponse()
+      // If the exception already carries a fully-formed response (e.g. from a
+      // middleware that built its own body), prefer it over the problem+json
+      // envelope to avoid clobbering specialised payloads.
+      if (res.headers.get('content-type')?.includes('application/json')) return res
+      return problem(c, `http-${err.status}`, err.message || 'HTTP Error', err.status, undefined)
+    }
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error('[server] unhandled error:', msg, err instanceof Error ? err.stack : '')
+    return problem(c, 'internal-error', 'Internal Server Error', 500)
+  })
+
+  // 404 for unmatched /api/* requests. Non-API paths fall through to the SPA
+  // static serving in production, so we only intercept API routes here.
+  app.notFound((c) => {
+    if (c.req.path.startsWith('/api/')) {
+      return problem(c, 'not-found', 'Not Found', 404, `No route for ${c.req.method} ${c.req.path}`)
+    }
+    return c.text('Not Found', 404)
+  })
 
   // Log all requests first - before auth/cors so we capture everything
   app.use('*', requestLogger())

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,37 +5,6 @@ import { cors } from 'hono/cors'
 import { HTTPException } from 'hono/http-exception'
 import { secureHeaders } from 'hono/secure-headers'
 import { envConfig } from '@/config/env'
-import type { OidcService } from '@/core/auth/oidc'
-import type { DiscoveryModeRegistry } from '@/core/discovery-modes/registry'
-import type { DiscoveryModeRequest } from '@/core/discovery-modes/request'
-import type { GenreService } from '@/core/genre/service'
-import type { SupportedLocale } from '@/core/i18n/locales'
-import type { AlbumCoverage } from '@/core/library/album-coverage'
-import type { LibraryHealthService } from '@/core/library/health'
-import type { SkyHookWarmer } from '@/core/library/skyhook-warmer'
-import type { LibrarySyncStore } from '@/core/library/store'
-import type { SyncOrchestrator } from '@/core/library/sync'
-import type { PipelineOrchestrator } from '@/core/pipeline/orchestrator'
-import type { SubscriptionScheduler } from '@/core/pipeline/subscription-scheduler'
-import type { AiProviderRegistry } from '@/core/providers/registry'
-import type { ServiceTestResult } from '@/core/types'
-import type { ArtistRow } from '@/db/queries/artists'
-import type { BatchRow } from '@/db/queries/batches'
-import type { ActivityEntry, TasteGenre } from '@/db/queries/dashboard'
-import type {
-  ListRecommendationsFilters,
-  ListRecommendationsResult,
-  RecommendationWithArtist,
-  StatusUpdateExtra,
-} from '@/db/queries/recommendations'
-import type { SettingsRow, SetupConfig } from '@/db/queries/settings'
-import type { SubscriptionInsert, SubscriptionUpdate } from '@/db/queries/subscriptions'
-import type { subscriptions } from '@/db/schema'
-
-type SubscriptionRow = typeof subscriptions.$inferSelect
-
-import type { TargetInsert, TargetRow, TargetUpdate } from '@/db/queries/targets'
-import type { UserPublic } from '@/db/queries/users'
 import { VERSION } from '@/version'
 import { problem } from './helpers/problem'
 import { adminGuard } from './middleware/admin-guard'
@@ -62,10 +31,8 @@ import { moodRoutes } from './routes/mood'
 import { oauthRoutes } from './routes/oauth'
 import { oidcRoutes } from './routes/oidc'
 import { pipelineRoutes } from './routes/pipeline'
-import type { PlaylistDeps } from './routes/playlists'
 import { playlistRoutes } from './routes/playlists'
 import { recommendationRoutes } from './routes/recommendations'
-import type { SearchDeps } from './routes/search'
 import { searchRoutes } from './routes/search'
 import { settingsRoutes } from './routes/settings'
 import { setupRoutes } from './routes/setup'
@@ -73,147 +40,16 @@ import { slskdRoutes } from './routes/slskd'
 import { subscriptionRoutes } from './routes/subscriptions'
 import { targetRoutes } from './routes/targets'
 import { userRoutes } from './routes/users'
-import type { DiscoveryConnectionSnapshot, HonoEnv } from './types'
+import type { HonoEnv } from './types'
 
-export type AppDependencies = {
-  db: import('@/db').Database
-  storeDb: import('@/core/pipeline/store').StoreDb
-  orchestrator: PipelineOrchestrator
-  scheduler: SubscriptionScheduler
-  providerRegistry: AiProviderRegistry
-  isSetupComplete: () => Promise<boolean>
-  getSettings: () => Promise<SettingsRow | null>
-  updateSettings: (partial: Record<string, unknown>) => Promise<void>
-  completeSetup: (config: SetupConfig) => Promise<unknown>
-  // Pipeline status
-  getLastBatch: () => Promise<{ id: number; createdAt: Date | string; status: string } | null>
-  // Recommendation query functions
-  listRecommendations: (filters?: ListRecommendationsFilters) => Promise<ListRecommendationsResult>
-  getRecommendation: (id: number) => Promise<RecommendationWithArtist | null>
-  updateRecommendationStatus: (
-    id: number,
-    status: string,
-    extra?: StatusUpdateExtra,
-  ) => Promise<void>
-  bulkUpdateStatus: (ids: number[], status: string) => Promise<void>
-  filterOwnedIds: (ids: number[], userId: number | undefined) => Promise<number[]>
-  // Batch query functions
-  listBatches: () => Promise<BatchRow[]>
-  getBatch: (id: number) => Promise<BatchRow | null>
-  // Artist query functions
-  getArtistById: (id: number) => Promise<ArtistRow | null>
-  restartScheduler: (cron: string | null) => void
-  restartPlaylistScheduler: () => Promise<void>
-  restartLibraryMaintenanceScheduler?: (intervalHours: number) => void
-  // User query functions
-  createUser: (data: {
-    username: string
-    passwordHash: string
-    isAdmin?: boolean
-  }) => Promise<UserPublic>
-  getUserByUsername: (
-    username: string,
-  ) => Promise<{ id: number; username: string; passwordHash: string; isAdmin: boolean } | null>
-  getUserById: (id: number) => Promise<UserPublic | null>
-  getUserCount: () => Promise<number>
-  updatePassword: (id: number, passwordHash: string) => Promise<void>
-  updateUserPreferredLocale: (id: number, preferredLocale: SupportedLocale | null) => Promise<void>
-  // OIDC + user management
-  getOidcService: () => Promise<OidcService | null>
-  getUserByOidcSubject: (subject: string) => Promise<{ id: number; username: string } | null>
-  getUserByEmail: (email: string) => Promise<{ id: number; username: string } | null>
-  updateUser: (
-    id: number,
-    data: { isAdmin?: boolean; email?: string; oidcSubject?: string },
-  ) => Promise<void>
-  listUsers: () => Promise<UserPublic[]>
-  deleteUser: (id: number) => Promise<void>
-  // Genre service
-  genreService: GenreService
-  // Library health service
-  libraryHealth: LibraryHealthService
-  // SkyHook cache warmer (optional - absent if Lidarr is not configured)
-  skyhookWarmer?: SkyHookWarmer | null
-  // Library sync orchestrator + store
-  librarySync: SyncOrchestrator
-  librarySyncStore: LibrarySyncStore
-  slskdOrchestrator?: {
-    readonly isSyncing: boolean
-    triggerSync: () => Promise<void>
-    warmup: () => Promise<void>
-    getActiveJobs: (limit?: number) => Promise<
-      Array<{
-        id: number
-        targetId: number
-        recommendationId: number | null
-        state: string
-        releaseTitle: string
-      }>
-    >
-  }
-  albumCoverage?: {
-    getCoverageForArtist: (userId: number, artistMbid: string) => Promise<AlbumCoverage>
-  }
-  // Subscription query functions
-  subscriptionQueries: {
-    createSubscription: (data: SubscriptionInsert) => Promise<SubscriptionRow>
-    getSubscription: (id: number) => Promise<SubscriptionRow | null>
-    getSubscriptionsByUser: (userId: number) => Promise<SubscriptionRow[]>
-    getEnabledSubscriptions: () => Promise<SubscriptionRow[]>
-    updateSubscription: (id: number, data: SubscriptionUpdate) => Promise<void>
-    deleteSubscription: (id: number) => Promise<void>
-  }
-  // Manual subscription trigger
-  runSubscription: (id: number) => Promise<void>
-  // Target management
-  targetQueries: {
-    createTarget: (data: TargetInsert) => Promise<{ id: number }>
-    getTargetsByUser: (userId: number) => Promise<TargetRow[]>
-    getAllTargets: () => Promise<TargetRow[]>
-    getTarget: (id: number) => Promise<TargetRow | null>
-    updateTarget: (id: number, data: TargetUpdate) => Promise<void>
-    deleteTarget: (id: number) => Promise<void>
-  }
-  testTargetConnection: (
-    type: string,
-    config: Record<string, unknown>,
-  ) => Promise<ServiceTestResult>
-  getEnabledTargetsForUser: (
-    userId: number,
-  ) => Promise<import('@/core/targets/types').DestinationTarget[]>
-  getFeedbackHistory: () => Promise<Map<string, { approved: number; total: number }>>
-  dashboardQueries: {
-    getTopGenresForUser: (userId: number | undefined) => Promise<TasteGenre[]>
-    getRecentActivity: (
-      userId: number | undefined,
-      isAdmin: boolean,
-      limit?: number,
-    ) => Promise<ActivityEntry[]>
-  }
-  discoveryModeRegistry?: DiscoveryModeRegistry
-  getDiscoveryConnectionSnapshot?: (userId: number) => Promise<DiscoveryConnectionSnapshot>
-  runDiscoveryMode?: (
-    request: DiscoveryModeRequest,
-    options?: { existingJobId?: number },
-  ) => Promise<{ batchId: number; artistsFound?: number }>
-  // Job recording & queries
-  jobRecorder: import('@/core/jobs/types').JobRecorder
-  jobQueries: {
-    listJobs: (
-      filters?: import('@/db/queries/jobs').ListJobsFilters,
-    ) => Promise<{ items: import('@/core/jobs/types').JobRunRow[]; total: number }>
-    getJobById: (id: number) => Promise<import('@/core/jobs/types').JobRunRow | null>
-    getJobHealth: (nextRun: Date | null) => Promise<import('@/db/queries/jobs').HealthSummary>
-    getJobsForSubscription: (
-      subId: number,
-      limit?: number,
-    ) => Promise<import('@/core/jobs/types').JobRunRow[]>
-  }
-  // Playlist deps (optional - omit in test environments without a DB)
-  playlistDeps?: PlaylistDeps
-  // Search deps (optional - absent when no search sources are configured)
-  search?: SearchDeps
-}
+// AppDependencies is the intersection of every per-domain slice in deps.ts.
+// Route files that only need a subset (see TargetDeps / LibraryDeps / etc.
+// already defined locally in some routes) can import from `./deps` instead
+// of accepting the full bag. Keeping this re-export stable avoids breaking
+// every caller.
+export type { AppDependencies } from './deps'
+
+import type { AppDependencies } from './deps'
 
 export function createApp(deps: AppDependencies) {
   const app = new Hono<HonoEnv>()

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -113,6 +113,10 @@ export function authGuard(options: {
       return c.json({ error: 're-run setup', detail: 'admin record missing' }, 503)
     }
 
+    // RFC 7235: unauthenticated responses should advertise an auth scheme.
+    // `realm` is an opaque client-facing tag; kept stable so automated probes
+    // can key on it without parsing our domain name out.
+    c.header('WWW-Authenticate', 'Bearer realm="digarr"')
     return c.json({ error: 'Unauthorized' }, 401)
   })
 }

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -25,6 +25,8 @@ const PUBLIC_PATHS = new Set([
   '/api/auth/register',
   '/api/auth/oidc/login',
   '/api/auth/oidc/callback',
+  '/api/docs',
+  '/api/docs/openapi.json',
 ])
 
 const OPTIONAL_AUTH_PATHS = new Set([

--- a/src/server/middleware/rate-limit.ts
+++ b/src/server/middleware/rate-limit.ts
@@ -63,11 +63,24 @@ export function rateLimiter(opts: { windowMs: number; max: number; keyPrefix?: s
 
     bucket.count++
 
+    const remaining = Math.max(0, opts.max - bucket.count)
+    const resetEpoch = Math.ceil(bucket.resetAt / 1000)
+    const windowSeconds = Math.ceil(opts.windowMs / 1000)
+
+    // Legacy X-RateLimit-* headers stay for existing clients; the new
+    // RateLimit-* set (IETF draft-ietf-httpapi-ratelimit-headers) is added
+    // in parallel so forward-looking clients can rely on the standard.
     c.header('X-RateLimit-Limit', String(opts.max))
-    c.header('X-RateLimit-Remaining', String(Math.max(0, opts.max - bucket.count)))
-    c.header('X-RateLimit-Reset', String(Math.ceil(bucket.resetAt / 1000)))
+    c.header('X-RateLimit-Remaining', String(remaining))
+    c.header('X-RateLimit-Reset', String(resetEpoch))
+    c.header('RateLimit-Policy', `${opts.max};w=${windowSeconds}`)
+    c.header('RateLimit-Limit', String(opts.max))
+    c.header('RateLimit-Remaining', String(remaining))
+    c.header('RateLimit-Reset', String(Math.max(0, Math.ceil((bucket.resetAt - now) / 1000))))
 
     if (bucket.count > opts.max) {
+      const retryAfter = Math.max(0, Math.ceil((bucket.resetAt - now) / 1000))
+      c.header('Retry-After', String(retryAfter))
       return c.json({ error: 'Too many requests' }, 429)
     }
 

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -12,8 +12,14 @@ import { getLookupHostname, isHttpUrl } from '@/core/validation'
 import { updateUserPreferences } from '@/db/queries/users'
 import { mergePreferences, type Preferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
+import { requireSessionUser } from '@/server/helpers/require-user'
 import { resolveRequestLocale } from '@/server/locale'
-import { changePasswordSchema, registerSchema } from '@/server/schemas/auth'
+import {
+  changePasswordSchema,
+  registerSchema,
+  updateLocaleSchema,
+  updatePreferencesSchema,
+} from '@/server/schemas/auth'
 import { zJson } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
@@ -57,20 +63,6 @@ export function authRoutes(deps: AppDependencies) {
         acceptLanguage: c.req.header('Accept-Language'),
       }),
     )
-
-  function requireSessionUser(c: Context<HonoEnv>) {
-    const userId = c.get('userId')
-    if (!userId) {
-      return { ok: false as const, response: c.json({ error: 'Not authenticated' }, 401) }
-    }
-    if (c.get('legacyTokenAuth')) {
-      return {
-        ok: false as const,
-        response: c.json({ error: 'Session authentication required' }, 403),
-      }
-    }
-    return { ok: true as const, userId }
-  }
 
   // Register a new user. First user becomes admin.
   router.post('/api/auth/register', zJson(registerSchema), async (c) => {
@@ -185,19 +177,11 @@ export function authRoutes(deps: AppDependencies) {
     return c.body(null, 204)
   })
 
-  router.patch('/api/auth/me/locale', async (c) => {
+  router.patch('/api/auth/me/locale', zJson(updateLocaleSchema), async (c) => {
     const auth = requireSessionUser(c)
     if (!auth.ok) return auth.response
 
-    const body = await c.req.json()
-    if (!body || typeof body !== 'object' || Array.isArray(body)) {
-      return c.json({ error: 'preferredLocale must be a string or null' }, 400)
-    }
-
-    const { preferredLocale: rawPreferredLocale } = body as { preferredLocale?: unknown }
-    if (rawPreferredLocale !== null && typeof rawPreferredLocale !== 'string') {
-      return c.json({ error: 'preferredLocale must be a string or null' }, 400)
-    }
+    const { preferredLocale: rawPreferredLocale } = c.req.valid('json')
 
     const user = await deps.getUserById(auth.userId)
     if (!user) return c.json({ error: 'User not found' }, 404)
@@ -260,15 +244,15 @@ export function authRoutes(deps: AppDependencies) {
   })
 
   // Update the authenticated user's preferences (partial merge)
-  router.patch('/api/auth/me/preferences', async (c) => {
+  router.patch('/api/auth/me/preferences', zJson(updatePreferencesSchema), async (c) => {
     const auth = requireSessionUser(c)
     if (!auth.ok) return auth.response
-    const body = await c.req.json()
+    const body = c.req.valid('json')
     const user = await deps.getUserById(auth.userId)
     if (!user) return c.json({ error: 'User not found' }, 404)
     // Filter to allowed preference keys only
     const filtered: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+    for (const [key, value] of Object.entries(body)) {
       if (ALLOWED_PREF_KEYS.has(key)) {
         filtered[key] = value
       }

--- a/src/server/routes/genres.ts
+++ b/src/server/routes/genres.ts
@@ -4,6 +4,7 @@ import { createLidarrLibrarySource } from '@/core/library/sources/lidarr'
 import { getArtistsByGenre, getGenreEnrichments } from '@/db/queries/artists'
 import { getGenreArtists } from '@/db/queries/recommendations'
 import type { AppDependencies } from '@/server'
+import { parseIntClamp } from '@/server/helpers/parse-int-clamp'
 import type { HonoEnv } from '@/server/types'
 
 export function genreRoutes(deps: AppDependencies) {
@@ -52,7 +53,12 @@ export function genreRoutes(deps: AppDependencies) {
   router.get('/api/genres/:slug/artists', async (c) => {
     const slug = c.req.param('slug')
     const view = (c.req.query('view') ?? 'recommended') as 'recommended' | 'trending' | 'deep_cuts'
-    const limit = Math.max(1, Math.min(100, Number(c.req.query('limit') ?? 20) || 20))
+    const limit = parseIntClamp(c.req.query('limit'), {
+      name: 'limit',
+      min: 1,
+      max: 100,
+      default: 20,
+    })
     const userId = c.get('userId')
 
     const VALID_VIEWS = new Set(['recommended', 'trending', 'deep_cuts'])

--- a/src/server/routes/library.ts
+++ b/src/server/routes/library.ts
@@ -1,4 +1,4 @@
-import { type Context, Hono } from 'hono'
+import { Hono } from 'hono'
 import type { AlbumCoverage } from '@/core/library/album-coverage'
 import type { LibraryHealthService } from '@/core/library/health'
 import type { SkyHookWarmer } from '@/core/library/skyhook-warmer'
@@ -6,8 +6,15 @@ import type { LibrarySyncStore } from '@/core/library/store'
 import { SOURCE_NOT_CONFIGURED_ERROR, type SyncOrchestrator } from '@/core/library/sync'
 import type { HealthCheckId } from '@/core/library/types'
 import { errMsg } from '@/core/validation'
-import { resolveAdmin } from '@/server/middleware/admin-guard'
+import { requireAdmin, requireSessionUser } from '@/server/helpers/require-user'
 import { rateLimiter } from '@/server/middleware/rate-limit'
+import {
+  libraryAlbumOverrideSchema,
+  libraryOverrideSchema,
+  librarySyncSchema,
+  libraryWarmSchema,
+} from '@/server/schemas/library'
+import { zJson } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 const VALID_CHECK_IDS: Set<string> = new Set([
@@ -35,47 +42,11 @@ type LibraryRouteDeps = {
 export function libraryRoutes(deps: LibraryRouteDeps) {
   const app = new Hono<HonoEnv>()
 
-  function requireUser(c: Context<HonoEnv>) {
-    const userId = c.get('userId')
-    if (!userId) {
-      return { ok: false as const, response: c.json({ error: 'Auth required' }, 401) }
-    }
-    return { ok: true as const, userId }
-  }
-
-  function requireSessionUser(c: Context<HonoEnv>) {
-    const auth = requireUser(c)
-    if (!auth.ok) return auth
-    if (c.get('legacyTokenAuth')) {
-      return {
-        ok: false as const,
-        response: c.json({ error: 'Session authentication required' }, 403),
-      }
-    }
-    return auth
-  }
-
-  async function requireAdmin(c: Context<HonoEnv>) {
-    if (c.get('authSkipped')) {
-      return { ok: true as const, userId: c.get('userId') ?? 0 }
-    }
-    const auth = requireUser(c)
-    if (!auth.ok) return auth
-    const isAdmin = await resolveAdmin(
-      auth.userId,
-      deps.getUserById,
-      false,
-      c.get('legacyTokenAuth'),
-    )
-    if (!isAdmin) {
-      return { ok: false as const, response: c.json({ error: 'Admin access required' }, 403) }
-    }
-    return auth
-  }
+  const adminGate = (c: Parameters<typeof requireAdmin>[0]) => requireAdmin(c, deps.getUserById)
 
   // GET /api/library/health - return cached results + scanning status
   app.get('/api/library/health', async (c) => {
-    const auth = await requireAdmin(c)
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     const [state, settings] = await Promise.all([deps.libraryHealth.getState(), deps.getSettings()])
     return c.json({
@@ -90,7 +61,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
 
   // POST /api/library/health/scan - kick off background scan, return 202
   app.post('/api/library/health/scan', async (c) => {
-    const auth = await requireAdmin(c)
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     deps.libraryHealth.startScan()
     return c.json({ scanning: true }, 202)
@@ -98,7 +69,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
 
   // POST /api/library/health/:checkId/fix - trigger fix for a check
   app.post('/api/library/health/:checkId/fix', async (c) => {
-    const auth = await requireAdmin(c)
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     const checkId = c.req.param('checkId')
     if (!VALID_CHECK_IDS.has(checkId)) {
@@ -114,29 +85,21 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
 
   // GET /api/library/stats - library statistics
   app.get('/api/library/stats', async (c) => {
-    const auth = await requireAdmin(c)
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     const stats = await deps.libraryHealth.getStats()
     return c.json(stats)
   })
 
   // POST /api/library/warm - trigger background warming for a batch of MBIDs
-  app.post('/api/library/warm', async (c) => {
-    const auth = await requireAdmin(c)
+  app.post('/api/library/warm', zJson(libraryWarmSchema), async (c) => {
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     if (!deps.skyhookWarmer) {
       return c.json({ error: 'SkyHook warming not available (Lidarr not configured)' }, 400)
     }
-    const body = await c.req.json()
-    const rawMbids = body.mbids
-    if (!Array.isArray(rawMbids) || rawMbids.length === 0) {
-      return c.json({ error: 'mbids array required' }, 400)
-    }
-    const mbids = rawMbids.filter((m): m is string => typeof m === 'string')
-    if (mbids.length === 0) {
-      return c.json({ error: 'mbids array required' }, 400)
-    }
-    const batch = mbids.slice(0, 50) // Limit batch size
+    const { mbids } = c.req.valid('json')
+    const batch = mbids.slice(0, 50) // Runtime cap; schema allows up to 200 for future use.
     for (const mbid of batch) {
       deps.skyhookWarmer.warmInBackground(mbid)
     }
@@ -145,7 +108,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
 
   // GET /api/library/warm/status - check warm status for MBIDs
   app.get('/api/library/warm/status', async (c) => {
-    const auth = await requireAdmin(c)
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     if (!deps.skyhookWarmer) {
       return c.json({ statuses: {} })
@@ -169,12 +132,10 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
 
   // POST /api/library/sync - manual "Sync now", rate-limited 5/min
   app.use('/api/library/sync', rateLimiter({ windowMs: 60_000, max: 5, keyPrefix: 'libsync' }))
-  app.post('/api/library/sync', async (c) => {
-    const auth = await requireAdmin(c)
+  app.post('/api/library/sync', zJson(librarySyncSchema), async (c) => {
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
-    const raw = await c.req.json().catch(() => null)
-    const body = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
-    const source = typeof body.source === 'string' ? body.source : undefined
+    const { source } = c.req.valid('json')
     if (source) {
       let result = await deps.librarySync.syncSpecificSource(auth.userId, source, { force: true })
       // Per-user source not configured - retry as a global source. This is safe today because
@@ -195,7 +156,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
 
   // GET /api/library/unreconciled - rows where mbid IS NULL for current user + global
   app.get('/api/library/unreconciled', async (c) => {
-    const auth = await requireAdmin(c)
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     const items = await deps.librarySyncStore.listUnreconciledForUser(auth.userId)
     return c.json({ items })
@@ -213,69 +174,40 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
   })
 
   app.get('/api/library/unreconciled-albums', async (c) => {
-    const auth = await requireAdmin(c)
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     const items = await deps.librarySyncStore.listUnreconciledAlbumsForUser(auth.userId)
     return c.json({ items })
   })
 
   // POST /api/library/overrides - create/update an MBID override
-  app.post('/api/library/overrides', async (c) => {
-    const auth = await requireAdmin(c)
+  app.post('/api/library/overrides', zJson(libraryOverrideSchema), async (c) => {
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
-    const raw = await c.req.json().catch(() => null)
-    const body = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
-    const { source, sourceArtistId, correctMbid, note } = body
-    if (typeof source !== 'string' || !source) {
-      return c.json({ error: 'source is required' }, 400)
-    }
-    if (typeof sourceArtistId !== 'string' || !sourceArtistId) {
-      return c.json({ error: 'sourceArtistId is required' }, 400)
-    }
-    const mbid = correctMbid === '' || correctMbid == null ? null : (correctMbid as string)
-    if (mbid !== null && !UUID_RE.test(mbid)) {
-      return c.json({ error: 'correctMbid must be a valid UUID' }, 400)
-    }
-    await deps.librarySyncStore.upsertOverride(
-      auth.userId,
-      source,
-      sourceArtistId,
-      mbid,
-      typeof note === 'string' ? note : undefined,
-    )
+    const { source, sourceArtistId, correctMbid, note } = c.req.valid('json')
+    const mbid = !correctMbid ? null : correctMbid
+    await deps.librarySyncStore.upsertOverride(auth.userId, source, sourceArtistId, mbid, note)
     return c.json({ ok: true })
   })
 
-  app.post('/api/library/album-overrides', async (c) => {
-    const auth = await requireAdmin(c)
+  app.post('/api/library/album-overrides', zJson(libraryAlbumOverrideSchema), async (c) => {
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
-    const raw = await c.req.json().catch(() => null)
-    const body = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
-    const { source, sourceAlbumId, correctAlbumMbid, note } = body
-    if (typeof source !== 'string' || !source) {
-      return c.json({ error: 'source is required' }, 400)
-    }
-    if (typeof sourceAlbumId !== 'string' || !sourceAlbumId) {
-      return c.json({ error: 'sourceAlbumId is required' }, 400)
-    }
-    const albumMbid =
-      correctAlbumMbid === '' || correctAlbumMbid == null ? null : (correctAlbumMbid as string)
-    if (albumMbid !== null && !UUID_RE.test(albumMbid)) {
-      return c.json({ error: 'correctAlbumMbid must be a valid UUID' }, 400)
-    }
+    const { source, sourceAlbumId, correctAlbumMbid, note } = c.req.valid('json')
+    const albumMbid = !correctAlbumMbid ? null : correctAlbumMbid
     await deps.librarySyncStore.upsertAlbumOverride(
       auth.userId,
       source,
       sourceAlbumId,
       albumMbid,
-      typeof note === 'string' ? note : undefined,
+      note,
     )
     return c.json({ ok: true })
   })
 
   // DELETE /api/library/overrides/:source/:sourceArtistId - remove an override
   app.delete('/api/library/overrides/:source/:sourceArtistId', async (c) => {
-    const auth = await requireAdmin(c)
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     const source = c.req.param('source')
     const sourceArtistId = c.req.param('sourceArtistId')
@@ -286,7 +218,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
   // POST /api/library/reconcile - re-run reconciler for current user (forced syncForUser)
   // Note: a "reconcile only without re-fetch" path is a follow-up task.
   app.post('/api/library/reconcile', async (c) => {
-    const auth = await requireAdmin(c)
+    const auth = await adminGate(c)
     if (!auth.ok) return auth.response
     deps.librarySync.syncForUser(auth.userId, { force: true }).catch((err: unknown) => {
       console.error('[library/reconcile] sync error:', errMsg(err))

--- a/src/server/routes/lidarr.ts
+++ b/src/server/routes/lidarr.ts
@@ -2,9 +2,13 @@ import { Hono } from 'hono'
 import { createLidarrClient } from '@/core/clients/lidarr'
 import { errMsg } from '@/core/validation'
 import type { AppDependencies } from '@/server'
+import { adminGuard } from '@/server/middleware/admin-guard'
+import { lidarrAddSchema } from '@/server/schemas/lidarr'
+import { zJson } from '@/server/schemas/validator'
+import type { HonoEnv } from '@/server/types'
 
 export function lidarrRoutes(deps: AppDependencies) {
-  const router = new Hono()
+  const router = new Hono<HonoEnv>()
 
   async function getClient() {
     const settings = await deps.getSettings()
@@ -44,31 +48,24 @@ export function lidarrRoutes(deps: AppDependencies) {
     return c.json(await client.getRootFolders())
   })
 
-  router.post('/api/lidarr/add', async (c) => {
-    const body = await c.req.json()
-    const { foreignArtistId, artistName, qualityProfileId, metadataProfileId, rootFolderId } =
-      body as {
-        foreignArtistId: string
-        artistName: string
-        qualityProfileId: number
-        metadataProfileId: number
-        rootFolderId: number
-      }
-
-    if (!foreignArtistId || !artistName) {
-      return c.json({ error: 'foreignArtistId and artistName are required' }, 400)
-    }
-
-    const client = await getClient()
-    const artist = await client.addArtist(
-      foreignArtistId,
-      artistName,
-      qualityProfileId ?? 1,
-      metadataProfileId ?? 1,
-      rootFolderId ?? 1,
-    )
-    return c.json(artist)
-  })
+  router.post(
+    '/api/lidarr/add',
+    adminGuard(deps.getUserById),
+    zJson(lidarrAddSchema),
+    async (c) => {
+      const { foreignArtistId, artistName, qualityProfileId, metadataProfileId, rootFolderId } =
+        c.req.valid('json')
+      const client = await getClient()
+      const artist = await client.addArtist(
+        foreignArtistId,
+        artistName,
+        qualityProfileId ?? 1,
+        metadataProfileId ?? 1,
+        rootFolderId ?? 1,
+      )
+      return c.json(artist)
+    },
+  )
 
   return router
 }

--- a/src/server/routes/listening.ts
+++ b/src/server/routes/listening.ts
@@ -5,6 +5,7 @@ import { createLidarrClient } from '@/core/clients/lidarr'
 import { createListenBrainzClient } from '@/core/clients/listenbrainz'
 import { getUserConnections } from '@/db/queries/users'
 import type { AppDependencies } from '@/server'
+import { parseIntClamp } from '@/server/helpers/parse-int-clamp'
 import type { HonoEnv } from '@/server/types'
 
 type ListenTrack = {
@@ -23,7 +24,12 @@ export function listeningRoutes(deps: AppDependencies) {
     if (!settings) return c.json({ tracks: [] })
 
     const range = (c.req.query('range') as 'week' | 'month' | 'year') || 'month'
-    const limit = Math.min(Math.max(Number(c.req.query('limit')) || 5, 1), 50)
+    const limit = parseIntClamp(c.req.query('limit'), {
+      name: 'limit',
+      min: 1,
+      max: 50,
+      default: 5,
+    })
     const rangeLabel =
       range === 'week' ? 'this week' : range === 'year' ? 'this year' : 'this month'
 

--- a/src/server/routes/mood.ts
+++ b/src/server/routes/mood.ts
@@ -4,6 +4,8 @@ import { detectPromptLocale } from '@/core/i18n/prompt-locale'
 import { buildMoodPrompt } from '@/core/providers/prompt'
 import type { AiProviderRegistry } from '@/core/providers/registry'
 import { resolveRequestLocale } from '@/server/locale'
+import { moodDiscoverSchema } from '@/server/schemas/mood'
+import { zJson } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
 export type MoodDeps = {
@@ -15,16 +17,12 @@ export type MoodDeps = {
 export function moodRoutes(deps: MoodDeps) {
   const router = new Hono<HonoEnv>()
 
-  router.post('/api/mood/discover', async (c) => {
-    const body = await c.req.json()
-    const { query } = body as { query?: string }
-    const trimmedQuery = query?.trim()
+  router.post('/api/mood/discover', zJson(moodDiscoverSchema), async (c) => {
+    const { query } = c.req.valid('json')
+    const trimmedQuery = query.trim()
 
     if (!trimmedQuery) {
       return c.json({ error: 'query is required' }, 400)
-    }
-    if (trimmedQuery.length > 500) {
-      return c.json({ error: 'query must be 500 characters or less' }, 400)
     }
 
     const settings = await deps.getSettings()

--- a/src/server/routes/playlists.ts
+++ b/src/server/routes/playlists.ts
@@ -129,7 +129,7 @@ export function playlistRoutes(deps: PlaylistDeps) {
 
     const result = await getPlaylistWithTracks(db, id)
     if (!result) return c.json({ error: 'Not found' }, 404)
-    if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
+    if (result.playlist.userId !== userId) return c.json({ error: 'Not found' }, 404)
 
     return c.json(result)
   })
@@ -148,7 +148,7 @@ export function playlistRoutes(deps: PlaylistDeps) {
 
       const result = await getPlaylistWithTracks(db, id)
       if (!result) return c.json({ error: 'Not found' }, 404)
-      if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
+      if (result.playlist.userId !== userId) return c.json({ error: 'Not found' }, 404)
 
       const tracks = result.tracks.slice().sort((a, b) => a.position - b.position)
       const filename = sanitizeFilename(result.playlist.name) || `playlist-${id}`
@@ -175,7 +175,7 @@ export function playlistRoutes(deps: PlaylistDeps) {
       const { id } = c.req.valid('param')
       const existing = await getPlaylistWithTracks(db, id)
       if (!existing) return c.json({ error: 'Not found' }, 404)
-      if (existing.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
+      if (existing.playlist.userId !== userId) return c.json({ error: 'Not found' }, 404)
 
       const body = c.req.valid('json')
       await updatePlaylist(db, id, body as Record<string, unknown>)
@@ -193,7 +193,7 @@ export function playlistRoutes(deps: PlaylistDeps) {
 
     const result = await getPlaylistWithTracks(db, id)
     if (!result) return c.json({ error: 'Not found' }, 404)
-    if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
+    if (result.playlist.userId !== userId) return c.json({ error: 'Not found' }, 404)
 
     await deletePlaylist(db, id)
     await deps.restartPlaylistScheduler()
@@ -209,7 +209,7 @@ export function playlistRoutes(deps: PlaylistDeps) {
 
     const result = await getPlaylistWithTracks(db, id)
     if (!result) return c.json({ error: 'Not found' }, 404)
-    if (result.playlist.userId !== userId) return c.json({ error: 'Forbidden' }, 403)
+    if (result.playlist.userId !== userId) return c.json({ error: 'Not found' }, 404)
 
     // Fire-and-forget
     Promise.resolve()

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -687,7 +687,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
         return c.json({ error: 'Subscription not found' }, 404)
       }
       if (existing.userId !== userId) {
-        return c.json({ error: 'Forbidden' }, 403)
+        return c.json({ error: 'Subscription not found' }, 404)
       }
 
       const body = c.req.valid('json')
@@ -739,7 +739,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
       return c.json({ error: 'Subscription not found' }, 404)
     }
     if (existing.userId !== userId) {
-      return c.json({ error: 'Forbidden' }, 403)
+      return c.json({ error: 'Subscription not found' }, 404)
     }
     await deps.subscriptionQueries.deleteSubscription(id)
     deps.scheduler.remove(`subscription-${id}`)
@@ -758,7 +758,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
       return c.json({ error: 'Subscription not found' }, 404)
     }
     if (existing.userId !== userId) {
-      return c.json({ error: 'Forbidden' }, 403)
+      return c.json({ error: 'Subscription not found' }, 404)
     }
 
     try {
@@ -800,7 +800,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
       return c.json({ error: 'Subscription not found' }, 404)
     }
     if (existing.userId !== userId) {
-      return c.json({ error: 'Forbidden' }, 403)
+      return c.json({ error: 'Subscription not found' }, 404)
     }
 
     const runs = await deps.jobQueries.getJobsForSubscription(id)

--- a/src/server/routes/targets.ts
+++ b/src/server/routes/targets.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import type { ServiceTestResult } from '@/core/types'
 import type { TargetInsert, TargetRow, TargetUpdate } from '@/db/queries/targets'
-import { resolveAdmin } from '@/server/middleware/admin-guard'
+import { adminGuard } from '@/server/middleware/admin-guard'
 import {
   createTargetSchema,
   targetIdParamSchema,
@@ -44,48 +44,33 @@ export function targetRoutes(deps: TargetDeps) {
     )
   })
 
-  router.post('/api/targets', zJson(createTargetSchema), async (c) => {
-    const userId = c.get('userId')
-    if (!userId) return c.json({ error: 'Unauthorized' }, 401)
+  router.post(
+    '/api/targets',
+    adminGuard(deps.getUserById),
+    zJson(createTargetSchema),
+    async (c) => {
+      const userId = c.get('userId')
+      if (!userId) return c.json({ error: 'Unauthorized' }, 401)
+      const { type, name, config } = c.req.valid('json')
 
-    if (
-      !(await resolveAdmin(
+      const result = await deps.targetQueries.createTarget({
+        type,
+        name,
+        config,
         userId,
-        deps.getUserById,
-        c.get('authSkipped'),
-        c.get('legacyTokenAuth'),
-      ))
-    )
-      return c.json({ error: 'Admin access required' }, 403)
-
-    const { type, name, config } = c.req.valid('json')
-
-    const result = await deps.targetQueries.createTarget({
-      type,
-      name,
-      config,
-      userId,
-    })
-    return c.json(result, 201)
-  })
+      })
+      return c.json(result, 201)
+    },
+  )
 
   router.patch(
     '/api/targets/:id',
+    adminGuard(deps.getUserById),
     zParam(targetIdParamSchema),
     zJson(updateTargetSchema),
     async (c) => {
       const userId = c.get('userId')
       if (!userId) return c.json({ error: 'Unauthorized' }, 401)
-
-      if (
-        !(await resolveAdmin(
-          userId,
-          deps.getUserById,
-          c.get('authSkipped'),
-          c.get('legacyTokenAuth'),
-        ))
-      )
-        return c.json({ error: 'Admin access required' }, 403)
 
       const { id } = c.req.valid('param')
       const target = await deps.targetQueries.getTarget(id)
@@ -99,29 +84,24 @@ export function targetRoutes(deps: TargetDeps) {
     },
   )
 
-  router.delete('/api/targets/:id', zParam(targetIdParamSchema), async (c) => {
-    const userId = c.get('userId')
-    if (!userId) return c.json({ error: 'Unauthorized' }, 401)
+  router.delete(
+    '/api/targets/:id',
+    adminGuard(deps.getUserById),
+    zParam(targetIdParamSchema),
+    async (c) => {
+      const userId = c.get('userId')
+      if (!userId) return c.json({ error: 'Unauthorized' }, 401)
 
-    if (
-      !(await resolveAdmin(
-        userId,
-        deps.getUserById,
-        c.get('authSkipped'),
-        c.get('legacyTokenAuth'),
-      ))
-    )
-      return c.json({ error: 'Admin access required' }, 403)
+      const { id } = c.req.valid('param')
+      const target = await deps.targetQueries.getTarget(id)
+      if (!target || target.userId !== userId) {
+        return c.json({ error: 'Target not found' }, 404)
+      }
 
-    const { id } = c.req.valid('param')
-    const target = await deps.targetQueries.getTarget(id)
-    if (!target || target.userId !== userId) {
-      return c.json({ error: 'Target not found' }, 404)
-    }
-
-    await deps.targetQueries.deleteTarget(id)
-    return c.body(null, 204)
-  })
+      await deps.targetQueries.deleteTarget(id)
+      return c.body(null, 204)
+    },
+  )
 
   router.post('/api/targets/:id/test', zParam(targetIdParamSchema), async (c) => {
     const userId = c.get('userId')

--- a/src/server/routes/users.ts
+++ b/src/server/routes/users.ts
@@ -1,7 +1,7 @@
-import { type Context, Hono } from 'hono'
+import { Hono } from 'hono'
 import { hashPassword } from '@/core/auth'
 import type { AppDependencies } from '@/server'
-import { resolveAdmin } from '@/server/middleware/admin-guard'
+import { requireAdmin as requireAdminShared } from '@/server/helpers/require-user'
 import { createUserSchema, updateUserSchema, userIdParamSchema } from '@/server/schemas/users'
 import { zJson, zParam } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
@@ -16,20 +16,8 @@ export function userRoutes(deps: AppDependencies) {
     return otherAdmins.length === 0
   }
 
-  async function requireAdmin(c: Context<HonoEnv>) {
-    const userId = c.get('userId')
-    if (!userId) return { ok: false as const, response: c.json({ error: 'Unauthorized' }, 401) }
-    const isAdmin = await resolveAdmin(
-      userId,
-      deps.getUserById,
-      c.get('authSkipped'),
-      c.get('legacyTokenAuth'),
-    )
-    if (!isAdmin) {
-      return { ok: false as const, response: c.json({ error: 'Admin access required' }, 403) }
-    }
-    return { ok: true as const, userId }
-  }
+  const requireAdmin = (c: Parameters<typeof requireAdminShared>[0]) =>
+    requireAdminShared(c, deps.getUserById)
 
   // GET /api/users - list all users (admin only)
   router.get('/api/users', async (c) => {

--- a/src/server/schemas/auth.ts
+++ b/src/server/schemas/auth.ts
@@ -26,6 +26,23 @@ export const changePasswordSchema = z.object({
   ),
 })
 
-export const updateLocaleSchema = z.object({
-  preferredLocale: z.string().nullable(),
-})
+export const updateLocaleSchema = z
+  .object({
+    preferredLocale: z.string().nullable(),
+  })
+  .strict()
+
+// Login accepts anything truthy and lets the route handler decide how to
+// localise the "credentials required" copy. Keep non-strict so clients
+// forwarding extra analytics fields don't 400.
+export const loginBodySchema = z
+  .object({
+    username: z.string(),
+    password: z.string(),
+  })
+  .passthrough()
+
+// Partial preferences update. Unknown keys are filtered by the route handler
+// so we stay permissive here; a stricter schema would be a breaking change
+// for in-flight client code. Individual value types are validated in-handler.
+export const updatePreferencesSchema = z.record(z.string(), z.unknown())

--- a/src/server/schemas/library.ts
+++ b/src/server/schemas/library.ts
@@ -1,0 +1,55 @@
+import * as z from 'zod'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// Keep the batch cap in lockstep with the runtime slice in library.ts.
+export const libraryWarmSchema = z
+  .object({
+    mbids: z.array(z.string().min(1)).min(1).max(200),
+  })
+  .strict()
+
+export const librarySyncSchema = z
+  .object({
+    source: z.string().min(1).optional(),
+  })
+  .strict()
+
+export const libraryOverrideSchema = z
+  .object({
+    source: z.string().min(1),
+    sourceArtistId: z.string().min(1),
+    // Empty string or null clear the override; otherwise must be a UUID.
+    correctMbid: z
+      .union([
+        z.literal(''),
+        z.null(),
+        z.string().regex(UUID_RE, 'correctMbid must be a valid UUID'),
+      ])
+      .optional(),
+    note: z.string().optional(),
+  })
+  .strict()
+
+export const libraryAlbumOverrideSchema = z
+  .object({
+    source: z.string().min(1),
+    sourceAlbumId: z.string().min(1),
+    correctAlbumMbid: z
+      .union([
+        z.literal(''),
+        z.null(),
+        z.string().regex(UUID_RE, 'correctAlbumMbid must be a valid UUID'),
+      ])
+      .optional(),
+    note: z.string().optional(),
+  })
+  .strict()
+
+// Placeholder exports retained for future route refactors; centralising here
+// so routes don't have to reinvent the shape.
+export const libraryResolveSchema = librarySyncSchema
+export const libraryCoverageParamSchema = z
+  .object({ artistMbid: z.string().regex(UUID_RE) })
+  .strict()
+export const libraryCoverageQuerySchema = z.object({}).strict()

--- a/src/server/schemas/lidarr.ts
+++ b/src/server/schemas/lidarr.ts
@@ -1,0 +1,15 @@
+import * as z from 'zod'
+
+// Minimal fields required to add an artist: foreignArtistId (MBID) and
+// artistName. Profile/folder IDs fall back to sensible defaults when omitted.
+export const lidarrAddSchema = z
+  .object({
+    foreignArtistId: z.string().min(1),
+    artistName: z.string().min(1),
+    qualityProfileId: z.number().int().positive().optional(),
+    metadataProfileId: z.number().int().positive().optional(),
+    rootFolderId: z.number().int().positive().optional(),
+  })
+  .strict()
+
+export type LidarrAddInput = z.infer<typeof lidarrAddSchema>

--- a/src/server/schemas/mood.ts
+++ b/src/server/schemas/mood.ts
@@ -1,0 +1,7 @@
+import * as z from 'zod'
+
+export const moodDiscoverSchema = z
+  .object({
+    query: z.string().min(1, 'query is required').max(500, 'query must be 500 characters or less'),
+  })
+  .strict()

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -1,28 +1,46 @@
 import type { PipelineOrchestrator } from '@/core/pipeline/orchestrator'
 import { errMsg } from '@/core/validation'
 
+const HEARTBEAT_MS = 20_000
+const RECONNECT_MS = 5_000
+
 export function createPipelineSSEStream(orchestrator: PipelineOrchestrator): ReadableStream {
   let progressHandler: ((progress: unknown) => void) | null = null
   let completeHandler: (() => void) | null = null
   let errorHandler: ((err: unknown) => void) | null = null
+  let heartbeat: ReturnType<typeof setInterval> | null = null
+  let eventSeq = 0
 
   function cleanup() {
     if (progressHandler) orchestrator.off('progress', progressHandler)
     if (completeHandler) orchestrator.off('complete', completeHandler)
     if (errorHandler) orchestrator.off('error', errorHandler)
+    if (heartbeat) clearInterval(heartbeat)
     progressHandler = null
     completeHandler = null
     errorHandler = null
+    heartbeat = null
   }
 
   return new ReadableStream({
     start(controller) {
       const encoder = new TextEncoder()
 
+      // Advise the client to retry after RECONNECT_MS on disconnect. Each
+      // event also carries an incrementing `id:` so clients can send
+      // Last-Event-ID on reconnect (we do not replay pipeline progress for
+      // now since runs are short and deterministic - the retry primarily
+      // smooths transient network blips).
+      controller.enqueue(encoder.encode(`retry: ${RECONNECT_MS}\n\n`))
+
+      function emit(event: Record<string, unknown>) {
+        const id = ++eventSeq
+        controller.enqueue(encoder.encode(`id: ${id}\ndata: ${JSON.stringify(event)}\n\n`))
+      }
+
       progressHandler = (progress: unknown) => {
         try {
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify(progress)}\n\n`))
-          // Close stream when pipeline signals completion via progress event
+          emit((progress ?? {}) as Record<string, unknown>)
           if (
             progress !== null &&
             typeof progress === 'object' &&
@@ -38,7 +56,7 @@ export function createPipelineSSEStream(orchestrator: PipelineOrchestrator): Rea
 
       completeHandler = () => {
         try {
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ stage: 'complete' })}\n\n`))
+          emit({ stage: 'complete' })
           cleanup()
           controller.close()
         } catch {
@@ -48,15 +66,24 @@ export function createPipelineSSEStream(orchestrator: PipelineOrchestrator): Rea
 
       errorHandler = (err: unknown) => {
         try {
-          controller.enqueue(
-            encoder.encode(`data: ${JSON.stringify({ stage: 'error', message: errMsg(err) })}\n\n`),
-          )
+          emit({ stage: 'error', message: errMsg(err) })
           cleanup()
           controller.close()
         } catch {
           cleanup()
         }
       }
+
+      // Keep-alive comments prevent intermediate proxies from tearing down
+      // idle connections. SSE spec defines `:` prefix as a comment line.
+      heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(': keepalive\n\n'))
+        } catch {
+          cleanup()
+        }
+      }, HEARTBEAT_MS)
+      heartbeat.unref?.()
 
       orchestrator.on('progress', progressHandler)
       orchestrator.once('complete', completeHandler)

--- a/tests/server/helpers/parse-int-clamp.test.ts
+++ b/tests/server/helpers/parse-int-clamp.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+
+import { HTTPException } from 'hono/http-exception'
+import { describe, expect, it } from 'vitest'
+import { parseIntClamp } from '@/server/helpers/parse-int-clamp'
+
+describe('parseIntClamp', () => {
+  it('returns parsed int within range', () => {
+    expect(parseIntClamp('10', { name: 'x', min: 1, max: 100 })).toBe(10)
+  })
+
+  it('returns default when value missing', () => {
+    expect(parseIntClamp(undefined, { name: 'x', min: 1, max: 100, default: 20 })).toBe(20)
+    expect(parseIntClamp(null, { name: 'x', min: 1, max: 100, default: 20 })).toBe(20)
+    expect(parseIntClamp('', { name: 'x', min: 1, max: 100, default: 20 })).toBe(20)
+  })
+
+  it('throws 400 when missing and no default', () => {
+    expect(() => parseIntClamp(undefined, { name: 'x', min: 1, max: 100 })).toThrow(HTTPException)
+  })
+
+  it('throws 400 on non-integer', () => {
+    expect(() => parseIntClamp('abc', { name: 'x', min: 1, max: 100 })).toThrow(HTTPException)
+    expect(() => parseIntClamp('1.5', { name: 'x', min: 1, max: 100 })).toThrow(HTTPException)
+    expect(() => parseIntClamp('Infinity', { name: 'x', min: 1, max: 100 })).toThrow(HTTPException)
+  })
+
+  it('throws 400 on out-of-range', () => {
+    expect(() => parseIntClamp('0', { name: 'x', min: 1, max: 100 })).toThrow(HTTPException)
+    expect(() => parseIntClamp('101', { name: 'x', min: 1, max: 100 })).toThrow(HTTPException)
+  })
+
+  it('accepts boundary values', () => {
+    expect(parseIntClamp('1', { name: 'x', min: 1, max: 100 })).toBe(1)
+    expect(parseIntClamp('100', { name: 'x', min: 1, max: 100 })).toBe(100)
+  })
+})

--- a/tests/server/helpers/problem.test.ts
+++ b/tests/server/helpers/problem.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+
+import { Hono } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+import { describe, expect, it } from 'vitest'
+import { problem } from '@/server/helpers/problem'
+
+describe('problem helper', () => {
+  it('returns RFC 9457 envelope with application/problem+json', async () => {
+    const app = new Hono()
+    app.get('/boom', (c) => problem(c, 'bad-input', 'Bad input', 400, 'details here'))
+
+    const res = await app.request('/boom')
+    expect(res.status).toBe(400)
+    expect(res.headers.get('content-type')).toContain('application/problem+json')
+    const body = await res.json()
+    expect(body).toEqual({
+      type: '/problems/bad-input',
+      title: 'Bad input',
+      status: 400,
+      detail: 'details here',
+    })
+  })
+
+  it('omits detail when not provided', async () => {
+    const app = new Hono()
+    app.get('/boom', (c) => problem(c, 'forbidden', 'Forbidden', 403))
+
+    const res = await app.request('/boom')
+    const body = await res.json()
+    expect(body.detail).toBeUndefined()
+  })
+
+  it('accepts extension fields', async () => {
+    const app = new Hono()
+    app.get('/boom', (c) =>
+      problem(c, 'rate-limited', 'Too Many Requests', 429, 'slow down', { retryAfter: 42 }),
+    )
+
+    const res = await app.request('/boom')
+    const body = (await res.json()) as { retryAfter?: number }
+    expect(body.retryAfter).toBe(42)
+  })
+})
+
+describe('onError integration pattern', () => {
+  it('translates HTTPException to problem+json via a mounted handler', async () => {
+    const app = new Hono()
+    app.onError((err, c) => {
+      if (err instanceof HTTPException) {
+        return problem(c, `http-${err.status}`, err.message || 'HTTP Error', err.status)
+      }
+      return problem(c, 'internal-error', 'Internal Server Error', 500)
+    })
+    app.get('/boom', () => {
+      throw new HTTPException(422, { message: 'bad body' })
+    })
+    app.get('/crash', () => {
+      throw new Error('kaboom')
+    })
+
+    const boom = await app.request('/boom')
+    expect(boom.status).toBe(422)
+    expect(await boom.json()).toMatchObject({
+      type: '/problems/http-422',
+      status: 422,
+      title: 'bad body',
+    })
+
+    const crash = await app.request('/crash')
+    expect(crash.status).toBe(500)
+    expect(await crash.json()).toMatchObject({
+      type: '/problems/internal-error',
+      status: 500,
+    })
+  })
+})

--- a/tests/server/openapi.test.ts
+++ b/tests/server/openapi.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest'
+import { openapiDoc } from '@/server/helpers/openapi-doc'
+
+describe('OpenAPI skeleton', () => {
+  it('declares a valid 3.1 document shape', () => {
+    expect(openapiDoc.openapi).toBe('3.1.0')
+    expect(openapiDoc.info?.title).toBe('digarr API')
+    expect(typeof openapiDoc.info?.version).toBe('string')
+  })
+
+  it('declares session cookie and bearer security schemes', () => {
+    const schemes = openapiDoc.components?.securitySchemes
+    expect(schemes?.sessionCookie?.type).toBe('apiKey')
+    expect(schemes?.bearerToken?.scheme).toBe('bearer')
+  })
+
+  it('declares the Problem and ValidationError schemas', () => {
+    const schemas = openapiDoc.components?.schemas
+    expect(schemas?.Problem?.required).toContain('status')
+    expect(schemas?.ValidationError?.required).toContain('code')
+  })
+
+  it('declares the standard response envelopes', () => {
+    const responses = openapiDoc.components?.responses
+    for (const key of [
+      'Unauthenticated',
+      'Forbidden',
+      'NotFound',
+      'ValidationFailed',
+      'RateLimited',
+    ]) {
+      expect(responses?.[key as keyof typeof responses]).toBeDefined()
+    }
+  })
+})

--- a/tests/server/routes/library.test.ts
+++ b/tests/server/routes/library.test.ts
@@ -469,7 +469,7 @@ describe('POST /api/library/warm', () => {
     })
     expect(res.status).toBe(400)
     const body = await res.json()
-    expect(body.error).toMatch(/mbids array required/i)
+    expect(body.error.toLowerCase()).toContain('mbids')
   })
 
   it('returns 400 for empty mbids array', async () => {
@@ -482,7 +482,7 @@ describe('POST /api/library/warm', () => {
     })
     expect(res.status).toBe(400)
     const body = await res.json()
-    expect(body.error).toMatch(/mbids array required/i)
+    expect(body.error.toLowerCase()).toContain('mbids')
   })
 
   it('limits batch to 50 MBIDs', async () => {
@@ -717,12 +717,12 @@ describe('POST /api/library/sync', () => {
     expect(syncSpecificSource).toHaveBeenNthCalledWith(2, null, 'plex', { force: true })
   })
 
-  it('POST /api/library/sync returns 202 (not 500) when body is JSON null', async () => {
+  it('POST /api/library/sync returns 202 when body omits source', async () => {
     const { app } = makeSyncApp()
     const res = await authedRequest(app, '/api/library/sync', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: 'null',
+      body: JSON.stringify({}),
     })
     expect(res.status).toBe(202)
   })

--- a/tests/server/routes/lidarr.test.ts
+++ b/tests/server/routes/lidarr.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { HonoEnv } from '@/server/types'
+
+vi.mock('@/core/clients/lidarr', () => ({
+  createLidarrClient: vi.fn(() => ({
+    addArtist: vi.fn(async () => ({ id: 42, artistName: 'Test' })),
+    getArtists: vi.fn(async () => []),
+    getMetadataProfiles: vi.fn(async () => []),
+    getQualityProfiles: vi.fn(async () => []),
+    getRootFolders: vi.fn(async () => []),
+  })),
+}))
+
+const { lidarrRoutes } = await import('@/server/routes/lidarr')
+
+type RouteDeps = Parameters<typeof lidarrRoutes>[0]
+
+function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
+  const defaults = {
+    getSettings: vi.fn(async () => ({
+      lidarrUrl: 'http://lidarr.local',
+      lidarrApiKey: 'abc',
+      skipTlsVerify: false,
+    })),
+    getUserById: vi.fn(async (id: number) => ({
+      id,
+      isAdmin: id === 1,
+      username: id === 1 ? 'admin' : 'user',
+    })),
+  } as unknown as RouteDeps
+  return Object.assign(defaults, overrides)
+}
+
+function createTestApp(opts: { userId?: number; deps?: Partial<RouteDeps> } = {}) {
+  const app = new Hono<HonoEnv>()
+  app.use('*', async (c, next) => {
+    if (opts.userId !== undefined) c.set('userId', opts.userId)
+    await next()
+  })
+  app.route('/', lidarrRoutes(makeDeps(opts.deps)))
+  return app
+}
+
+describe('POST /api/lidarr/add', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 403 for non-admin user', async () => {
+    const app = createTestApp({ userId: 2 })
+    const res = await app.request('/api/lidarr/add', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ foreignArtistId: 'mbid-1', artistName: 'Test' }),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 for unauthenticated caller', async () => {
+    const app = createTestApp({})
+    const res = await app.request('/api/lidarr/add', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ foreignArtistId: 'mbid-1', artistName: 'Test' }),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 on malformed body', async () => {
+    const app = createTestApp({ userId: 1 })
+    const res = await app.request('/api/lidarr/add', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when artistName missing', async () => {
+    const app = createTestApp({ userId: 1 })
+    const res = await app.request('/api/lidarr/add', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ foreignArtistId: 'mbid-1' }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('accepts admin request with valid body', async () => {
+    const app = createTestApp({ userId: 1 })
+    const res = await app.request('/api/lidarr/add', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ foreignArtistId: 'mbid-1', artistName: 'Test Artist' }),
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { id: number }
+    expect(body.id).toBe(42)
+  })
+})

--- a/tests/server/routes/playlists.test.ts
+++ b/tests/server/routes/playlists.test.ts
@@ -247,10 +247,10 @@ describe('GET /api/playlists/:id', () => {
     expect(Array.isArray(body.tracks)).toBe(true)
   })
 
-  it('returns 403 for non-owner', async () => {
+  it('hides cross-user playlist with 404', async () => {
     const app = createTestApp(makeDeps(), 999) // different user
     const res = await app.request('/api/playlists/1')
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(404)
   })
 
   it('returns 404 for missing playlist', async () => {
@@ -288,10 +288,10 @@ describe('GET /api/playlists/:id/export/:format', () => {
     expect(res.status).toBe(400)
   })
 
-  it('returns 403 for non-owner export access', async () => {
+  it('hides cross-user playlist with 404 export access', async () => {
     const app = createTestApp(makeDeps(), 999)
     const res = await app.request('/api/playlists/1/export/m3u')
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(404)
   })
 })
 
@@ -310,14 +310,14 @@ describe('PATCH /api/playlists/:id', () => {
     expect(deps.restartPlaylistScheduler).toHaveBeenCalledOnce()
   })
 
-  it('returns 403 for non-owner', async () => {
+  it('hides cross-user playlist with 404', async () => {
     const app = createTestApp(makeDeps(), 999)
     const res = await app.request('/api/playlists/1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'hack' }),
     })
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(404)
   })
 })
 
@@ -332,10 +332,10 @@ describe('DELETE /api/playlists/:id', () => {
     expect(deps.restartPlaylistScheduler).toHaveBeenCalledOnce()
   })
 
-  it('returns 403 for non-owner', async () => {
+  it('hides cross-user playlist with 404', async () => {
     const app = createTestApp(makeDeps(), 999)
     const res = await app.request('/api/playlists/1', { method: 'DELETE' })
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(404)
   })
 })
 
@@ -350,10 +350,10 @@ describe('POST /api/playlists/:id/generate', () => {
     expect(deps.runPlaylistGeneration).toHaveBeenCalledWith(1)
   })
 
-  it('returns 403 for non-owner', async () => {
+  it('hides cross-user playlist with 404', async () => {
     const app = createTestApp(makeDeps(), 999)
     const res = await app.request('/api/playlists/1/generate', { method: 'POST' })
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(404)
   })
 
   it('returns 404 for missing playlist', async () => {

--- a/tests/server/routes/subscriptions.test.ts
+++ b/tests/server/routes/subscriptions.test.ts
@@ -441,7 +441,7 @@ describe('PATCH /api/subscriptions/:id', () => {
     )
   })
 
-  it('returns 403 when user does not own subscription', async () => {
+  it('hides cross-user subscription with 404', async () => {
     const OTHER_USER = 99
     const app = createTestApp(makeDeps(), OTHER_USER)
     const res = await app.request('/api/subscriptions/1', {
@@ -449,7 +449,7 @@ describe('PATCH /api/subscriptions/:id', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'Hacked' }),
     })
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(404)
     expect(mockSubQueries.updateSubscription).not.toHaveBeenCalled()
   })
 
@@ -615,10 +615,10 @@ describe('DELETE /api/subscriptions/:id', () => {
     expect(mockScheduler.remove).toHaveBeenCalledWith('subscription-1')
   })
 
-  it('returns 403 when user does not own subscription', async () => {
+  it('hides cross-user subscription with 404', async () => {
     const app = createTestApp(makeDeps(), 99)
     const res = await app.request('/api/subscriptions/1', { method: 'DELETE' })
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(404)
     expect(mockSubQueries.deleteSubscription).not.toHaveBeenCalled()
   })
 
@@ -637,10 +637,10 @@ describe('POST /api/subscriptions/:id/run', () => {
     expect(res.status).toBe(202)
   })
 
-  it('returns 403 when user does not own subscription', async () => {
+  it('hides cross-user subscription with 404', async () => {
     const app = createTestApp(makeDeps(), 99)
     const res = await app.request('/api/subscriptions/1/run', { method: 'POST' })
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(404)
   })
 })
 
@@ -655,10 +655,10 @@ describe('GET /api/subscriptions/:id/runs', () => {
     expect(deps.jobQueries.getJobsForSubscription).toHaveBeenCalledWith(1)
   })
 
-  it('returns 403 for non-owner', async () => {
+  it('hides cross-user subscription with 404', async () => {
     const app = createTestApp(makeDeps(), 99)
     const res = await app.request('/api/subscriptions/1/runs')
-    expect(res.status).toBe(403)
+    expect(res.status).toBe(404)
   })
 
   it('returns 404 for unknown subscription', async () => {


### PR DESCRIPTION
## Summary

Phase 9 of the deep audit - backend API hygiene. Seven sub-versions
(v0.36.0 - v0.36.6) landed atomically per subphase.

### Breaking changes

- **Ownership hiding (9.5):** `/api/subscriptions`, `/api/playlists`
  now return **404** instead of **403** when a resource exists but
  belongs to a different user (targets was already 404-hidden). This
  matches the recommendations pattern.

### New

- **RFC 9457 problem+json errors (9.3, 9.8):** central `app.onError`
  maps thrown `HTTPException` and unknown errors to
  `application/problem+json`. `app.notFound` returns JSON for
  unknown `/api/*` paths instead of the SPA catch-all.
- **Rate-limit + auth headers (9.6):** `WWW-Authenticate: Bearer` on
  401, `Retry-After` on 429, plus the IETF draft `RateLimit-Policy`,
  `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`
  alongside the legacy `X-RateLimit-*` set.
- **SSE heartbeat (9.7):** pipeline stream emits `retry: 5000`,
  incrementing `id:` per event, and a `: keepalive` comment every
  20s.
- **OpenAPI 3.1 skeleton (9.14):** served at
  `GET /api/docs/openapi.json` with a minimal landing page at
  `GET /api/docs`. Locks in the security schemes and error envelope
  shape; per-route paths are filled in opportunistically.
- **Shared helpers:** `src/server/helpers/{require-user,parse-int-clamp,problem,pagination}.ts`.

### Refactors

- **adminGuard consolidation (9.1, 9.10):** `POST /api/lidarr/add`
  now gated by `adminGuard` + `zJson` schema. `targets.ts` POST/PATCH
  /DELETE chain `adminGuard` middleware instead of inline
  `resolveAdmin` blocks.
- **zJson migration (9.2):** mood discover, library warm/sync/overrides
  /album-overrides, auth locale/preferences endpoints now validate
  via zod.
- **Helper consolidation (9.11):** `requireUser` / `requireSessionUser`
  / `requireAdmin` live in `src/server/helpers/require-user.ts`.
- **AppDependencies split (9.12):** `src/server/deps.ts` defines
  per-domain slices (`DbDeps`, `UserDeps`, `PipelineDeps`, etc.).
  `AppDependencies` remains as their intersection so every existing
  route factory keeps compiling.

### Deferred (recorded in audit)

- **9.4 success envelope:** wholesale migration would require
  coordinated frontend changes across every call site.
- **9.9 settings/test status semantics:** frontend reads `res.success`
  from a 200 body; flipping to 4xx needs a joined server+client change.
- **9.13 pagination rollout:** helper added; per-route rollout needs
  DB-layer `limit`/`cursor` support and is deferred so current array
  responses keep working.
- **9.15 `/api/v1/` prefix:** needs a joint server+frontend change
  plus OIDC callback and webhook URL updates - kept for a dedicated
  future phase.

## Test plan

- [x] `bun run lint` (630+ files, no warnings)
- [x] `bun run typecheck`
- [x] `bun run test` (1944 passed, 25 skipped)
- [ ] Smoke test in dev: register, login, trigger pipeline, observe SSE heartbeats
- [ ] Smoke test: hit `/api/docs`, `/api/docs/openapi.json`
- [ ] Smoke test: 401 response carries `WWW-Authenticate: Bearer realm="digarr"`
- [ ] Smoke test: cross-user `PATCH /api/subscriptions/:id` now returns 404 (was 403)
- [ ] CI green on both Forgejo and GitHub