### PR TITLE
fix(auth): authorization hardening, non-admin approve-options, seed-button gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ entities.json
 # Compose secrets -- example files tracked, real values ignored
 deploy/docker/secrets/*
 !deploy/docker/secrets/*.example
+/plans/

--- a/docs/API.md
+++ b/docs/API.md
@@ -705,7 +705,7 @@ Settings notes:
 | GET | `/api/v1/lidarr/metadataprofiles` | Admin | Metadata profiles |
 | GET | `/api/v1/lidarr/rootfolders` | Admin | Root folders |
 | GET | `/api/v1/lidarr/approve-options` | Yes | Non-admin picker data for the approve dialog: quality/metadata profile names and root-folder paths only (no freeSpace/structure) |
-| POST | `/api/v1/lidarr/add` | Yes | Add artist to Lidarr |
+| POST | `/api/v1/lidarr/add` | Admin | Add artist to Lidarr |
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -198,7 +198,7 @@ Locale notes:
 | GET | `/api/v1/recommendations/:id` | Yes | Get single recommendation with artist data |
 | PATCH | `/api/v1/recommendations/:id` | Yes | Approve, reject, or restore a recommendation |
 | POST | `/api/v1/recommendations/bulk` | Yes | Bulk approve/reject |
-| GET | `/api/v1/recommendations/feedback-summary` | Yes | Genre approval rates (top 20) |
+| GET | `/api/v1/recommendations/feedback-summary` | Yes | Genre approval rates (top 20), scoped to the calling user's own feedback |
 
 **GET /api/v1/recommendations** query params:
 - `status` - `pending`, `approved`, `rejected`, `added_to_lidarr`, `add_failed` (comma-separated)
@@ -296,8 +296,8 @@ Notes:
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/api/v1/batches` | Yes | List all recommendation batches |
-| GET | `/api/v1/batches/:id` | Yes | Get batch details |
+| GET | `/api/v1/batches` | Admin | List all recommendation batches |
+| GET | `/api/v1/batches/:id` | Admin | Get batch details |
 
 Path params:
 - `:id` values are positive integers. Fractional, negative, zero, or unsafe integer values return `400`
@@ -322,7 +322,7 @@ Path params:
 | GET | `/api/v1/subscriptions/import/deezer-playlists` | Yes | List user's Deezer playlists |
 | POST | `/api/v1/subscriptions/import/deezer-playlists` | Yes | Import from a Deezer playlist (202) |
 | GET | `/api/v1/subscriptions/adapter-types` | Yes | Available adapter types with config schemas |
-| GET | `/api/v1/subscriptions/scheduler` | Yes | Scheduler job status |
+| GET | `/api/v1/subscriptions/scheduler` | Yes | Scheduler job status, scoped to the calling user's own subscriptions |
 | POST | `/api/v1/subscriptions/bulk-toggle` | Yes | Enable/disable all subscriptions |
 
 **Adapter types**: `genre`, `similar`, `discovery-mode`, `spotify-liked-songs`, `spotify-playlist`, `spotify-charts`, `deezer-favorites`, `deezer-followed`, `deezer-flow`, `deezer-playlists`, `lastfm-tag`, `lastfm-charts`, `listenbrainz`, `csv-import`
@@ -417,7 +417,7 @@ Discovery-mode subscription notes:
 | GET | `/api/v1/genres/search` | Yes | Search genres |
 | GET | `/api/v1/genres/:slug` | Yes | Genre detail with sub-genres and library artists |
 | GET | `/api/v1/genres/:slug/artists` | Yes | Artists by genre (view: recommended/trending/deep_cuts) |
-| POST | `/api/v1/genres/seed` | Yes | Seed genre database from Lidarr library (202) |
+| POST | `/api/v1/genres/seed` | Admin | Seed genre database from Lidarr library (202) |
 
 **GET /api/v1/genres/search** query params:
 - `q` - required search string, minimum 2 characters
@@ -700,10 +700,11 @@ Settings notes:
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| GET | `/api/v1/lidarr/stats` | Yes | Artist count, monitored count |
-| GET | `/api/v1/lidarr/profiles` | Yes | Quality profiles |
-| GET | `/api/v1/lidarr/metadataprofiles` | Yes | Metadata profiles |
-| GET | `/api/v1/lidarr/rootfolders` | Yes | Root folders |
+| GET | `/api/v1/lidarr/stats` | Admin | Artist count, monitored count |
+| GET | `/api/v1/lidarr/profiles` | Admin | Quality profiles |
+| GET | `/api/v1/lidarr/metadataprofiles` | Admin | Metadata profiles |
+| GET | `/api/v1/lidarr/rootfolders` | Admin | Root folders |
+| GET | `/api/v1/lidarr/approve-options` | Yes | Non-admin picker data for the approve dialog: quality/metadata profile names and root-folder paths only (no freeSpace/structure) |
 | POST | `/api/v1/lidarr/add` | Yes | Add artist to Lidarr |
 
 ---

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -9,6 +9,11 @@ login returns a session token delivered as both an `httpOnly; SameSite=Lax`
 cookie and an `Authorization: Bearer` token for SPA fetches. Tokens are
 SHA-256 hashed before storage.
 
+Logout (`POST /api/v1/auth/logout`) deletes the session server-side (by both
+the bearer and cookie token, if present) and clears the `digarr_session`
+cookie by emitting `Set-Cookie ... Max-Age=0; Path=/`, so a stale browser
+cookie cannot be replayed after sign-out.
+
 Registration is closed by default after the first user has been created. To
 open registration in a fresh install or internal deployment, set
 `DIGARR_DISABLE_REGISTRATION=false`.

--- a/src/core/pipeline/store.ts
+++ b/src/core/pipeline/store.ts
@@ -45,7 +45,7 @@ export interface StoreDb {
 
   getBlockedMbids: (userId: number) => Promise<Set<string>>
 
-  getFeedbackHistory: () => Promise<Map<string, { approved: number; total: number }>>
+  getFeedbackHistory: (userId?: number) => Promise<Map<string, { approved: number; total: number }>>
 
   lookupArtistMetadata?: (name: string) => Promise<{
     spotifyGenres: string[] | null

--- a/src/db/queries/recommendations.ts
+++ b/src/db/queries/recommendations.ts
@@ -218,9 +218,11 @@ export async function bulkUpdateStatus(db: Database, ids: number[], status: stri
 
 export async function getGenreFeedbackHistory(
   db: Database,
+  userId?: number,
 ): Promise<Map<string, { approved: number; total: number }>> {
   // Pushing the per-genre tally into SQL via unnest lets Postgres do the
   // hash-aggregate work - JS side only walks the reduced result.
+  const userFilter = userId !== undefined ? sql`AND r.user_id = ${userId}` : sql``
   const result = await db.execute(sql`
     SELECT
       genre,
@@ -231,6 +233,7 @@ export async function getGenreFeedbackHistory(
     CROSS JOIN LATERAL unnest(a.genres) AS genre
     WHERE r.acted_on_at IS NOT NULL
       AND a.genres IS NOT NULL
+      ${userFilter}
     GROUP BY genre
   `)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,7 @@ const storeDb: StoreDb = {
   },
   getRejectedMbids: (cooldownDays) => getRejectedArtistMbids(db, cooldownDays),
   getBlockedMbids: (userId) => getBlockedArtistMbids(db, userId),
-  getFeedbackHistory: () => getGenreFeedbackHistory(db),
+  getFeedbackHistory: (userId) => getGenreFeedbackHistory(db, userId),
   lookupArtistMetadata: (name) => lookupByName(db, name),
   getPopularityMap: () => getPopularityMap(db),
   getLibraryArtistsForUser: async (userId, options) => {
@@ -1299,7 +1299,7 @@ const app = createApp({
 
     return { success: false, message: `Unknown target type: ${type}` }
   },
-  getFeedbackHistory: () => getGenreFeedbackHistory(db),
+  getFeedbackHistory: (userId) => getGenreFeedbackHistory(db, userId),
   dashboardQueries: {
     getTopGenresForUser: (userId) => getTopGenresForUser(db, userId),
     getRecentActivity: (userId, isAdmin, limit) => getRecentActivity(db, userId, isAdmin, limit),

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -127,7 +127,7 @@ export interface RecommendationDeps {
   listBatches: (opts?: { limit?: number; cursor?: Cursor | null }) => Promise<BatchRow[]>
   getBatch: (id: number) => Promise<BatchRow | null>
   getArtistById: (id: number) => Promise<ArtistRow | null>
-  getFeedbackHistory: () => Promise<Map<string, { approved: number; total: number }>>
+  getFeedbackHistory: (userId?: number) => Promise<Map<string, { approved: number; total: number }>>
   listArtistBlocks: (params: {
     userId: number
     limit?: number

--- a/src/server/routes/auth.ts
+++ b/src/server/routes/auth.ts
@@ -1,5 +1,6 @@
 import { lookup } from 'node:dns/promises'
 import { type Context, Hono } from 'hono'
+import { deleteCookie, getCookie } from 'hono/cookie'
 import { envConfig } from '@/config/env'
 import { generateSessionToken, hashPassword, verifyPassword } from '@/core/auth'
 import { encryptField } from '@/core/crypto'
@@ -15,6 +16,7 @@ import type { AppDependencies } from '@/server'
 import { problem } from '@/server/helpers/problem'
 import { requireSessionUser } from '@/server/helpers/require-user'
 import { resolveRequestLocale } from '@/server/locale'
+import { SESSION_COOKIE_NAME } from '@/server/middleware/session-cookie'
 import {
   changePasswordSchema,
   registerSchema,
@@ -177,7 +179,11 @@ export function authRoutes(deps: AppDependencies) {
     const header = c.req.header('Authorization')
     if (header?.startsWith('Bearer ')) {
       await deleteSession(header.slice(7))
+    } else {
+      const cookieToken = getCookie(c, SESSION_COOKIE_NAME)
+      if (cookieToken) await deleteSession(cookieToken)
     }
+    deleteCookie(c, SESSION_COOKIE_NAME, { path: '/' })
     return c.body(null, 204)
   })
 

--- a/src/server/routes/batches.ts
+++ b/src/server/routes/batches.ts
@@ -3,11 +3,12 @@ import type { AppDependencies } from '@/server'
 import { readPagination } from '@/server/helpers/pagination'
 import { encodeCursor } from '@/server/helpers/pagination-cursor'
 import { parsePositiveIntParam } from '@/server/helpers/parse-int-clamp'
+import { adminGuard } from '@/server/middleware/admin-guard'
 
 export function batchRoutes(deps: AppDependencies) {
   const router = new Hono()
 
-  router.get('/api/v1/batches', async (c) => {
+  router.get('/api/v1/batches', adminGuard(deps.getUserById), async (c) => {
     const page = readPagination(c)
     if (page === null) {
       const batches = await deps.listBatches()
@@ -22,7 +23,7 @@ export function batchRoutes(deps: AppDependencies) {
     return c.json({ data, meta: { limit: page.limit, nextCursor } })
   })
 
-  router.get('/api/v1/batches/:id', async (c) => {
+  router.get('/api/v1/batches/:id', adminGuard(deps.getUserById), async (c) => {
     const id = parsePositiveIntParam(c.req.param('id'))
     if (id == null) return c.json({ error: 'Invalid batch ID' }, 400)
     const batch = await deps.getBatch(id)

--- a/src/server/routes/genres.ts
+++ b/src/server/routes/genres.ts
@@ -5,6 +5,7 @@ import { getArtistsByGenre, getGenreEnrichments } from '@/db/queries/artists'
 import { getGenreArtists } from '@/db/queries/recommendations'
 import type { AppDependencies } from '@/server'
 import { parseIntClamp } from '@/server/helpers/parse-int-clamp'
+import { adminGuard } from '@/server/middleware/admin-guard'
 import type { HonoEnv } from '@/server/types'
 
 export function genreRoutes(deps: AppDependencies) {
@@ -75,7 +76,7 @@ export function genreRoutes(deps: AppDependencies) {
     return c.json({ artists })
   })
 
-  router.post('/api/v1/genres/seed', async (c) => {
+  router.post('/api/v1/genres/seed', adminGuard(deps.getUserById), async (c) => {
     const settings = await deps.getSettings()
     if (!settings?.lidarrUrl || !settings?.lidarrApiKey) {
       return c.json({ error: 'Lidarr not configured' }, 400)

--- a/src/server/routes/lidarr.ts
+++ b/src/server/routes/lidarr.ts
@@ -48,6 +48,26 @@ export function lidarrRoutes(deps: AppDependencies) {
     return c.json(await client.getRootFolders())
   })
 
+  // Non-admin picker for the approve dialog. The four GETs above stay
+  // admin-only because they expose library structure and free-space; this
+  // endpoint returns only the fields the picker needs. The explicit .map
+  // projection is the security boundary -- never c.json a raw client object,
+  // as RootFolder carries freeSpace (and the types may gain fields later).
+  router.get('/api/v1/lidarr/approve-options', async (c) => {
+    const client = await getClient()
+    const [qualityProfiles, metadataProfiles, rootFolders] = await Promise.all([
+      client.getQualityProfiles(),
+      client.getMetadataProfiles(),
+      client.getRootFolders(),
+    ])
+    return c.json({
+      qualityProfiles: qualityProfiles.map((p) => ({ id: p.id, name: p.name })),
+      metadataProfiles: metadataProfiles.map((p) => ({ id: p.id, name: p.name })),
+      // path is kept as the picker label; freeSpace and any other fields drop.
+      rootFolders: rootFolders.map((f) => ({ id: f.id, path: f.path })),
+    })
+  })
+
   router.post(
     '/api/v1/lidarr/add',
     adminGuard(deps.getUserById),

--- a/src/server/routes/lidarr.ts
+++ b/src/server/routes/lidarr.ts
@@ -24,7 +24,7 @@ export function lidarrRoutes(deps: AppDependencies) {
 
   router.onError((err, c) => c.json({ error: errMsg(err) }, 500))
 
-  router.get('/api/v1/lidarr/stats', async (c) => {
+  router.get('/api/v1/lidarr/stats', adminGuard(deps.getUserById), async (c) => {
     const client = await getClient()
     const artists = await client.getArtists()
     return c.json({
@@ -33,17 +33,17 @@ export function lidarrRoutes(deps: AppDependencies) {
     })
   })
 
-  router.get('/api/v1/lidarr/metadataprofiles', async (c) => {
+  router.get('/api/v1/lidarr/metadataprofiles', adminGuard(deps.getUserById), async (c) => {
     const client = await getClient()
     return c.json(await client.getMetadataProfiles())
   })
 
-  router.get('/api/v1/lidarr/profiles', async (c) => {
+  router.get('/api/v1/lidarr/profiles', adminGuard(deps.getUserById), async (c) => {
     const client = await getClient()
     return c.json(await client.getQualityProfiles())
   })
 
-  router.get('/api/v1/lidarr/rootfolders', async (c) => {
+  router.get('/api/v1/lidarr/rootfolders', adminGuard(deps.getUserById), async (c) => {
     const client = await getClient()
     return c.json(await client.getRootFolders())
   })

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -316,7 +316,8 @@ export function recommendationRoutes(deps: AppDependencies) {
   })
 
   router.get('/api/v1/recommendations/feedback-summary', async (c) => {
-    const history = await deps.getFeedbackHistory()
+    const userId = c.get('userId')
+    const history = await deps.getFeedbackHistory(userId)
     const summary = [...history.entries()]
       .map(([genre, { approved, total }]) => ({
         genre,

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -686,7 +686,13 @@ export function subscriptionRoutes(deps: AppDependencies) {
     if (!userId) return notAuthenticated(c)
 
     const jobs = deps.scheduler.listJobs()
-    return c.json({ jobs })
+    const subs = await deps.subscriptionQueries.getSubscriptionsByUser(userId)
+    const ownedIds = new Set(subs.map((s) => String(s.id)))
+    const filtered = jobs.filter((j) => {
+      const m = j.name.match(/^subscription-(\d+)$/)
+      return m?.[1] ? ownedIds.has(m[1]) : false
+    })
+    return c.json({ jobs: filtered })
   })
 
   router.patch(

--- a/src/web/components/approve-dialog.tsx
+++ b/src/web/components/approve-dialog.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react'
-import { getLidarrMetadataProfiles, getLidarrProfiles, getLidarrRootFolders } from '../lib/api'
+import { getLidarrApproveOptions } from '../lib/api'
 import { useI18n } from '../lib/i18n'
 import type { MonitorOption } from './monitoring-options'
 import { Button } from './ui/button'
 
 type Profile = { id: number; name: string }
-type RootFolder = { id: number; path: string; freeSpace: number }
+type RootFolder = { id: number; path: string }
 
 type Props = {
   defaults: { qualityProfileId: number; metadataProfileId: number; rootFolderId: number }
@@ -31,11 +31,11 @@ export function ApproveDialog({ defaults, monitorOption, onConfirm, onCancel }: 
   const [error, setError] = useState(false)
 
   useEffect(() => {
-    Promise.all([getLidarrProfiles(), getLidarrMetadataProfiles(), getLidarrRootFolders()])
-      .then(([p, m, r]) => {
-        setProfiles(p as Profile[])
-        setMetadataProfiles(m as Profile[])
-        setRootFolders(r as RootFolder[])
+    getLidarrApproveOptions()
+      .then((opts) => {
+        setProfiles(opts.qualityProfiles)
+        setMetadataProfiles(opts.metadataProfiles)
+        setRootFolders(opts.rootFolders)
       })
       .catch(() => setError(true))
       .finally(() => setLoading(false))

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -370,6 +370,15 @@ export const getLidarrMetadataProfiles = () =>
   fetchApi<Array<{ id: number; name: string }>>('/lidarr/metadataprofiles')
 export const getLidarrRootFolders = () =>
   fetchApi<Array<{ id: number; path: string; freeSpace?: number }>>('/lidarr/rootfolders')
+// Non-admin-safe picker data for the approve dialog: profile names + root-folder
+// paths only, no freeSpace/structure. The three fns above stay for the admin
+// settings screen, which is allowed to see the full payloads.
+export const getLidarrApproveOptions = () =>
+  fetchApi<{
+    qualityProfiles: Array<{ id: number; name: string }>
+    metadataProfiles: Array<{ id: number; name: string }>
+    rootFolders: Array<{ id: number; path: string }>
+  }>('/lidarr/approve-options')
 
 // Library Health
 export type HealthCheckItem = {

--- a/src/web/pages/genres.tsx
+++ b/src/web/pages/genres.tsx
@@ -6,12 +6,16 @@ import { GenreGrid } from '../components/genre-grid'
 import { Hint } from '../components/hint'
 import { Input } from '../components/ui/input'
 import { usePullToRefresh } from '../hooks/use-pull-to-refresh'
-import { getGenres, searchGenres, seedGenres } from '../lib/api'
+import { getCurrentUser, getGenres, searchGenres, seedGenres } from '../lib/api'
 import { useI18n } from '../lib/i18n'
 
 export function GenresPage() {
   const { t } = useI18n()
   const queryClient = useQueryClient()
+  // Seeding genres calls POST /api/v1/genres/seed, which is admin-gated server-side.
+  // Hide the trigger from non-admins so they never see a control that always 403s.
+  const { data: currentUser } = useQuery({ queryKey: ['currentUser'], queryFn: getCurrentUser })
+  const isAdmin = currentUser?.isAdmin ?? false
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const [seeding, setSeeding] = useState(false)
@@ -98,14 +102,16 @@ export function GenresPage() {
       {isEmpty ? (
         <div className="py-16 text-center space-y-4">
           <p className="text-muted text-sm">{t('genres.empty')}</p>
-          <button
-            type="button"
-            onClick={handleSeed}
-            disabled={seeding}
-            className="px-4 py-2 bg-accent text-accent-fg rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {seeding ? t('genres.seeding') : t('genres.seedFromLibrary')}
-          </button>
+          {isAdmin && (
+            <button
+              type="button"
+              onClick={handleSeed}
+              disabled={seeding}
+              className="px-4 py-2 bg-accent text-accent-fg rounded-md text-sm font-medium hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {seeding ? t('genres.seeding') : t('genres.seedFromLibrary')}
+            </button>
+          )}
         </div>
       ) : (
         <div className="space-y-2">
@@ -136,45 +142,47 @@ export function GenresPage() {
         </div>
       )}
 
-      {/* FAB: Seed Genres - mobile only, above bottom nav */}
-      <button
-        type="button"
-        onClick={handleSeed}
-        disabled={seeding}
-        aria-label={seeding ? t('genres.seeding') : t('genres.seed')}
-        title={seeding ? t('genres.seeding') : t('genres.seedFromLibrary')}
-        className="md:hidden fixed bottom-20 right-4 z-30 w-12 h-12 rounded-full bg-accent text-accent-fg shadow-lg flex items-center justify-center hover:opacity-90 disabled:opacity-50 transition-opacity"
-      >
-        {seeding ? (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="w-5 h-5 animate-spin"
-            aria-hidden="true"
-          >
-            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-          </svg>
-        ) : (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="w-5 h-5"
-            aria-hidden="true"
-          >
-            <path d="M12 5v14M5 12h14" />
-          </svg>
-        )}
-      </button>
+      {/* FAB: Seed Genres - mobile only, above bottom nav. Admin-only (see above). */}
+      {isAdmin && (
+        <button
+          type="button"
+          onClick={handleSeed}
+          disabled={seeding}
+          aria-label={seeding ? t('genres.seeding') : t('genres.seed')}
+          title={seeding ? t('genres.seeding') : t('genres.seedFromLibrary')}
+          className="md:hidden fixed bottom-20 right-4 z-30 w-12 h-12 rounded-full bg-accent text-accent-fg shadow-lg flex items-center justify-center hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          {seeding ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-5 h-5 animate-spin"
+              aria-hidden="true"
+            >
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-5 h-5"
+              aria-hidden="true"
+            >
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+          )}
+        </button>
+      )}
     </div>
   )
 }

--- a/tests/server/routes/auth.test.ts
+++ b/tests/server/routes/auth.test.ts
@@ -507,6 +507,77 @@ describe('POST /api/v1/auth/logout', () => {
     })
     expect(res.status).toBe(401)
   })
+
+  it('clears the session cookie on logout', async () => {
+    const storedHash = hashPassword('password1234')
+    const app = createApp(
+      makeDeps({
+        getUserByUsername: vi.fn(async () => ({
+          id: 1,
+          username: 'testuser',
+          passwordHash: storedHash,
+          isAdmin: false,
+        })),
+        getUserCount: vi.fn(async () => 1),
+      }),
+    )
+
+    // Login
+    const loginRes = await app.request('/api/v1/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'testuser', password: 'password1234' }),
+    })
+    const { token } = await loginRes.json()
+
+    // Logout with Bearer token
+    const logoutRes = await app.request('/api/v1/auth/logout', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(logoutRes.status).toBe(204)
+    // The response should include a Set-Cookie header clearing the session cookie
+    const setCookie = logoutRes.headers.get('set-cookie')
+    expect(setCookie).not.toBeNull()
+    expect(setCookie).toContain('digarr_session=')
+    expect(setCookie?.toLowerCase()).toContain('max-age=0')
+  })
+
+  it('deletes session from cookie when no Bearer header is present', async () => {
+    const storedHash = hashPassword('password1234')
+    const app = createApp(
+      makeDeps({
+        getUserByUsername: vi.fn(async () => ({
+          id: 1,
+          username: 'testuser',
+          passwordHash: storedHash,
+          isAdmin: false,
+        })),
+        getUserCount: vi.fn(async () => 1),
+      }),
+    )
+
+    // Login
+    const loginRes = await app.request('/api/v1/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'testuser', password: 'password1234' }),
+    })
+    const { token } = await loginRes.json()
+
+    // Logout without Bearer header, using cookie instead
+    const logoutRes = await app.request('/api/v1/auth/logout', {
+      method: 'POST',
+      headers: { Cookie: `digarr_session=${token}` },
+    })
+    expect(logoutRes.status).toBe(204)
+
+    // Token should no longer work (session was deleted from DB)
+    const res = await app.request('/api/v1/settings', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(res.status).toBe(401)
+  })
 })
 
 describe('GET /api/v1/auth/me', () => {

--- a/tests/server/routes/batches.test.ts
+++ b/tests/server/routes/batches.test.ts
@@ -4,25 +4,46 @@ import { Hono } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
 import type { AppDependencies } from '@/server'
 import { batchRoutes } from '@/server/routes/batches'
+import type { HonoEnv } from '@/server/types'
 
 function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
   return {
     listBatches: vi.fn(async () => []),
     getBatch: vi.fn(async () => null),
+    getUserById: vi.fn(async (id: number) => ({ id, isAdmin: id === 1 })),
     ...overrides,
   } as unknown as AppDependencies
 }
 
-function makeApp(deps: AppDependencies) {
-  const app = new Hono()
+function makeApp(deps: AppDependencies, opts: { userId?: number; authSkipped?: boolean } = {}) {
+  const app = new Hono<HonoEnv>()
+  app.use('*', async (c, next) => {
+    if (opts.userId !== undefined) c.set('userId', opts.userId)
+    if (opts.authSkipped) c.set('authSkipped', true)
+    await next()
+  })
   app.route('/', batchRoutes(deps))
   return app
 }
 
+describe('GET /api/v1/batches', () => {
+  it('returns 403 for non-admin user', async () => {
+    const app = makeApp(makeDeps(), { userId: 2 })
+    const res = await app.request('/api/v1/batches')
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 for unauthenticated caller', async () => {
+    const app = makeApp(makeDeps())
+    const res = await app.request('/api/v1/batches')
+    expect(res.status).toBe(403)
+  })
+})
+
 describe('GET /api/v1/batches/:id', () => {
   it('rejects fractional ids before querying', async () => {
     const getBatch = vi.fn(async () => null)
-    const app = makeApp(makeDeps({ getBatch }))
+    const app = makeApp(makeDeps({ getBatch }), { userId: 1 })
 
     const res = await app.request('/api/v1/batches/1.5')
 

--- a/tests/server/routes/genres.test.ts
+++ b/tests/server/routes/genres.test.ts
@@ -145,7 +145,11 @@ function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
       createdAt: new Date(),
     })),
     getUserByUsername: vi.fn(async () => null),
-    getUserById: vi.fn(async () => null),
+    getUserById: vi.fn(async () => ({
+      id: 1,
+      username: 'admin',
+      isAdmin: true,
+    })) as unknown as AppDependencies['getUserById'],
     getUserCount: vi.fn(async () => 0),
     updatePassword: vi.fn(async () => {}),
     updateUserPreferredLocale: vi.fn(async () => {}),

--- a/tests/server/routes/lidarr.test.ts
+++ b/tests/server/routes/lidarr.test.ts
@@ -8,9 +8,13 @@ vi.mock('@/core/clients/lidarr', () => ({
   createLidarrClient: vi.fn(() => ({
     addArtist: vi.fn(async () => ({ id: 42, artistName: 'Test' })),
     getArtists: vi.fn(async () => []),
-    getMetadataProfiles: vi.fn(async () => []),
-    getQualityProfiles: vi.fn(async () => []),
-    getRootFolders: vi.fn(async () => []),
+    // Carry extra fields the approve-options projection must strip: profiles
+    // gain a stray prop, root folders carry freeSpace + structure metadata.
+    getMetadataProfiles: vi.fn(async () => [{ id: 10, name: 'Standard', extra: 'leak' }]),
+    getQualityProfiles: vi.fn(async () => [{ id: 20, name: 'FLAC', extra: 'leak' }]),
+    getRootFolders: vi.fn(async () => [
+      { id: 30, path: '/music', freeSpace: 9_999_999, unmappedFolders: ['/secret'] },
+    ]),
   })),
 }))
 
@@ -137,5 +141,44 @@ describe('GET /api/v1/lidarr/* (admin guard)', () => {
     const app = createTestApp({ userId: 2 })
     const res = await app.request('/api/v1/lidarr/metadataprofiles')
     expect(res.status).toBe(403)
+  })
+})
+
+describe('GET /api/v1/lidarr/approve-options (non-admin picker)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 200 with picker data for a non-admin user', async () => {
+    const app = createTestApp({ userId: 2 })
+    const res = await app.request('/api/v1/lidarr/approve-options')
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      qualityProfiles: Array<{ id: number; name: string }>
+      metadataProfiles: Array<{ id: number; name: string }>
+      rootFolders: Array<{ id: number; path: string }>
+    }
+    expect(body.qualityProfiles).toEqual([{ id: 20, name: 'FLAC' }])
+    expect(body.metadataProfiles).toEqual([{ id: 10, name: 'Standard' }])
+    expect(body.rootFolders).toEqual([{ id: 30, path: '/music' }])
+  })
+
+  it('projects away freeSpace and any structure metadata', async () => {
+    const app = createTestApp({ userId: 2 })
+    const res = await app.request('/api/v1/lidarr/approve-options')
+    const raw = await res.text()
+    // Regression guard for the .map projection: none of the stripped fields
+    // may leak into the serialized response.
+    expect(raw).not.toContain('freeSpace')
+    expect(raw).not.toContain('unmappedFolders')
+    expect(raw).not.toContain('extra')
+  })
+
+  // Unlike the four GETs above, this route omits adminGuard on purpose so a
+  // non-admin can populate the approve dialog. Login is still enforced, but by
+  // the app-level auth middleware (see src/server/index.ts), not here -- so
+  // there is no per-route auth assertion to make in this unit harness.
+  it('does not wrap the route in adminGuard (admin also gets 200)', async () => {
+    const app = createTestApp({ userId: 1 })
+    const res = await app.request('/api/v1/lidarr/approve-options')
+    expect(res.status).toBe(200)
   })
 })

--- a/tests/server/routes/lidarr.test.ts
+++ b/tests/server/routes/lidarr.test.ts
@@ -99,3 +99,43 @@ describe('POST /api/v1/lidarr/add', () => {
     expect(body.id).toBe(42)
   })
 })
+
+describe('GET /api/v1/lidarr/* (admin guard)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 403 for non-admin user on /rootfolders', async () => {
+    const app = createTestApp({ userId: 2 })
+    const res = await app.request('/api/v1/lidarr/rootfolders')
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 for unauthenticated caller on /rootfolders', async () => {
+    const app = createTestApp({})
+    const res = await app.request('/api/v1/lidarr/rootfolders')
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 200 for admin user on /rootfolders', async () => {
+    const app = createTestApp({ userId: 1 })
+    const res = await app.request('/api/v1/lidarr/rootfolders')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 403 for non-admin user on /stats', async () => {
+    const app = createTestApp({ userId: 2 })
+    const res = await app.request('/api/v1/lidarr/stats')
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 for non-admin user on /profiles', async () => {
+    const app = createTestApp({ userId: 2 })
+    const res = await app.request('/api/v1/lidarr/profiles')
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 for non-admin user on /metadataprofiles', async () => {
+    const app = createTestApp({ userId: 2 })
+    const res = await app.request('/api/v1/lidarr/metadataprofiles')
+    expect(res.status).toBe(403)
+  })
+})

--- a/tests/server/routes/recommendations.test.ts
+++ b/tests/server/routes/recommendations.test.ts
@@ -863,4 +863,11 @@ describe('GET /api/v1/recommendations/feedback-summary', () => {
     const body = await res.json()
     expect(body.summary).toHaveLength(0)
   })
+
+  it('scopes feedback history to the current user', async () => {
+    const getFeedbackHistory = vi.fn().mockResolvedValue(new Map())
+    const app = createApp(makeDeps({ getFeedbackHistory }))
+    await authedRequest(app, '/api/v1/recommendations/feedback-summary')
+    expect(getFeedbackHistory).toHaveBeenCalledWith(1)
+  })
 })

--- a/tests/server/routes/subscriptions.test.ts
+++ b/tests/server/routes/subscriptions.test.ts
@@ -634,6 +634,21 @@ describe('GET /api/v1/subscriptions/scheduler', () => {
     const res = await app.request('/api/v1/subscriptions/scheduler')
     expect(res.status).toBe(401)
   })
+
+  it('filters out jobs belonging to other users', async () => {
+    mockScheduler.listJobs.mockReturnValueOnce([
+      { name: 'subscription-1', expression: '0 9 * * *', nextRun: new Date('2026-04-01') },
+      { name: 'subscription-2', expression: '0 10 * * *', nextRun: new Date('2026-04-02') },
+      { name: 'subscription-99', expression: '0 11 * * *', nextRun: new Date('2026-04-03') },
+    ])
+    // User 42 owns subscription 1 only (mockSub.id = 1)
+    const app = createTestApp(makeDeps(), USER_ID)
+    const res = await app.request('/api/v1/subscriptions/scheduler')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.jobs).toHaveLength(1)
+    expect(body.jobs[0].name).toBe('subscription-1')
+  })
 })
 
 describe('DELETE /api/v1/subscriptions/:id', () => {

--- a/tests/web/pages/genres.test.tsx
+++ b/tests/web/pages/genres.test.tsx
@@ -19,6 +19,7 @@ function renderWithQuery(ui: ReactElement) {
 }
 
 vi.mock('@/web/lib/api', () => ({
+  getCurrentUser: vi.fn(),
   getGenres: vi.fn(),
   getUserPreferences: vi.fn().mockResolvedValue({ dismissedHints: [] }),
   searchGenres: vi.fn(),
@@ -34,13 +35,17 @@ vi.mock('sonner', () => ({
 }))
 
 import { toast } from 'sonner'
-import { getGenres, seedGenres } from '@/web/lib/api'
+import { getCurrentUser, getGenres, seedGenres } from '@/web/lib/api'
 import { GenresPage } from '@/web/pages/genres'
 
+const mockGetCurrentUser = vi.mocked(getCurrentUser)
 const mockGetGenres = vi.mocked(getGenres)
 const mockSeedGenres = vi.mocked(seedGenres)
 const mockToastSuccess = vi.mocked(toast.success)
 const mockToastError = vi.mocked(toast.error)
+
+const adminUser = { id: 1, username: 'admin', isAdmin: true } as never
+const regularUser = { id: 2, username: 'user', isAdmin: false } as never
 
 describe('GenresPage', () => {
   beforeEach(() => {
@@ -59,6 +64,7 @@ describe('GenresPage', () => {
       },
     })
     mockGetGenres.mockResolvedValue([])
+    mockGetCurrentUser.mockResolvedValue(adminUser)
   })
 
   it('uses translated seed toast messages in French', async () => {
@@ -91,5 +97,33 @@ describe('GenresPage', () => {
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("Échec de l'initialisation des genres")
     })
+  })
+
+  it('shows the seed button to an admin', async () => {
+    mockGetCurrentUser.mockResolvedValue(adminUser)
+
+    renderWithQuery(<GenresPage />)
+
+    expect(
+      await screen.findByRole('button', {
+        name: 'Initialiser les genres depuis votre bibliothèque',
+      }),
+    ).toBeTruthy()
+  })
+
+  it('hides the seed button from a non-admin', async () => {
+    mockGetCurrentUser.mockResolvedValue(regularUser)
+
+    renderWithQuery(<GenresPage />)
+
+    // Wait for the empty-state message to confirm the page rendered, then assert
+    // neither the empty-state seed button nor the mobile FAB is present.
+    await screen.findByText('Aucun genre dans votre bibliothèque pour le moment.')
+    expect(
+      screen.queryByRole('button', {
+        name: 'Initialiser les genres depuis votre bibliothèque',
+      }),
+    ).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Initialiser les genres' })).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Lands the authorization-hardening line of work (plans 001, 007, and 008 parts A + F):

- **001** `fix(auth)`: harden authorization and close IDOR gaps
- **007** `feat(lidarr)`: non-admin `GET /api/v1/lidarr/approve-options` (projected `{id,name}` profiles + `{id,path}` root folders, `freeSpace`/structure stripped); the four raw Lidarr GETs stay admin-only
- **008 A** `fix(genres)`: admin-gate the seed-genres UI control (empty-state button + mobile FAB hidden from non-admins, matching the already-gated `POST /genres/seed`)
- **008 F** `docs`: document logout teardown in AUTHENTICATION.md; correct `POST /lidarr/add` auth label to `Admin`

## Test plan

- Full suite green; `lidarr` route tests 14/14, `genres` web tests 4/4
- `typecheck` 0, `lint` 0, `check-api-docs` 0