### PR TITLE
docs(pipeline): document run/rescan as intentionally non-admin

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -144,6 +144,12 @@ Setup validation rules:
 | POST | `/api/v1/pipeline/quick-discover` | Yes | Fire-and-forget: discover artists similar to a given name. Rate limited: 5/min |
 | POST | `/api/v1/pipeline/rescan` | Yes | Re-fetch images/metadata for existing recommendations |
 
+`POST /api/v1/pipeline/run` and `/api/v1/pipeline/rescan` are intentionally
+available to any authenticated user (not admin-only): "Run Scan" is a core
+regular-user action on the dashboard and discover screens. Concurrency is
+bounded by a single-flight orchestrator, so a second run while one is active
+returns `409` rather than starting a parallel run.
+
 **POST /api/v1/pipeline/quick-discover** body:
 ```json
 { "artistName": "Radiohead" }

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -44,6 +44,11 @@ const EMPTY_DISCOVERY_SNAPSHOT = {
 export function pipelineRoutes(deps: AppDependencies) {
   const router = new Hono<HonoEnv>()
 
+  // Intentionally NOT admin-gated: "Run Scan" is a core regular-user action,
+  // reachable from the dashboard (TodaysPick) and discover surfaces. Any
+  // authenticated user may start a run; concurrency is bounded by the
+  // orchestrator.isRunning singleton (a second run returns 409), so the blast
+  // radius is one in-flight pipeline regardless of caller. See plan 008 Part C.
   router.post('/api/v1/pipeline/run', async (c) => {
     if (deps.orchestrator.isRunning) {
       return problem(
@@ -453,6 +458,8 @@ export function pipelineRoutes(deps: AppDependencies) {
   })
 
   // Re-resolve existing artists to update images/metadata
+  // Non-admin by design, same rationale as /pipeline/run above: any authenticated
+  // user may re-fetch images/metadata for existing recommendations.
   router.post('/api/v1/pipeline/rescan', async (c) => {
     const settings = await deps.getSettings()
     if (!settings?.lidarrUrl || !settings?.lidarrApiKey) {


### PR DESCRIPTION
## Summary

Plan 008 Part C considered admin-gating `POST /pipeline/{run,rescan}`, but both are called from non-admin surfaces (the dashboard `TodaysPick` "Run Scan" and two discover buttons), so gating them would break the core regular-user workflow. Resolution **C2**: leave them reachable by any authenticated user, bounded by the `orchestrator.isRunning` single-flight guard (409 on concurrent runs).

Adds intent comments at both routes and a note in `API.md` so the open-by-design choice is not mistaken for an oversight. **No behavior change.**

## Test plan

- `bun run test tests/server/routes/pipeline.test.ts` -> 12/12 green
- `typecheck` 0, `lint` 0, `check-api-docs` 0