### PR TITLE
fix(a11y): lift accent-pill contrast to WCAG AA, fix strict-mode locators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 .env.*
 !.env.example
 *.log
+test-results/
+playwright-report/
 
 # ===========================
 # Local

--- a/src/web/pages/dashboard.tsx
+++ b/src/web/pages/dashboard.tsx
@@ -158,7 +158,7 @@ function ListeningActivity({
               key={r}
               type="button"
               onClick={() => onRangeChange(r)}
-              className={`text-xs px-2 py-0.5 rounded ${range === r ? 'bg-accent/20 text-accent' : 'text-muted hover:text-text'}`}
+              className={`text-xs px-2 py-0.5 rounded ${range === r ? 'bg-accent text-accent-fg' : 'text-muted hover:text-text'}`}
             >
               {r === 'week' ? t('dashboard.week') : t('dashboard.month')}
             </button>

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -1349,7 +1349,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                 href="https://www.discogs.com/settings/developers"
                 target="_blank"
                 rel="noreferrer"
-                className="text-accent hover:underline"
+                className="text-accent underline"
               >
                 {t('settings.getPersonalAccessToken')}
               </a>
@@ -1635,7 +1635,7 @@ function TargetTypeIcon({ type }: { type: string }) {
   const src = iconMap[type]
   if (src) return <img src={src} alt="" className="w-5 h-5" />
   return (
-    <span className="w-5 h-5 rounded bg-accent/20 text-accent text-micro font-bold flex items-center justify-center uppercase">
+    <span className="w-5 h-5 rounded bg-accent text-accent-fg text-micro font-bold flex items-center justify-center uppercase">
       {type.charAt(0)}
     </span>
   )
@@ -2490,7 +2490,7 @@ function AccountTab() {
             {t('settings.signedInAs')}{' '}
             <span className="text-text font-medium">{user?.username ?? '...'}</span>
             {user?.isAdmin && (
-              <span className="ml-2 text-xs bg-accent/20 text-accent px-1.5 py-0.5 rounded">
+              <span className="ml-2 text-xs bg-accent text-accent-fg px-1.5 py-0.5 rounded">
                 {t('userManagement.adminBadge')}
               </span>
             )}

--- a/tests/e2e/a11y/discover.spec.ts
+++ b/tests/e2e/a11y/discover.spec.ts
@@ -12,7 +12,7 @@ test.describe('Discover page a11y', () => {
     await page.goto('/discover')
 
     // Main content landmark should be on-screen before we scan.
-    await expect(page.getByRole('main').or(page.getByRole('heading'))).toBeVisible({
+    await expect(page.getByRole('main')).toBeVisible({
       timeout: 10_000,
     })
 

--- a/tests/e2e/a11y/settings.spec.ts
+++ b/tests/e2e/a11y/settings.spec.ts
@@ -11,7 +11,7 @@ test.describe('Settings page a11y', () => {
     await installAuthToken(page, token)
     await page.goto('/settings')
 
-    await expect(page.getByRole('main').or(page.getByRole('heading'))).toBeVisible({
+    await expect(page.getByRole('main')).toBeVisible({
       timeout: 10_000,
     })
 


### PR DESCRIPTION
## Summary
- Swap `bg-accent/20 text-accent` to solid `bg-accent text-accent-fg` (contrast-verified in every theme) on dashboard range picker, settings admin badge, and target-type icon fallback. The tinted pattern failed 4.5:1 under `youtarr-light` at 3.84:1, tripping axe-core on the setup a11y test (which lands on the dashboard once setup is complete).
- Fix a11y spec strict-mode locators: `getByRole('main').or(heading)` resolves to 2 elements on pages that render both; switch to `getByRole('main')` alone.
- Pin a persistent underline on the Discogs dev-tokens link (WCAG 1.4.1: the parent `opacity-60` wrapper made it fail 1.26:1 vs surrounding text).
- Gitignore `test-results/` and `playwright-report/` (previously untracked artifacts kept slipping into diffs).

Setup + Discover a11y tests now green. Settings still surfaces pre-existing, unrelated `text-muted` / link-in-text contrast issues in `youtarr-light` that want a theme-level `--color-muted` revision -- out of scope here.

## Test plan
- [x] `bun run lint` / `bun run typecheck` clean
- [x] `bun run test` 2030 passed
- [x] `bun run test:e2e:a11y` -- setup + discover pass; settings fails on unrelated pre-existing issues (see commit body)
- [ ] CI green