### PR TITLE
chore(release): sync deploy digests to v1.0.0-rc.5

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.5"
-  digest: "sha256:0843728ff4497fbde2d101371ba2aea0493a0f7c8db3a5324510eef84c533d71"
+  digest: "sha256:2a2e967df0802ce677ecbebd48ebbd4f13725211618e7c9720dafa233c2b91a4"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:0843728ff4497fbde2d101371ba2aea0493a0f7c8db3a5324510eef84c533d71
+          image: ghcr.io/iuliandita/digarr@sha256:2a2e967df0802ce677ecbebd48ebbd4f13725211618e7c9720dafa233c2b91a4
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:0843728ff4497fbde2d101371ba2aea0493a0f7c8db3a5324510eef84c533d71"
+          image: "ghcr.io/iuliandita/digarr@sha256:2a2e967df0802ce677ecbebd48ebbd4f13725211618e7c9720dafa233c2b91a4"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:0843728ff4497fbde2d101371ba2aea0493a0f7c8db3a5324510eef84c533d71 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:2a2e967df0802ce677ecbebd48ebbd4f13725211618e7c9720dafa233c2b91a4 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.5</Repository>
    <Tag>1.0.0-rc.5</Tag>
    <TagDescription>v1.0.0-rc.5 prerelease</TagDescription>


### PR DESCRIPTION
Point the Helm/k8s/unraid deploy artefacts at the rc.5 image digest so the GitOps manifests resolve to the actually-shipped image instead of the previous one.

- Ran `bun scripts/sync-deploy-digests.ts v1.0.0-rc.5` -> `sha256:2a2e967df080…` (was `sha256:0843728ff449…`).
- Updated deploy/k8s/deployment.yaml, deploy/helm/digarr/values.yaml, deploy/unraid/digarr.xml; regenerated deploy/k8s/rendered.yaml.
- Verified all three deploy files carry the same digest (matches release.yml verify-digest-sync); no stale digest remains; lint clean.