### PR TITLE
feat(dashboard): swap subscriptions and listening history positions

### DIFF
--- a/src/web/pages/dashboard.tsx
+++ b/src/web/pages/dashboard.tsx
@@ -625,7 +625,7 @@ export function Dashboard() {
         {t('dashboard.feedbackTip')}
       </Hint>
 
-      {/* Recently Approved + Subscription Pulse */}
+      {/* Recently Approved + Listening Activity */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <SectionHeader
@@ -635,16 +635,6 @@ export function Dashboard() {
           />
           <RecentlyApproved recs={approvedRecs} loading={approvedLoading} />
         </div>
-        <div className="space-y-3">
-          <SubscriptionPulse subs={subsData} scheduler={schedulerData} />
-          <Hint id="dashboard-subscriptions-tip" type="inline">
-            {t('dashboard.subscriptionsTip')}
-          </Hint>
-        </div>
-      </div>
-
-      {/* Listening Activity + Taste Profile */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="space-y-3">
           <ListeningHistory
             data={topArtistsData}
@@ -661,6 +651,16 @@ export function Dashboard() {
             {t('dashboard.listeningTip')}
           </Hint>
           <RecentActivity data={recentTracksData} />
+        </div>
+      </div>
+
+      {/* Subscription Pulse + Taste Profile */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-3">
+          <SubscriptionPulse subs={subsData} scheduler={schedulerData} />
+          <Hint id="dashboard-subscriptions-tip" type="inline">
+            {t('dashboard.subscriptionsTip')}
+          </Hint>
         </div>
         <div className="space-y-3">
           <TasteProfile genres={tasteData} loading={tasteLoading} />


### PR DESCRIPTION
v1 RC touch-up. Replaces #152 (auto-closed by branch rename).

## Summary
- Subscriptions block moves from top-right to bottom-left
- Listening history (plus recently played) moves from bottom-left to top-right
- Pairs Recently Approved with Listening Activity above the fold; groups Subscriptions with Your Taste below

## Test plan
- [ ] Visual: dashboard renders with new ordering on desktop and mobile
- [ ] Hint dismiss state still persists per-section (subscriptions tip, listening tip)
- [ ] Recently Played still appears under Listening History in the new top-right slot