### PR TITLE
chore(release): sync deploy digests to v1.0.0-rc.6

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.6"
-  digest: "sha256:2a2e967df0802ce677ecbebd48ebbd4f13725211618e7c9720dafa233c2b91a4"
+  digest: "sha256:834164cb70b411f28e0a51c4e918241bba8f997f09d30f330b371558cd40db33"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:2a2e967df0802ce677ecbebd48ebbd4f13725211618e7c9720dafa233c2b91a4
+          image: ghcr.io/iuliandita/digarr@sha256:834164cb70b411f28e0a51c4e918241bba8f997f09d30f330b371558cd40db33
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:2a2e967df0802ce677ecbebd48ebbd4f13725211618e7c9720dafa233c2b91a4"
+          image: "ghcr.io/iuliandita/digarr@sha256:834164cb70b411f28e0a51c4e918241bba8f997f09d30f330b371558cd40db33"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:2a2e967df0802ce677ecbebd48ebbd4f13725211618e7c9720dafa233c2b91a4 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:834164cb70b411f28e0a51c4e918241bba8f997f09d30f330b371558cd40db33 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.6</Repository>
    <Tag>1.0.0-rc.6</Tag>
    <TagDescription>v1.0.0-rc.6 prerelease</TagDescription>


### PR DESCRIPTION
Repoints the k8s, Helm, and Unraid image digests at the published v1.0.0-rc.6 multi-arch manifest (`sha256:834164cb...`) and regenerates `deploy/k8s/rendered.yaml` (helm 3.16.4). Standard post-release digest sync; follows the rc.5 #183 pattern.