### PR TITLE
chore(release): sync deploy digests to v1.0.0-rc.8

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.8"
-  digest: "sha256:06cc04983020205d875fd33a0bae753230c6b2fce3dac73ce67928fcb4b77d61"
+  digest: "sha256:9fc2859f1766bed2b973ff05788e9bbc45f0fc8b4ed06f62e4142de74a60fee2"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:06cc04983020205d875fd33a0bae753230c6b2fce3dac73ce67928fcb4b77d61
+          image: ghcr.io/iuliandita/digarr@sha256:9fc2859f1766bed2b973ff05788e9bbc45f0fc8b4ed06f62e4142de74a60fee2
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:06cc04983020205d875fd33a0bae753230c6b2fce3dac73ce67928fcb4b77d61"
+          image: "ghcr.io/iuliandita/digarr@sha256:9fc2859f1766bed2b973ff05788e9bbc45f0fc8b4ed06f62e4142de74a60fee2"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:06cc04983020205d875fd33a0bae753230c6b2fce3dac73ce67928fcb4b77d61 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:9fc2859f1766bed2b973ff05788e9bbc45f0fc8b4ed06f62e4142de74a60fee2 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.8</Repository>
    <Tag>1.0.0-rc.8</Tag>
    <TagDescription>v1.0.0-rc.8 prerelease</TagDescription>


### PR DESCRIPTION
## Summary

Post-release digest sync for **v1.0.0-rc.8** (mirrors #202 for rc.7). Repoints the digarr image digest in `deploy/k8s/deployment.yaml`, `deploy/helm/digarr/values.yaml`, and `deploy/unraid/digarr.xml` to the published rc.8 image (`sha256:9fc2859f...`), and regenerates `deploy/k8s/rendered.yaml` (helm 3.16.4) to match.

The release commit (#209) left the digest at the rc.7 image; `verify-digest-sync` passed because the three files agreed with each other. This realigns them with the actual rc.8 image for reproducibility.

## Test plan

- `scripts/sync-deploy-digests.ts v1.0.0-rc.8` produced the new digest from the published image
- `rendered.yaml` regenerated deterministically with helm 3.16.4 -> `helm-drift` passes
- `lint` 0