### PR TITLE
fix(ci): authenticate Dependabot lockfile fetch with basic auth

### DIFF
--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -46,7 +46,7 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git -c http.extraheader="AUTHORIZATION: bearer ${GITHUB_TOKEN}" fetch --depth=1 origin "$HEAD_REF"
+          git fetch --depth=1 "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$HEAD_REF"
           git checkout --detach FETCH_HEAD
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2


### PR DESCRIPTION
## Problem

The `dependabot-bun-lockfile.yml` workflow's "Switch to Dependabot PR head" step fetched the PR head with an `AUTHORIZATION: bearer <token>` extraheader. GitHub's git-over-HTTPS endpoint rejects the bearer scheme, so the fetch 401'd, fell back to a username prompt, and died with `exit code 128` (`could not read Username for 'https://github.com'`).

Result: `bun.lock` was never regenerated, so it stayed out of sync with the bumped `package.json`, and `bun install --frozen-lockfile` failed on every npm Dependabot PR (lint/test/coverage/audit all cascaded red). The workflow has never successfully synced a lockfile.

## Fix

Fetch over an `https://x-access-token:${GITHUB_TOKEN}@github.com/...` basic-auth URL instead, matching the existing push step in the same job. Credentials remain non-persisted (explicit fetch URL, never written to git config), so the workflow's security model is unchanged: still fork-gated, still `--ignore-scripts`, still no `actions/checkout` on the PR head.

## Verification

- `yaml.safe_load` parses clean; `actionlint` reports no findings.
- Functional proof: recreate the open npm Dependabot PRs (#172, #175) and confirm the `sync-lockfile` job now succeeds and pushes a refreshed `bun.lock`.