### PR TITLE
refactor(jobs): extract recordFailureSafely for fire-and-forget failures

### DIFF
--- a/src/core/discovery-modes/run.ts
+++ b/src/core/discovery-modes/run.ts
@@ -3,6 +3,7 @@ import { executeDiscoveryMode } from '@/core/discovery-modes/executor'
 import { prepareDiscoveryModeRequest } from '@/core/discovery-modes/prepare'
 import type { DiscoveryModeRegistry } from '@/core/discovery-modes/registry'
 import type { DiscoveryModeRequest } from '@/core/discovery-modes/request'
+import { recordFailureSafely } from '@/core/jobs/record-failure-safely'
 import type { JobRecorder } from '@/core/jobs/types'
 import type { PipelineDeps, PipelineOrchestrator } from '@/core/pipeline/orchestrator'
 import { errMsg } from '@/core/validation'
@@ -105,7 +106,7 @@ export async function runDiscoveryMode({
     return { batchId: result.batchId, artistsFound: explicitCandidates.length }
   } catch (error: unknown) {
     if (jobId != null && jobRecorder) {
-      await jobRecorder.fail(jobId, errMsg(error)).catch(() => {})
+      await recordFailureSafely(jobRecorder, jobId, errMsg(error))
     }
     throw error
   }

--- a/src/core/jobs/record-failure-safely.ts
+++ b/src/core/jobs/record-failure-safely.ts
@@ -1,0 +1,20 @@
+import type { JobRecorder } from './types'
+
+/**
+ * Best-effort job-failure recording.
+ *
+ * Marks the job failed via `recorder.fail` and swallows any error the recorder
+ * itself throws, so a logging/DB hiccup never masks the original error the
+ * caller is already handling (every call site uses this from a `catch` block
+ * that goes on to rethrow or continue). `recorder.fail` already truncates long
+ * messages to 2048 chars; this wrapper adds nothing beyond swallowing the
+ * rejection. Callers that need to observe a recording failure (e.g. log it)
+ * should call `recorder.fail` directly instead.
+ */
+export async function recordFailureSafely(
+  recorder: JobRecorder,
+  jobId: number,
+  message: string,
+): Promise<void> {
+  await recorder.fail(jobId, message).catch(() => {})
+}

--- a/src/core/library/sync.ts
+++ b/src/core/library/sync.ts
@@ -1,5 +1,6 @@
 import PQueue from 'p-queue'
 import type { createMusicBrainzClient } from '@/core/clients/musicbrainz'
+import { recordFailureSafely } from '@/core/jobs/record-failure-safely'
 import type { JobRecorder, JobType } from '@/core/jobs/types'
 import { errMsg } from '@/core/validation'
 import { type ReconciledAlbum, reconcileAlbumsForArtist } from './album-reconciler'
@@ -218,11 +219,7 @@ export function createSyncOrchestrator(deps: SyncOrchestratorDeps) {
         // best-effort
       }
       if (jobId !== null) {
-        try {
-          await deps.recorder.fail(jobId, error)
-        } catch {
-          // best-effort
-        }
+        await recordFailureSafely(deps.recorder, jobId, error)
       }
       return { source: source.id, status: 'failed', error }
     }

--- a/src/core/pipeline/auto-approve.ts
+++ b/src/core/pipeline/auto-approve.ts
@@ -1,3 +1,4 @@
+import { recordFailureSafely } from '@/core/jobs/record-failure-safely'
 import type { DestinationTarget, TargetAddOptions } from '@/core/targets/types'
 import type { StatusUpdateExtra } from '@/db/queries/recommendations'
 
@@ -120,9 +121,11 @@ export async function autoApprove(
             },
           })
         } else {
-          await deps.jobRecorder
-            .fail(targetJobId, result.error ?? 'Target returned failure')
-            .catch(() => {})
+          await recordFailureSafely(
+            deps.jobRecorder,
+            targetJobId,
+            result.error ?? 'Target returned failure',
+          )
         }
       }
     }

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -8,6 +8,7 @@ import { createMusicinfoClient } from '@/core/clients/musicinfo'
 import { decryptField } from '@/core/crypto'
 import type { SupportedLocale } from '@/core/i18n/locales'
 import { createTranslator } from '@/core/i18n/translator'
+import { recordFailureSafely } from '@/core/jobs/record-failure-safely'
 import { sendWebhook } from '@/core/notifications'
 import { createDiscogsSource } from '@/core/plugins/discogs'
 import { createEmbySource } from '@/core/plugins/emby'
@@ -489,7 +490,7 @@ export class PipelineOrchestrator extends EventEmitter {
       return { batchId }
     } catch (err: unknown) {
       if (jobId != null && deps.jobRecorder) {
-        await deps.jobRecorder.fail(jobId, errMsg(err)).catch(() => {})
+        await recordFailureSafely(deps.jobRecorder, jobId, errMsg(err))
       }
       this.emit('error', err)
       throw err

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { resolveDeezerToken } from './core/deezer-auth'
 import { createDefaultDiscoveryModeRegistry } from './core/discovery-modes/registry'
 import { runDiscoveryMode } from './core/discovery-modes/run'
 import { GenreService } from './core/genre/service'
+import { recordFailureSafely } from './core/jobs/record-failure-safely'
 import { createJobRecorder } from './core/jobs/recorder'
 import { startStuckDetector } from './core/jobs/stuck-detector'
 import { createAlbumCoverageService } from './core/library/album-coverage'
@@ -1089,7 +1090,7 @@ async function executePlaylistGeneration(playlistId: number): Promise<void> {
     }
   } catch (err: unknown) {
     if (jobId != null) {
-      await jobRecorder.fail(jobId, errMsg(err)).catch(() => {})
+      await recordFailureSafely(jobRecorder, jobId, errMsg(err))
     }
     throw err
   }

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -12,6 +12,7 @@ import type { DiscoveryModeRequest } from '@/core/discovery-modes/request'
 import { normalizeDiscoveryModeRequest } from '@/core/discovery-modes/request'
 import { buildDiscoveryModeJobMetadata } from '@/core/discovery-modes/run'
 import { detectPromptLocale } from '@/core/i18n/prompt-locale'
+import { recordFailureSafely } from '@/core/jobs/record-failure-safely'
 import type { AutoApproveDeps } from '@/core/pipeline/auto-approve'
 import { filter } from '@/core/pipeline/filter'
 import type { PipelineDeps } from '@/core/pipeline/orchestrator'
@@ -441,7 +442,7 @@ export function pipelineRoutes(deps: AppDependencies) {
         }
       } catch (err: unknown) {
         if (jobId != null && jobRecorder) {
-          await jobRecorder.fail(jobId, errMsg(err)).catch(() => {})
+          await recordFailureSafely(jobRecorder, jobId, errMsg(err))
         }
         console.error('Quick discover failed:', err)
       }

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { selectPopularReleaseGroups } from '@/core/albums/popular'
 import { createMusicBrainzClient } from '@/core/clients/musicbrainz'
 import { createSpotifyClient } from '@/core/clients/spotify'
+import { recordFailureSafely } from '@/core/jobs/record-failure-safely'
 import { resolveSpotifyToken } from '@/core/spotify-auth'
 import { mergePreferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
@@ -132,7 +133,7 @@ async function addArtistToTarget(
         },
       })
     } else {
-      await jobRecorder.fail(targetJobId, result.error ?? 'Target returned failure').catch(() => {})
+      await recordFailureSafely(jobRecorder, targetJobId, result.error ?? 'Target returned failure')
     }
   }
 

--- a/tests/core/jobs/record-failure-safely.test.ts
+++ b/tests/core/jobs/record-failure-safely.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest'
+import { recordFailureSafely } from '@/core/jobs/record-failure-safely'
+import type { JobRecorder } from '@/core/jobs/types'
+
+function fakeRecorder(fail: JobRecorder['fail']): JobRecorder {
+  return {
+    start: vi.fn(),
+    complete: vi.fn(),
+    fail,
+    markStuck: vi.fn(),
+  } as unknown as JobRecorder
+}
+
+describe('recordFailureSafely', () => {
+  it('forwards jobId and message to recorder.fail', async () => {
+    const fail = vi.fn().mockResolvedValue(undefined)
+    await recordFailureSafely(fakeRecorder(fail), 7, 'boom')
+    expect(fail).toHaveBeenCalledWith(7, 'boom')
+  })
+
+  it('swallows a rejecting recorder.fail so the caller can rethrow the real error', async () => {
+    const fail = vi.fn().mockRejectedValue(new Error('db down'))
+    await expect(recordFailureSafely(fakeRecorder(fail), 7, 'boom')).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

The "mark job failed, swallow any recorder error" pattern was duplicated across seven call sites. Wrap it once in `recordFailureSafely(recorder, jobId, message)` so the swallow intent is documented in one place. `recorder.fail` still owns the 2048-char truncation; the helper only swallows the rejection. **Pure refactor, no behavior change.**

`subscriptions/runner.ts` is deliberately left alone: it logs the recorder error rather than swallowing it (different intent).

## Test plan

- Touched-module suites green (390 tests); new helper unit test 2/2
- `typecheck` 0, `lint` 0