### PR TITLE
chore(release): sync deploy digests to v1.0.0-rc.7

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.7"
-  digest: "sha256:834164cb70b411f28e0a51c4e918241bba8f997f09d30f330b371558cd40db33"
+  digest: "sha256:06cc04983020205d875fd33a0bae753230c6b2fce3dac73ce67928fcb4b77d61"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:834164cb70b411f28e0a51c4e918241bba8f997f09d30f330b371558cd40db33
+          image: ghcr.io/iuliandita/digarr@sha256:06cc04983020205d875fd33a0bae753230c6b2fce3dac73ce67928fcb4b77d61
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:834164cb70b411f28e0a51c4e918241bba8f997f09d30f330b371558cd40db33"
+          image: "ghcr.io/iuliandita/digarr@sha256:06cc04983020205d875fd33a0bae753230c6b2fce3dac73ce67928fcb4b77d61"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:834164cb70b411f28e0a51c4e918241bba8f997f09d30f330b371558cd40db33 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:06cc04983020205d875fd33a0bae753230c6b2fce3dac73ce67928fcb4b77d61 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.7</Repository>
    <Tag>1.0.0-rc.7</Tag>
    <TagDescription>v1.0.0-rc.7 prerelease</TagDescription>


### PR DESCRIPTION
Repoint image digest pins in values.yaml, deployment.yaml, rendered.yaml, and the Unraid template to the published v1.0.0-rc.7 image (sha256:06cc0498...).