### PR TITLE
fix(targets): scope target list to owner for non-admins

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -370,7 +370,7 @@ Discovery-mode subscription notes:
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/api/v1/targets` | Yes | List all targets (config masked for non-owners) |
+| GET | `/api/v1/targets` | Yes | List targets. Admins see all targets (config masked for non-owners); non-admins see only their own |
 | POST | `/api/v1/targets` | Admin | Create target |
 | PATCH | `/api/v1/targets/:id` | Admin | Update target |
 | DELETE | `/api/v1/targets/:id` | Admin | Delete target |

--- a/src/server/routes/targets.ts
+++ b/src/server/routes/targets.ts
@@ -33,17 +33,30 @@ type TargetDeps = {
 export function targetRoutes(deps: TargetDeps) {
   const router = new Hono<HonoEnv>()
 
-  // Returns all targets. Each target includes `owned: true` if it belongs to the caller.
-  // Non-owners see masked configs and cannot modify/delete.
+  // Admins see every target (with masked configs); each row carries `owned: true`
+  // when it belongs to the caller. Non-admins see ONLY their own targets -- other
+  // users' target url/host/name/userId must not leak to a non-admin caller.
   router.get('/api/v1/targets', async (c) => {
     const userId = c.get('userId')
     if (!userId) return notAuthenticated(c)
+    const user = await deps.getUserById(userId)
+    const isAdmin = !!user?.isAdmin
     const page = readPagination(c)
     const shape = (t: TargetRow) => ({
       ...t,
       config: maskConfig(t.config),
       owned: t.userId === userId,
     })
+    // Non-admins are scoped to their own targets. getTargetsByUser is unpaginated
+    // (a user owns few targets), so return the full owned set in whichever response
+    // shape the caller asked for -- a single page with no continuation cursor.
+    if (!isAdmin) {
+      const owned = await deps.targetQueries.getTargetsByUser(userId)
+      const shaped = owned.map(shape)
+      return page === null
+        ? c.json(shaped)
+        : c.json({ data: shaped, meta: { limit: page.limit, nextCursor: null } })
+    }
     if (page === null) {
       const allTargets = await deps.targetQueries.getAllTargets()
       return c.json(allTargets.map(shape))

--- a/tests/server/routes/targets.test.ts
+++ b/tests/server/routes/targets.test.ts
@@ -19,11 +19,11 @@ const mockDeps = {
 
 const { targetRoutes } = await import('@/server/routes/targets')
 
-function createTestApp() {
+function createTestApp(userId = 1) {
   const app = new Hono<HonoEnv>()
   // Simulate auth middleware setting userId
   app.use('*', async (c, next) => {
-    c.set('userId', 1)
+    c.set('userId', userId)
     await next()
   })
   app.route('/', targetRoutes(mockDeps as never))
@@ -33,6 +33,12 @@ function createTestApp() {
 describe('target routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // clearAllMocks wipes call history but not implementations; re-assert the
+    // admin default so a per-test isAdmin:false override does not leak forward
+    // into the adminGuard-protected mutation tests.
+    mockDeps.getUserById.mockResolvedValue({ isAdmin: true })
+    mockDeps.targetQueries.getAllTargets.mockResolvedValue([])
+    mockDeps.targetQueries.getTargetsByUser.mockResolvedValue([])
   })
 
   it('GET /api/v1/targets returns all targets with ownership flag', async () => {
@@ -63,6 +69,66 @@ describe('target routes', () => {
     expect(body[0].config.apiKey).toBe('***')
     expect(body[0].owned).toBe(true)
     expect(body[1].owned).toBe(false)
+  })
+
+  it('GET /api/v1/targets scopes a non-admin to their own targets only', async () => {
+    // The non-admin caller (userId 2) must never receive another user's target.
+    mockDeps.getUserById.mockResolvedValue({ isAdmin: false })
+    mockDeps.targetQueries.getTargetsByUser.mockResolvedValue([
+      {
+        id: 2,
+        type: 'lidarr',
+        name: 'My Own Lidarr',
+        enabled: true,
+        userId: 2,
+        config: { url: 'http://mine:8686', apiKey: 'mine-secret' },
+      },
+    ])
+    // If the handler ever calls getAllTargets for a non-admin, this leak payload
+    // would surface in the response and fail the regression assertions below.
+    mockDeps.targetQueries.getAllTargets.mockResolvedValue([
+      {
+        id: 99,
+        type: 'lidarr',
+        name: 'Admin Secret Lidarr',
+        enabled: true,
+        userId: 1,
+        config: { url: 'http://other-user-host:8686', apiKey: 'leak' },
+      },
+    ])
+    const app = createTestApp(2)
+    const res = await app.request('/api/v1/targets')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].userId).toBe(2)
+    expect(body[0].owned).toBe(true)
+    expect(mockDeps.targetQueries.getTargetsByUser).toHaveBeenCalledWith(2)
+    expect(mockDeps.targetQueries.getAllTargets).not.toHaveBeenCalled()
+    // Regression guard: no field from another user's target may serialize.
+    const raw = JSON.stringify(body)
+    expect(raw).not.toContain('other-user-host')
+    expect(raw).not.toContain('Admin Secret Lidarr')
+    expect(raw).not.toContain('leak')
+  })
+
+  it('GET /api/v1/targets masks secrets in the non-admin owned list', async () => {
+    mockDeps.getUserById.mockResolvedValue({ isAdmin: false })
+    mockDeps.targetQueries.getTargetsByUser.mockResolvedValue([
+      {
+        id: 2,
+        type: 'lidarr',
+        name: 'My Own Lidarr',
+        enabled: true,
+        userId: 2,
+        config: { url: 'http://mine:8686', apiKey: 'mine-secret' },
+      },
+    ])
+    const app = createTestApp(2)
+    const res = await app.request('/api/v1/targets')
+    const body = await res.json()
+    expect(body[0].config.apiKey).toBe('***')
+    expect(JSON.stringify(body)).not.toContain('mine-secret')
   })
 
   it('POST /api/v1/targets creates a target', async () => {


### PR DESCRIPTION
## Summary

`GET /api/v1/targets` returned **every** user's targets to **any** authenticated caller. `maskConfig` only redacts `apiKey`/`token`/`password`/`secret`, so other users' target `url`/`host`/`name`/`userId` still leaked across accounts. The mutation routes were already `adminGuard`-wrapped; only the list read was open.

Resolve admin status inline (the same `getUserById` lookup `adminGuard` uses) and branch the data source:
- **admins** keep the full cross-user view via `getAllTargets`
- **non-admins** get only their own via the existing `getTargetsByUser`

This is decision **B1** from plan 008 (the cleaner security boundary, reuses an existing query).

## Test plan

- `bun run test tests/server/routes/targets.test.ts` -> 10/10 green
- New regression test asserts a second user's `url`/`host`/`name` never serialize for a non-admin, and secrets stay masked on the owned path
- `typecheck` 0, `lint` 0, `check-api-docs` 0