### PR TITLE
chore(deps): bump hono to ^4.12.26 to clear CORS advisory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@hono/zod-validator": "^0.8.0",
         "croner": "^10.0.1",
         "drizzle-orm": "^0.45.2",
-        "hono": "^4.12.23",
+        "hono": "^4.12.26",
         "openai": "^6.39.1",
         "openid-client": "^6.8.4",
         "p-queue": "^9.3.0",
@@ -392,7 +392,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.12.23", "", {}, "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="],
+    "hono": ["hono@4.12.26", "", {}, "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@hono/zod-validator": "^0.8.0",
     "croner": "^10.0.1",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.12.23",
+    "hono": "^4.12.26",
     "openai": "^6.39.1",
     "openid-client": "^6.8.4",
     "p-queue": "^9.3.0",


### PR DESCRIPTION
## Summary

`bun audit` flagged `hono <4.12.25` HIGH (GHSA-88fw-hqm2-52qc: CORS middleware reflects any Origin with credentials when `origin` defaults to wildcard) plus several moderate advisories. digarr does not use the vulnerable wildcard-credentials default, but hono is a direct dependency and the patch is cheap. Bumped to `4.12.26` (latest stable 4.x); `bun install` refreshed the lockfile.

Dev-only `vite`/`undici` advisories left untouched per plan 008 E.

## Test plan

- Full suite green (2194 passed / 25 pre-existing skips)
- `typecheck` 0, `lint` 0
- `bun audit | grep hono` -> advisory cleared