### PR TITLE
fix(a11y): drop opacity-60 on service cards, force link underlines

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,15 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
   "files": {
-    "includes": ["**", "!drizzle", "!dist", "!.worktrees", "!docs/local"]
+    "includes": [
+      "**",
+      "!drizzle",
+      "!dist",
+      "!.worktrees",
+      "!docs/local",
+      "!test-results",
+      "!playwright-report"
+    ]
   },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {

--- a/src/web/components/admin/upgrade-section.tsx
+++ b/src/web/components/admin/upgrade-section.tsx
@@ -30,7 +30,7 @@ export function UpgradeSection() {
             <button
               type="button"
               onClick={() => setExpanded(!expanded)}
-              className="text-accent hover:underline"
+              className="text-accent underline"
             >
               {data.pendingCount} pending
             </button>

--- a/src/web/components/album-picker.tsx
+++ b/src/web/components/album-picker.tsx
@@ -150,7 +150,7 @@ export function AlbumPicker({
                 <button
                   type="button"
                   onClick={handleSelectAll}
-                  className="text-xs text-accent hover:underline"
+                  className="text-xs text-accent underline"
                 >
                   {t('albumPicker.selectAll')}
                 </button>

--- a/src/web/components/discovery-mode-form.tsx
+++ b/src/web/components/discovery-mode-form.tsx
@@ -215,7 +215,7 @@ function TagBuilderField({
         </div>
       ))}
       {rows.length < 10 && (
-        <button type="button" onClick={addRow} className="text-sm text-accent hover:underline">
+        <button type="button" onClick={addRow} className="text-sm text-accent underline">
           {tFn('discoveryMode.addTag')}
         </button>
       )}

--- a/src/web/components/discovery-mode-info-box.tsx
+++ b/src/web/components/discovery-mode-info-box.tsx
@@ -38,7 +38,7 @@ export function DiscoveryModeInfoBox({
             }
             setDismissed(true)
           }}
-          className="text-xs font-medium text-accent hover:underline"
+          className="text-xs font-medium text-accent underline"
         >
           {t('discoveryMode.dismiss')}
         </button>

--- a/src/web/components/health-check-card.tsx
+++ b/src/web/components/health-check-card.tsx
@@ -94,7 +94,7 @@ export function HealthCheckCard({ check, onFix, fixing, lidarrBaseUrl }: Props) 
                   href={`${lidarrBaseUrl.replace(/\/$/, '')}/artist/${item.mbid}`}
                   target="_blank"
                   rel="noreferrer"
-                  className="font-medium text-accent hover:underline truncate"
+                  className="font-medium text-accent underline truncate"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {item.artistName}
@@ -114,7 +114,7 @@ export function HealthCheckCard({ check, onFix, fixing, lidarrBaseUrl }: Props) 
       {hasMore && (
         <button
           type="button"
-          className="text-xs text-accent hover:underline text-left w-fit"
+          className="text-xs text-accent underline text-left w-fit"
           onClick={() => setExpanded((v) => !v)}
         >
           {expanded ? 'Show less' : `Show all ${check.count}`}

--- a/src/web/components/import-artists.tsx
+++ b/src/web/components/import-artists.tsx
@@ -104,7 +104,7 @@ export function ImportArtists({
             ) : (
               <p className="text-xs text-muted italic">
                 {t('importArtists.connectSpotifyFirst').split('{0}')[0]}
-                <Link to="/settings" className="text-accent hover:underline">
+                <Link to="/settings" className="text-accent underline">
                   {t('nav.settings')}
                 </Link>
                 {t('importArtists.connectSpotifyFirst').split('{0}')[1]}
@@ -143,7 +143,7 @@ export function ImportArtists({
             ) : (
               <p className="text-xs text-muted italic">
                 {t('importArtists.connectSpotifyFirst').split('{0}')[0]}
-                <Link to="/settings" className="text-accent hover:underline">
+                <Link to="/settings" className="text-accent underline">
                   {t('nav.settings')}
                 </Link>
                 {t('importArtists.connectSpotifyFirst').split('{0}')[1]}

--- a/src/web/components/recommendation-card.tsx
+++ b/src/web/components/recommendation-card.tsx
@@ -176,7 +176,7 @@ function StatusBadge({
           <button
             type="button"
             onClick={() => onRetry(id)}
-            className="text-xs text-accent hover:underline"
+            className="text-xs text-accent underline"
           >
             {t('recommendation.retry')}
           </button>
@@ -841,7 +841,7 @@ export function RecommendationCard({
                 href={`https://musicbrainz.org/artist/${rec.artist.mbid}`}
                 target="_blank"
                 rel="noreferrer"
-                className="text-xs text-accent hover:underline"
+                className="text-xs text-accent underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 {t('recommendation.viewOnMusicBrainz')}

--- a/src/web/components/system-health-card.tsx
+++ b/src/web/components/system-health-card.tsx
@@ -114,7 +114,7 @@ export function SystemHealthCard({ embedded = false }: { embedded?: boolean }) {
             {t('systemHealth.title')}
           </h2>
         </div>
-        <Link to="/settings?tab=jobs" className="text-xs text-accent hover:underline">
+        <Link to="/settings?tab=jobs" className="text-xs text-accent underline">
           {t('systemHealth.viewHistory')}
         </Link>
       </div>

--- a/src/web/pages/dashboard.tsx
+++ b/src/web/pages/dashboard.tsx
@@ -59,7 +59,7 @@ function SectionHeader({
     <div className="flex items-center justify-between mb-3">
       <h2 className="text-sm font-semibold text-text uppercase tracking-wide">{title}</h2>
       {linkText && linkTo && (
-        <Link to={linkTo} className="text-xs text-accent hover:underline">
+        <Link to={linkTo} className="text-xs text-accent underline">
           {linkText}
         </Link>
       )}
@@ -85,7 +85,7 @@ function SubscriptionPulse({
         />
         <div className="bg-surface border border-border rounded-lg p-6 text-center space-y-2">
           <p className="text-sm text-muted">{t('dashboard.subscriptionsEmpty')}</p>
-          <Link to="/subscriptions" className="text-xs text-accent hover:underline inline-block">
+          <Link to="/subscriptions" className="text-xs text-accent underline inline-block">
             {t('dashboard.setUpAutomaticDiscovery')}
           </Link>
         </div>
@@ -168,7 +168,7 @@ function ListeningActivity({
       {!data || data.tracks.length === 0 ? (
         <div className="bg-surface border border-border rounded-lg p-6 text-center space-y-2">
           <p className="text-sm text-muted">{t('dashboard.connectListening')}</p>
-          <Link to="/settings" className="text-xs text-accent hover:underline inline-block">
+          <Link to="/settings" className="text-xs text-accent underline inline-block">
             {t('dashboard.connectAccount')}
           </Link>
         </div>

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -1157,11 +1157,7 @@ export function DiscoverPage() {
       {bulkMode && (
         <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 px-4 py-2.5 bg-surface border border-border rounded-lg shadow-lg text-sm">
           <span className="text-muted tabular-nums">{checkedIds.size} selected</span>
-          <button
-            type="button"
-            onClick={handleSelectAll}
-            className="text-xs text-accent hover:underline"
-          >
+          <button type="button" onClick={handleSelectAll} className="text-xs text-accent underline">
             {t('common.all')}
           </button>
           <button

--- a/src/web/pages/discovery-modes.tsx
+++ b/src/web/pages/discovery-modes.tsx
@@ -8,7 +8,7 @@ export function DiscoveryModesPage() {
   return (
     <div className="max-w-6xl mx-auto space-y-6 px-6 py-6">
       <div className="space-y-3">
-        <Link to="/discover" className="text-sm text-accent hover:underline">
+        <Link to="/discover" className="text-sm text-accent underline">
           {t('nav.recommendations')}
         </Link>
         <div className="space-y-1">

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -555,7 +555,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
         <>
           <IntegrationCapabilities />
           {/* Lidarr */}
-          <div className={isLidarrConfigured ? '' : 'opacity-60'}>
+          <div>
             <ServiceCard
               name="Lidarr"
               description={
@@ -565,7 +565,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                     href="https://wiki.servarr.com/lidarr/settings#security"
                     target="_blank"
                     rel="noreferrer"
-                    className="text-accent hover:underline"
+                    className="text-accent underline"
                   >
                     {t('settings.getApiKey')}
                   </a>
@@ -634,7 +634,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
           <Hint id="settings-ai-tip" type="inline">
             {t('settings.aiTip')}
           </Hint>
-          <div className={isAiConfigured ? '' : 'opacity-60'}>
+          <div>
             <ServiceCard
               name={aiProviderLabel}
               description={
@@ -645,7 +645,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                       href="https://console.anthropic.com/settings/keys"
                       target="_blank"
                       rel="noreferrer"
-                      className="text-accent hover:underline"
+                      className="text-accent underline"
                     >
                       {t('settings.getApiKey')}
                     </a>
@@ -655,7 +655,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                       href="https://platform.openai.com/api-keys"
                       target="_blank"
                       rel="noreferrer"
-                      className="text-accent hover:underline"
+                      className="text-accent underline"
                     >
                       {t('settings.getApiKey')}
                     </a>
@@ -665,7 +665,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                       href="https://aistudio.google.com/apikey"
                       target="_blank"
                       rel="noreferrer"
-                      className="text-accent hover:underline"
+                      className="text-accent underline"
                     >
                       {t('settings.getApiKey')}
                     </a>
@@ -675,7 +675,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                       href="https://ollama.com/library"
                       target="_blank"
                       rel="noreferrer"
-                      className="text-accent hover:underline"
+                      className="text-accent underline"
                     >
                       {t('settings.browseModels')}
                     </a>
@@ -827,7 +827,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
       </Hint>
 
       {/* ListenBrainz */}
-      <div className={isLbConfigured ? '' : 'opacity-60'}>
+      <div>
         <ServiceCard
           name="ListenBrainz"
           description={
@@ -837,7 +837,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                 href="https://listenbrainz.org/settings/"
                 target="_blank"
                 rel="noreferrer"
-                className="text-accent hover:underline"
+                className="text-accent underline"
               >
                 {t('settings.getToken')}
               </a>
@@ -897,7 +897,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
       </div>
 
       {/* Last.fm */}
-      <div className={isLfConfigured ? '' : 'opacity-60'}>
+      <div>
         <ServiceCard
           name="Last.fm"
           description={
@@ -907,7 +907,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                 href="https://www.last.fm/api/account/create"
                 target="_blank"
                 rel="noreferrer"
-                className="text-accent hover:underline"
+                className="text-accent underline"
               >
                 {t('settings.getApiKey')}
               </a>
@@ -965,7 +965,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
       </div>
 
       {/* Spotify */}
-      <div className={spotifyConnected ? '' : 'opacity-60'}>
+      <div>
         <ServiceCard
           name="Spotify"
           description={
@@ -975,7 +975,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                 href="https://developer.spotify.com/dashboard"
                 target="_blank"
                 rel="noreferrer"
-                className="text-accent hover:underline"
+                className="text-accent underline"
               >
                 {t('settings.createSpotifyApp')}
               </a>
@@ -1056,7 +1056,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
       </div>
 
       {/* Deezer */}
-      <div className={deezerConnected ? '' : 'opacity-60'}>
+      <div>
         <ServiceCard
           name={t('settings.deezer')}
           description={t('settings.deezerDescription')}
@@ -1157,7 +1157,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
       </div>
 
       {/* Plex */}
-      <div className={isPlexConfigured ? '' : 'opacity-60'}>
+      <div>
         <ServiceCard
           name="Plex"
           description={t('settings.plexDescription')}
@@ -1211,7 +1211,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
       </div>
 
       {/* Jellyfin */}
-      <div className={isJellyfinConfigured ? '' : 'opacity-60'}>
+      <div>
         <ServiceCard
           name="Jellyfin"
           description={t('settings.jellyfinDescription')}
@@ -1276,7 +1276,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
       </div>
 
       {/* Emby */}
-      <div className={isEmbyConfigured ? '' : 'opacity-60'}>
+      <div>
         <ServiceCard
           name="Emby"
           description={t('settings.embyDescription')}
@@ -1339,7 +1339,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
       </div>
 
       {/* Discogs */}
-      <div className={isDiscogsConfigured ? '' : 'opacity-60'}>
+      <div>
         <ServiceCard
           name="Discogs"
           description={

--- a/src/web/pages/setup.tsx
+++ b/src/web/pages/setup.tsx
@@ -345,7 +345,7 @@ function StepAi({
                 href={link.url}
                 target="_blank"
                 rel="noreferrer"
-                className="text-xs text-accent hover:underline"
+                className="text-xs text-accent underline"
               >
                 {t('setup.getApiKey')}
               </a>


### PR DESCRIPTION
Stacked on #135. Targets that PR's branch; rebase to \`main\` once #135 lands.

## Summary
- **Root cause:** settings a11y test surfaced `text-muted` at 2.66:1 rendered color (\`#9d9d9d\` on \`#fdfdfd\`). The raw \`--color-muted\` passes 5:1+ on every theme's surface; the \`opacity-60\` wrapper on unconfigured service cards was dimming both fg and bg into contrast failure. Drop the wrapper (10 occurrences in \`settings.tsx\`). The ServiceCard header already renders a status-dot + "Not configured" label, so the signal isn't lost.
- Force persistent \`underline\` on all 26 \`text-accent hover:underline\` call sites so in-text links satisfy WCAG 1.4.1 (non-color distinguisher) regardless of rendering opacity.
- Chore: exclude \`test-results/\` and \`playwright-report/\` from biome scan so transient Playwright artifacts don't trip lint.

All three a11y tests now green (setup + discover + settings).

## Test plan
- [x] \`bun run lint\` / \`bun run typecheck\` clean
- [x] \`bun run test\` 2030 passed
- [x] \`bun run test:e2e:a11y\` 3/3 passed
- [ ] Visual sanity check in browser (service cards no longer dim when unconfigured; the top-right "Not configured" chip remains the signal)
- [ ] CI green