### PR TITLE
fix(db): retry startup connection with exponential backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes are documented here.
 
 Releases that have been promoted to the `:stable` Docker channel carry a `(stable)` marker after the version heading. Promotion happens after a release has been live for at least seven days with no follow-up patch.
 
+## Unreleased
+
+### Fixed
+
+- The app no longer crash-loops when Postgres is still starting up (SQLSTATE 57P03 "not yet accepting connections"). The initial DB connection now retries with exponential backoff (1s to 30s cap) until Postgres finishes recovery, and the HTTP server only starts after the database is reachable.
+
 ## v1.0.0-rc.6 - 2026-05-29
 
 Dependency and toolchain maintenance release candidate.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,15 +43,16 @@ Async IIFE in `src/index.ts`:
 
 1. `createJobRecorder(db)` - module-level, before the IIFE
 2. `markStuck()` - flips any in-progress jobs left over from a crashed prior run
-3. `preFlightCheck()` - auto-backup if pending migrations are detected
-4. `migrate()` - drizzle-kit migrations
-5. `autoSetup()` - first-admin bootstrap when the env vars are present
-6. Bootstrap user setup
-7. Lidarr target backfill
-8. Pipeline scheduler
-9. Subscription scheduler
-10. Playlist scheduler
-11. `startStuckDetector()` - cron every 5 min, as the last boot step
+3. `waitForDatabase()` - retry/backoff until Postgres accepts connections (survives a slow PG startup without crash-looping on kubelet); the HTTP server only binds after this succeeds
+4. `preFlightCheck()` - auto-backup if pending migrations are detected
+5. `migrate()` - drizzle-kit migrations
+6. `autoSetup()` - first-admin bootstrap when the env vars are present
+7. Bootstrap user setup
+8. Lidarr target backfill
+9. Pipeline scheduler
+10. Subscription scheduler
+11. Playlist scheduler
+12. `startStuckDetector()` - cron every 5 min, as the last boot step
 
 ## Key invariants
 

--- a/src/db/wait.ts
+++ b/src/db/wait.ts
@@ -1,0 +1,97 @@
+import type { Pool } from 'pg'
+
+const STARTUP_RETRY_INITIAL_MS = 1_000
+const STARTUP_RETRY_MAX_MS = 30_000
+
+// Postgres SQLSTATE codes that mean "the server is up but not ready to serve
+// queries yet" (or the connection itself broke). All are safe to retry.
+const RETRYABLE_PG_CODES = new Set([
+  '57P03', // cannot_connect_now — still starting up / in recovery
+  '57P02', // crash_shutdown
+  '08000', // connection_exception
+  '08001', // sqlclient_unable_to_establish_sqlconnection
+  '08003', // connection_does_not_exist
+  '08004', // sqlserver_rejected_establishment_of_sqlconnection
+  '08006', // connection_failure
+  '08007', // transaction_resolution_unknown
+])
+
+// Node-level network errors raised before Postgres ever responds (server not
+// listening yet, DNS not resolved, etc.).
+const RETRYABLE_NET_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPIPE',
+])
+
+/**
+ * True for connection failures that are expected while Postgres is still
+ * starting up (57P03 "not yet accepting connections", ECONNREFUSED, etc.).
+ * Permanent errors such as bad credentials (28P01) return false so they
+ * propagate immediately instead of spinning behind the startup probe.
+ */
+export function isRetryableConnectionError(err: unknown): boolean {
+  if (err === null || typeof err !== 'object') return false
+  const code = (err as { code?: unknown }).code
+  if (typeof code !== 'string') return false
+  return RETRYABLE_PG_CODES.has(code) || RETRYABLE_NET_CODES.has(code)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export type WaitForDatabaseOptions = {
+  /** Initial backoff delay in ms, doubled each attempt up to maxDelayMs. */
+  initialDelayMs?: number
+  /** Upper bound on the per-attempt backoff delay. */
+  maxDelayMs?: number
+  /**
+   * Override the sleep between attempts. Tests inject a no-op to keep the
+   * suite fast; production leaves it undefined for real setTimeout backoff.
+   */
+  sleepFn?: (ms: number) => Promise<void>
+}
+
+/**
+ * Block at startup until Postgres accepts a connection and answers
+ * `SELECT 1`. Retries transient connection failures (server still in
+ * recovery, not listening yet, DNS flapping) with exponential backoff so a
+ * slow-starting Postgres doesn't crash-loop the pod on kubelet restarts.
+ *
+ * Permanent errors (bad credentials, etc.) propagate immediately. This is
+ * startup-only: runtime disconnects are recovered by the pool itself.
+ */
+export async function waitForDatabase(
+  pool: Pool,
+  options: WaitForDatabaseOptions = {},
+): Promise<void> {
+  const initialDelayMs = options.initialDelayMs ?? STARTUP_RETRY_INITIAL_MS
+  const maxDelayMs = options.maxDelayMs ?? STARTUP_RETRY_MAX_MS
+  const sleepFn = options.sleepFn ?? sleep
+
+  let attempt = 0
+  let delay = initialDelayMs
+  for (;;) {
+    attempt++
+    try {
+      await pool.query('SELECT 1')
+      if (attempt > 1) console.log(`[db] connected after ${attempt} attempt(s)`)
+      return
+    } catch (err: unknown) {
+      if (!isRetryableConnectionError(err)) throw err
+      const code = (err as { code?: string }).code ?? 'n/a'
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(
+        `[db] startup connect attempt ${attempt} failed (code=${code}): ${msg}; retrying in ${delay}ms`,
+      )
+      await sleepFn(delay)
+      delay = Math.min(delay * 2, maxDelayMs)
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,7 @@ import {
   recommendationBatches,
   recommendations,
 } from './db/schema'
+import { waitForDatabase } from './db/wait'
 import { createApp } from './server'
 import { resolveUserPreferences } from './server/helpers/preferences'
 
@@ -200,6 +201,12 @@ if (isEncryptionEnabled()) {
 } else {
   console.log('Field-level encryption disabled (set DIGARR_ENCRYPTION_KEY to enable)')
 }
+
+// Wait for Postgres to accept connections before any DB operation. A
+// slow-starting Postgres (still in recovery) rejects with SQLSTATE 57P03;
+// without this guard the first query rejects and kills the process,
+// crash-looping the pod on kubelet until PG finishes recovery.
+await waitForDatabase(pool)
 
 // Pre-flight check: detect pending migrations and auto-backup if needed.
 await runPreFlightCheck(db)

--- a/tests/db/wait.test.ts
+++ b/tests/db/wait.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+import type { Pool } from 'pg'
+import { describe, expect, it, vi } from 'vitest'
+import { isRetryableConnectionError, waitForDatabase } from '@/db/wait'
+
+function pgError(code: string, message = 'boom') {
+  const e = new Error(message) as Error & { code: string }
+  e.code = code
+  return e
+}
+
+// Pool whose `query` throws the supplied errors in order, then succeeds.
+function poolFailingThenSucceeding(errors: unknown[]) {
+  let i = 0
+  return {
+    query: vi.fn(async () => {
+      if (i < errors.length) throw errors[i++]
+      return { rows: [{ '?column?': 1 }] }
+    }),
+  }
+}
+
+describe('isRetryableConnectionError', () => {
+  it('classifies 57P03 (cannot_connect_now) as retryable', () => {
+    expect(isRetryableConnectionError(pgError('57P03'))).toBe(true)
+  })
+
+  it('classifies connection_failure (08006) as retryable', () => {
+    expect(isRetryableConnectionError(pgError('08006'))).toBe(true)
+  })
+
+  it('classifies ECONNREFUSED as retryable', () => {
+    expect(isRetryableConnectionError(pgError('ECONNREFUSED'))).toBe(true)
+  })
+
+  it('does not classify auth failure (28P01) as retryable', () => {
+    expect(isRetryableConnectionError(pgError('28P01'))).toBe(false)
+  })
+
+  it('does not classify non-error or codeless values', () => {
+    expect(isRetryableConnectionError(null)).toBe(false)
+    expect(isRetryableConnectionError(undefined)).toBe(false)
+    expect(isRetryableConnectionError('nope')).toBe(false)
+    expect(isRetryableConnectionError({})).toBe(false)
+    // numeric code (not a string) must not match
+    expect(isRetryableConnectionError({ code: 57_003 })).toBe(false)
+  })
+})
+
+describe('waitForDatabase', () => {
+  it('resolves on the first successful connection without sleeping', async () => {
+    const pool = { query: vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] }) }
+    const sleepFn = vi.fn().mockResolvedValue(undefined)
+    await waitForDatabase(pool as unknown as Pool, { sleepFn })
+    expect(pool.query).toHaveBeenCalledTimes(1)
+    expect(pool.query).toHaveBeenCalledWith('SELECT 1')
+    expect(sleepFn).not.toHaveBeenCalled()
+  })
+
+  it('retries transient failures with exponential backoff then succeeds', async () => {
+    const pool = poolFailingThenSucceeding([
+      pgError('57P03', 'the database system is not yet accepting connections'),
+      pgError('ECONNREFUSED'),
+    ])
+    const sleepFn = vi.fn().mockResolvedValue(undefined)
+    await waitForDatabase(pool as unknown as Pool, {
+      sleepFn,
+      initialDelayMs: 10,
+      maxDelayMs: 40,
+    })
+    expect(pool.query).toHaveBeenCalledTimes(3)
+    expect(sleepFn).toHaveBeenCalledTimes(2)
+    expect(sleepFn).toHaveBeenNthCalledWith(1, 10)
+    expect(sleepFn).toHaveBeenNthCalledWith(2, 20)
+  })
+
+  it('caps the backoff at maxDelayMs', async () => {
+    const pool = poolFailingThenSucceeding([
+      pgError('57P03'),
+      pgError('57P03'),
+      pgError('57P03'),
+      pgError('57P03'),
+    ])
+    const sleepFn = vi.fn().mockResolvedValue(undefined)
+    await waitForDatabase(pool as unknown as Pool, {
+      sleepFn,
+      initialDelayMs: 10,
+      maxDelayMs: 40,
+    })
+    expect(pool.query).toHaveBeenCalledTimes(5)
+    expect(sleepFn).toHaveBeenCalledTimes(4)
+    expect(sleepFn).toHaveBeenNthCalledWith(1, 10)
+    expect(sleepFn).toHaveBeenNthCalledWith(2, 20)
+    expect(sleepFn).toHaveBeenNthCalledWith(3, 40)
+    expect(sleepFn).toHaveBeenNthCalledWith(4, 40)
+  })
+
+  it('uses the default 1s/30s backoff when no delays are provided', async () => {
+    const pool = poolFailingThenSucceeding([pgError('57P03')])
+    const sleepFn = vi.fn().mockResolvedValue(undefined)
+    await waitForDatabase(pool as unknown as Pool, { sleepFn })
+    expect(sleepFn).toHaveBeenNthCalledWith(1, 1000)
+  })
+
+  it('propagates non-retryable errors immediately without sleeping', async () => {
+    const pool = {
+      query: vi.fn().mockRejectedValue(pgError('28P01', 'password authentication failed')),
+    }
+    const sleepFn = vi.fn().mockResolvedValue(undefined)
+    await expect(waitForDatabase(pool as unknown as Pool, { sleepFn })).rejects.toThrow(
+      'password authentication failed',
+    )
+    expect(pool.query).toHaveBeenCalledTimes(1)
+    expect(sleepFn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- The app crashed on startup when Postgres was still in recovery (SQLSTATE 57P03 "not yet accepting connections"), relying on kubelet restarts (~25 loops) to eventually connect. The unhandled rejection from the first DB query killed the process.
- Added `waitForDatabase(pool)` as the first DB operation on boot. It retries transient connection errors (57P03, the `08xxx` connection class, network errors like `ECONNREFUSED`) with exponential backoff (1s, 2s, 4s, 8s, capped at 30s), logging each attempt. Permanent errors (bad credentials, etc.) propagate immediately.
- The HTTP server only starts after the DB is reachable (top-level `await` ordering in `src/index.ts`). Runtime disconnect handling is unchanged (the pg pool's own reconnection). No k8s manifests or initContainers changed.

## Test plan

- [x] `bun run lint` passes (biome check clean on changed files)
- [x] `bun run typecheck` passes (`tsc --noEmit`)
- [x] `bun run test` passes — 10/10 new tests in `tests/db/wait.test.ts`; 3 pre-existing integration test files (`tests/core/library/*`) fail identically on clean `main` due to no live Postgres on this machine
- [ ] `bun run test:e2e` passes (no UI changes)
- [x] Reviewed via `claude -p` — no P0/P1 issues found; all 5 requirements verified

## Notes

- The k8s `startupProbe` (30 x 5s = 150s) bounds the retry window, so a genuinely wrong `DATABASE_URL` still fails loudly via kubelet rather than hanging invisibly.
- `src/db/wait.ts` uses a type-only `pg` import (no import-time side effects) so it's unit-testable without triggering pool creation.
- `docs/ARCHITECTURE.md` boot-order list updated with the new `waitForDatabase()` step.
