### PR TITLE
Fix Clear All batching on 0.44.x

### DIFF
--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -60,6 +60,7 @@ const STATUS_PARAM: Record<FilterTab, string | undefined> = {
 const APPROVE_THRESHOLD_OPTIONS = [50, 60, 70, 80, 90]
 
 const PAGE_SIZE = 50
+const CLEAR_ALL_BATCH_SIZE = 200
 
 function SkeletonGrid() {
   return (
@@ -661,14 +662,27 @@ export function DiscoverPage() {
 
   async function handleClearAll() {
     try {
-      const pending = await getRecommendations({ status: 'pending', limit: '10000' })
-      const ids = (pending.items as Array<{ id: number }>).map((r) => r.id)
-      if (ids.length === 0) {
+      let cleared = 0
+
+      while (true) {
+        const pending = await getRecommendations({
+          status: 'pending',
+          limit: String(CLEAR_ALL_BATCH_SIZE),
+        })
+        const ids = (pending.items as Array<{ id: number }>).map((r) => r.id)
+        if (ids.length === 0) break
+
+        const result = (await bulkAction(ids, 'reject')) as { updated?: number } | undefined
+        const updated = typeof result?.updated === 'number' ? result.updated : ids.length
+        cleared += updated
+        if (updated === 0 || ids.length < CLEAR_ALL_BATCH_SIZE) break
+      }
+
+      if (cleared === 0) {
         toast.info(t('discover.noPendingToClear'))
         return
       }
-      await bulkAction(ids, 'reject')
-      toast.success(`${t('discover.clearedCount')} ${ids.length}`)
+      toast.success(`${t('discover.clearedCount')} ${cleared}`)
       refetch()
     } catch {
       toast.error(t('discover.clearFailed'))

--- a/tests/web/pages/discover.test.tsx
+++ b/tests/web/pages/discover.test.tsx
@@ -283,6 +283,51 @@ describe('DiscoverPage', () => {
     })
   })
 
+  it('clears all pending recommendations in bounded batches', async () => {
+    mockBulkAction.mockResolvedValue(undefined as unknown as never)
+    const firstBatch = Array.from({ length: 200 }, (_, idx) => makeRec({ id: idx + 1 }))
+    const secondBatch = Array.from({ length: 50 }, (_, idx) => makeRec({ id: idx + 201 }))
+    const pendingBatches = [firstBatch, secondBatch, []]
+
+    mockGetRecommendations.mockImplementation((params) => {
+      const p = params as Record<string, string> | undefined
+      if (p?.status === 'pending' && p.limit === '200') {
+        return Promise.resolve(makeRes(pendingBatches.shift() ?? []))
+      }
+      if (p?.status === 'pending' && p.limit === '10000') {
+        return Promise.resolve(makeRes([...firstBatch, ...secondBatch]))
+      }
+      return Promise.resolve(makeRes([makeRec()]))
+    })
+    ;(getWarmStatuses as ReturnType<typeof vi.fn>).mockResolvedValue({ statuses: {} })
+    mockListTargets.mockResolvedValue([])
+
+    renderWithQuery(<DiscoverPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Clear All' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Reject All' }))
+
+    await waitFor(() => {
+      expect(mockBulkAction).toHaveBeenCalledTimes(2)
+    })
+    expect(mockBulkAction).toHaveBeenNthCalledWith(
+      1,
+      firstBatch.map((r) => r.id),
+      'reject',
+    )
+    expect(mockBulkAction).toHaveBeenNthCalledWith(
+      2,
+      secondBatch.map((r) => r.id),
+      'reject',
+    )
+    expect(
+      mockGetRecommendations.mock.calls.some(([params]) => {
+        const p = params as Record<string, string> | undefined
+        return p?.status === 'pending' && Number(p.limit) > 200
+      }),
+    ).toBe(false)
+  })
+
   it('reject button calls updateRecommendation', async () => {
     mockUpdateRecommendation.mockResolvedValue(undefined as unknown as never)
     setupMockApi()


### PR DESCRIPTION
## Summary
- Fetch pending recommendations for Clear All in API-sized batches instead of requesting limit=10000.
- Reject each batch separately and report the number actually cleared.
- Add a regression test covering multi-batch Clear All behavior.

Refs #158

## Test Plan
- bun run test tests/web/pages/discover.test.tsx
- bun run lint
- bun run typecheck
- bun run test tests/server/routes/auth.test.ts tests/server/middleware/auth.test.ts tests/web/pages/genres.test.tsx
- bunx vitest run --testTimeout=15000

Note: bun run test with the default 5s timeout had one unrelated auth test timeout locally; the same file passed when rerun directly, and the full suite passed with a 15s timeout.