### PR TITLE
test(e2e): recommendation-seed harness + enable 4 fixme specs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,8 +9,10 @@ const webServer =
           port: 3000,
           reuseExistingServer: false,
           timeout: 30_000,
-          // Registers the test-only seed route (POST /api/v1/test/seed-recommendations).
-          env: { ...process.env, NODE_ENV: 'test' },
+          // NODE_ENV=test registers the seed route (POST /api/v1/test/seed-recommendations).
+          // DIGARR_DISABLE_RATE_LIMIT lifts the per-IP login budget so the many
+          // logins across specs in one window don't 429 the later specs.
+          env: { ...process.env, NODE_ENV: 'test', DIGARR_DISABLE_RATE_LIMIT: '1' },
         },
         {
           command: 'bun run dev:web',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,8 @@ const webServer =
           port: 3000,
           reuseExistingServer: false,
           timeout: 30_000,
+          // Registers the test-only seed route (POST /api/v1/test/seed-recommendations).
+          env: { ...process.env, NODE_ENV: 'test' },
         },
         {
           command: 'bun run dev:web',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -43,6 +43,7 @@ import { setupRoutes } from './routes/setup'
 import { slskdRoutes } from './routes/slskd'
 import { subscriptionRoutes } from './routes/subscriptions'
 import { targetRoutes } from './routes/targets'
+import { testSeedRoutes } from './routes/test-seed'
 import { userRoutes } from './routes/users'
 import type { HonoEnv } from './types'
 
@@ -346,6 +347,13 @@ export function createApp(deps: AppDependencies) {
   )
   if (deps.search) {
     app.route('/', searchRoutes(deps.search))
+  }
+
+  // Test-only seed routes. The `=== 'test'` guard is inlined to `false` by Bun
+  // at production build time (Dockerfile sets NODE_ENV=production), so this
+  // branch and the imported module are tree-shaken out of the prod bundle.
+  if (process.env.NODE_ENV === 'test') {
+    app.route('/', testSeedRoutes(deps))
   }
 
   // Serve built SPA in production (dev uses Vite's dev server with proxy)

--- a/src/server/middleware/rate-limit.ts
+++ b/src/server/middleware/rate-limit.ts
@@ -50,6 +50,13 @@ export function rateLimiter(opts: { windowMs: number; max: number; keyPrefix?: s
   ensurePruneStarted()
 
   return createMiddleware<HonoEnv>(async (c, next) => {
+    // Test-only escape hatch: browser E2E suites perform many logins across
+    // specs within one window and would otherwise trip the per-IP budget. The
+    // `NODE_ENV !== 'production'` guard is inlined to `false` and tree-shaken in
+    // a production build, so this can never be enabled in prod.
+    if (process.env.NODE_ENV !== 'production' && process.env.DIGARR_DISABLE_RATE_LIMIT === '1') {
+      return next()
+    }
     // Use socket IP to prevent bypass via forged X-Forwarded-For headers.
     // Same approach as proxy-auth.ts getSocketIp().
     const ip = getSocketIp(c) ?? 'unknown'

--- a/src/server/routes/test-seed.ts
+++ b/src/server/routes/test-seed.ts
@@ -1,0 +1,145 @@
+import { and, eq, inArray } from 'drizzle-orm'
+import { Hono } from 'hono'
+import { artists, recommendationBatches, recommendations } from '@/db/schema'
+import type { AppDependencies } from '@/server'
+import { notAuthenticated } from '@/server/helpers/auth-problems'
+import type { HonoEnv } from '@/server/types'
+
+// Fixed, deterministic seed set. UUIDs are stable so re-seeding upserts the same
+// artist rows instead of accumulating duplicates. Each artist carries a cached
+// Wikidata enrichment (description + externalLinks + wikidataId + a fresh
+// wikidataFetchedAt) so the enrichment endpoint serves the bio from cache with
+// no live upstream call, keeping the metadata-enrichment E2E deterministic.
+const SEED_ARTISTS = [
+  {
+    mbid: 'aaaaaaaa-0000-4000-8000-000000000001',
+    name: 'Seed Artist Alpha',
+    genres: ['indie rock', 'art rock'],
+    score: 0.92,
+    wikidataId: 'Q100000001',
+    description: 'Seed Artist Alpha is a fictional indie rock act used by the E2E harness.',
+    streamingUrls: { spotify: 'https://open.spotify.com/artist/seed-alpha' },
+    externalLinks: {
+      wikipedia: 'https://en.wikipedia.org/wiki/Seed_Artist_Alpha',
+      officialSite: 'https://example.com/seed-alpha',
+      discogs: 'https://www.discogs.com/artist/seed-alpha',
+    },
+  },
+  {
+    mbid: 'aaaaaaaa-0000-4000-8000-000000000002',
+    name: 'Seed Artist Bravo',
+    genres: ['synthpop'],
+    score: 0.81,
+    wikidataId: 'Q100000002',
+    description: 'Seed Artist Bravo is a fictional synthpop act used by the E2E harness.',
+    streamingUrls: { spotify: 'https://open.spotify.com/artist/seed-bravo' },
+    externalLinks: {
+      wikipedia: 'https://en.wikipedia.org/wiki/Seed_Artist_Bravo',
+    },
+  },
+  {
+    mbid: 'aaaaaaaa-0000-4000-8000-000000000003',
+    name: 'Seed Artist Charlie',
+    genres: ['folk'],
+    score: 0.74,
+    wikidataId: 'Q100000003',
+    description: 'Seed Artist Charlie is a fictional folk act used by the E2E harness.',
+    streamingUrls: { spotify: 'https://open.spotify.com/artist/seed-charlie' },
+    externalLinks: {
+      wikipedia: 'https://en.wikipedia.org/wiki/Seed_Artist_Charlie',
+    },
+  },
+] as const
+
+/**
+ * Test-only routes. Registered by `createApp` ONLY when `NODE_ENV === 'test'`.
+ * The production Docker image sets `NODE_ENV=production` before `bun run build`,
+ * so Bun inlines that guard to `false` and tree-shakes this whole module out of
+ * the bundle: the seed endpoint cannot exist in a production build.
+ */
+export function testSeedRoutes(deps: AppDependencies) {
+  const router = new Hono<HonoEnv>()
+
+  // Seed a fixed set of pending recommendations (and their artists) for the
+  // authenticated user so browser tests have something to approve/reject.
+  router.post('/api/v1/test/seed-recommendations', async (c) => {
+    const userId = c.get('userId')
+    if (typeof userId !== 'number') return notAuthenticated(c)
+
+    const db = deps.db
+    const now = new Date()
+
+    const artistIds: number[] = []
+    for (const seed of SEED_ARTISTS) {
+      const [row] = await db
+        .insert(artists)
+        .values({
+          mbid: seed.mbid,
+          name: seed.name,
+          tags: [...seed.genres],
+          genres: [...seed.genres],
+          streamingUrls: seed.streamingUrls,
+          description: { en: seed.description },
+          externalLinks: seed.externalLinks,
+          wikidataId: seed.wikidataId,
+          wikidataFetchedAt: now,
+          cachedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: artists.mbid,
+          set: {
+            name: seed.name,
+            description: { en: seed.description },
+            externalLinks: seed.externalLinks,
+            wikidataId: seed.wikidataId,
+            wikidataFetchedAt: now,
+            cachedAt: now,
+          },
+        })
+        .returning({ id: artists.id })
+      if (row) artistIds.push(row.id)
+    }
+
+    // Clear any prior seeded recommendations for this user so repeated seed
+    // calls leave a known, duplicate-free state.
+    if (artistIds.length > 0) {
+      await db
+        .delete(recommendations)
+        .where(
+          and(eq(recommendations.userId, userId), inArray(recommendations.artistId, artistIds)),
+        )
+    }
+
+    const [batch] = await db
+      .insert(recommendationBatches)
+      .values({
+        status: 'completed',
+        stats: { discovered: SEED_ARTISTS.length, added: SEED_ARTISTS.length, failed: 0 },
+      })
+      .returning({ id: recommendationBatches.id })
+
+    if (!batch) throw new Error('seed-recommendations: failed to create batch')
+
+    for (let i = 0; i < artistIds.length; i++) {
+      const seed = SEED_ARTISTS[i]
+      const artistId = artistIds[i]
+      if (!seed || artistId === undefined) continue
+      await db.insert(recommendations).values({
+        userId,
+        artistId,
+        batchId: batch.id,
+        score: seed.score,
+        sources: { similarity: seed.score, consensus: seed.score },
+        status: 'pending',
+      })
+    }
+
+    return c.json({
+      batchId: batch.id,
+      seeded: artistIds.length,
+      artists: SEED_ARTISTS.map((s, i) => ({ id: artistIds[i], mbid: s.mbid, name: s.name })),
+    })
+  })
+
+  return router
+}

--- a/tests/e2e/browser/approve-reject.spec.ts
+++ b/tests/e2e/browser/approve-reject.spec.ts
@@ -1,20 +1,26 @@
 import { expect, test } from '@playwright/test'
+import { ensureAdminToken, installAuthToken } from './auth'
+import { installDiscoverListView, seedRecommendations } from './seed'
 
 test.describe('Approve/Reject', () => {
-  // Requires authenticated session + seeded recommendations. Without those
-  // the discover page shows an empty state and the old "silent skip" on
-  // `isVisible()` let this test pass without proving anything. Re-enable
-  // once the E2E harness seeds a pipeline run (tracked as follow-up work).
-  test.fixme('approves a recommendation from discover page', async ({ page }) => {
+  test('approves a recommendation from discover page', async ({ page }) => {
+    const token = await ensureAdminToken(page.request, { completeSetup: true })
+    expect(token).toBeTruthy()
+    if (!token) return
+    await seedRecommendations(page.request, token)
+    await installAuthToken(page, token)
+    await installDiscoverListView(page)
+
     await page.goto('/discover')
 
-    const card = page.locator('[role="button"]').first()
-    await expect(card).toBeVisible({ timeout: 5_000 })
+    const card = page.locator('[data-testid="rec-card-button"]').first()
+    await expect(card).toBeVisible({ timeout: 10_000 })
     await card.hover()
 
     const approveBtn = card.getByRole('button', { name: /approve/i })
     await expect(approveBtn).toBeVisible()
     await approveBtn.click()
-    await expect(page.getByText(/approved|added/i)).toBeVisible({ timeout: 3_000 })
+
+    await expect(page.getByText(/approved|added/i).first()).toBeVisible({ timeout: 5_000 })
   })
 })

--- a/tests/e2e/browser/metadata-enrichment.spec.ts
+++ b/tests/e2e/browser/metadata-enrichment.spec.ts
@@ -1,30 +1,53 @@
 import { expect, test } from '@playwright/test'
+import { ensureAdminToken, installAuthToken } from './auth'
+import { installDiscoverListView, seedRecommendations } from './seed'
 
 test.describe('Metadata enrichment', () => {
-  // Requires authenticated session + seeded pipeline run with at least one
-  // recommendation. Marked fixme until the E2E harness seeds those - matches
-  // the pattern used by approve-reject.spec.ts.
-  test.fixme('recommendation card expansion shows bio and external links', async ({ page }) => {
-    await page.goto('/discover')
-    const firstCard = page.locator('[data-testid="recommendation-card"]').first()
-    await expect(firstCard).toBeVisible({ timeout: 5_000 })
-    await firstCard.click()
-    await expect(firstCard.locator('[data-testid="artist-bio"]')).toBeVisible({
-      timeout: 10_000,
-    })
-    await expect(firstCard.locator('text=MusicBrainz')).toBeVisible()
+  test.beforeEach(async ({ page }) => {
+    const token = await ensureAdminToken(page.request, { completeSetup: true })
+    expect(token).toBeTruthy()
+    if (!token) return
+    await seedRecommendations(page.request, token)
+    await installAuthToken(page, token)
+    await installDiscoverListView(page)
   })
 
-  test.fixme('settings toggle hides Wikidata bio from cards after reload', async ({ page }) => {
-    await page.goto('/settings')
-    await page.getByRole('tab', { name: /recommendations/i }).click()
-    await page.getByLabel(/bio and external links/i).uncheck()
-    await page.getByRole('button', { name: /save/i }).click()
+  test('recommendation card expansion shows bio and external links', async ({ page }) => {
     await page.goto('/discover')
-    const firstCard = page.locator('[data-testid="recommendation-card"]').first()
+    const firstCard = page.locator('[data-testid="rec-card-button"]').first()
+    await expect(firstCard).toBeVisible({ timeout: 10_000 })
     await firstCard.click()
-    // MusicBrainz pill always present (built from mbid). Bio should be absent
-    // because the backend returns an empty payload when wikidataEnabled=false.
-    await expect(firstCard.locator('text=MusicBrainz')).toBeVisible()
+
+    const enrichment = firstCard.getByTestId('artist-enrichment')
+    await expect(enrichment.getByTestId('artist-bio')).toBeVisible({ timeout: 10_000 })
+    // Seeded bio text proves the cached Wikidata description is served.
+    await expect(enrichment.getByTestId('artist-bio')).toContainText(/fictional/i)
+    // MusicBrainz pill (built from mbid). Scope to the enrichment panel + exact
+    // name so it doesn't collide with the "View on MusicBrainz" top-tracks link.
+    await expect(enrichment.getByRole('link', { name: 'MusicBrainz', exact: true })).toBeVisible()
+  })
+
+  test('settings toggle hides Wikidata bio from cards after reload', async ({ page }) => {
+    // Disable "Show artist bio and external links" in the Recommendations tab.
+    // The toggle lives inside the collapsed "Advanced" section, so expand it first.
+    await page.goto('/settings')
+    await page.getByRole('button', { name: 'Recommendations' }).first().click()
+    await page.getByRole('button', { name: 'Advanced', exact: true }).first().click()
+    await page.getByLabel(/bio and external links/i).uncheck()
+    await page.getByRole('button', { name: 'Save', exact: true }).first().click()
+    await expect(page.getByText(/recommendation settings saved/i)).toBeVisible({ timeout: 5_000 })
+
+    // Reload discover: the backend now returns an empty enrichment payload, so
+    // the seeded bio text is gone while the mbid-built MusicBrainz pill remains.
+    await page.goto('/discover')
+    const firstCard = page.locator('[data-testid="rec-card-button"]').first()
+    await expect(firstCard).toBeVisible({ timeout: 10_000 })
+    await firstCard.click()
+
+    const enrichment = firstCard.getByTestId('artist-enrichment')
+    await expect(enrichment.getByRole('link', { name: 'MusicBrainz', exact: true })).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(enrichment.getByTestId('artist-bio')).not.toContainText(/fictional/i)
   })
 })

--- a/tests/e2e/browser/pipeline-progress.spec.ts
+++ b/tests/e2e/browser/pipeline-progress.spec.ts
@@ -1,19 +1,25 @@
 import { expect, test } from '@playwright/test'
+import { ensureAdminToken, installAuthToken } from './auth'
+import { seedRecommendations } from './seed'
 
 test.describe('Pipeline Progress', () => {
-  // Needs an authenticated session with setup complete so the scan control
-  // is actually rendered. The old `if (isVisible)` guard let this test
-  // silently no-op when the harness loaded the pre-setup screen. Re-enable
-  // once the E2E harness seeds setup + authenticates before navigating.
-  test.fixme('shows progress when scan is triggered', async ({ page }) => {
+  test('shows progress when scan is triggered', async ({ page }) => {
+    const token = await ensureAdminToken(page.request, { completeSetup: true })
+    expect(token).toBeTruthy()
+    if (!token) return
+    await seedRecommendations(page.request, token)
+    await installAuthToken(page, token)
+
     await page.goto('/')
 
-    const scanButton = page.getByRole('button', { name: /scan|discover|run/i })
-    await expect(scanButton).toBeVisible()
+    const scanButton = page.getByRole('button', { name: /run scan/i }).first()
+    await expect(scanButton).toBeVisible({ timeout: 10_000 })
     await scanButton.click()
 
-    await expect(
-      page.getByText(/collecting|analyzing|discovering|resolving|scoring|filtering|storing/i),
-    ).toBeVisible({ timeout: 5_000 })
+    // The progress surface shows an elapsed-time readout ("Running for Ns")
+    // and a stage label as soon as the pipeline starts streaming.
+    await expect(page.getByText(/running for|running your first scan/i).first()).toBeVisible({
+      timeout: 10_000,
+    })
   })
 })

--- a/tests/e2e/browser/rejection-blocklist.spec.ts
+++ b/tests/e2e/browser/rejection-blocklist.spec.ts
@@ -1,57 +1,73 @@
 import { expect, test } from '@playwright/test'
+import { ensureAdminToken, installAuthToken } from './auth'
+import { installDiscoverStackView, seedRecommendations } from './seed'
 
+// The reason picker (reason + permanent block) only renders in the swipe
+// "stack" view, so these tests force that view before navigating.
 test.describe('rejection picker + blocklist', () => {
-  // Requires authenticated session + seeded recommendations - same harness
-  // gap that keeps approve-reject.spec.ts under test.fixme. Enable in tandem
-  // once the pipeline-seed fixture lands.
-  test.fixme('reject with reason + permanent block, then unblock', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
+    const token = await ensureAdminToken(page.request, { completeSetup: true })
+    expect(token).toBeTruthy()
+    if (!token) return
+    await seedRecommendations(page.request, token)
+    await installAuthToken(page, token)
+    await installDiscoverStackView(page)
+  })
+
+  test('reject with reason + permanent block, then unblock', async ({ page }) => {
     await page.goto('/discover')
 
-    // Open the picker via the reject control
-    const card = page.locator('[role="button"]').first()
-    await expect(card).toBeVisible({ timeout: 5_000 })
-    const artistName = (await card.locator('h2,h3').first().textContent())?.trim()
-    expect(artistName, 'expected to capture artist name from discover card').toBeTruthy()
-    await card.hover()
-    await card.getByRole('button', { name: /reject/i }).click()
+    // Open the picker via the stack-card reject control.
+    await page
+      .getByRole('button', { name: /^reject$/i })
+      .first()
+      .click()
 
-    // Picker opens
     const dialog = page.getByRole('dialog')
-    await expect(dialog).toBeVisible()
+    await expect(dialog).toBeVisible({ timeout: 10_000 })
+
+    // Picker title is "<prompt> - <artistName>"; capture the name to verify it
+    // later shows up (and disappears) in the Blocked settings tab.
+    const title = (await dialog.locator('h2').first().textContent()) ?? ''
+    const artistName = title.includes(' - ') ? title.split(' - ').slice(1).join(' - ').trim() : ''
+    expect(artistName, 'expected to capture artist name from picker title').toBeTruthy()
 
     // Pick reason and tick permanent
     await dialog.getByRole('button', { name: /tried it, didn't like it/i }).click()
     await dialog.getByLabel(/don't show this artist again/i).check()
 
-    // Submit (label flips to "Block forever" once permanent is checked)
+    // Submit (label flips to "Block forever" once permanent is checked). The
+    // stack view defers the actual reject PATCH behind a 250ms exit animation,
+    // so wait for it to land before navigating away, or the block write aborts.
+    const rejectPatch = page.waitForResponse(
+      (r) => /\/api\/v1\/recommendations\/\d+$/.test(r.url()) && r.request().method() === 'PATCH',
+    )
     await dialog.getByRole('button', { name: /block forever/i }).click()
     await expect(dialog).toBeHidden()
+    await rejectPatch
 
     // Navigate to Settings -> Blocked tab and verify the artist is listed
     await page.goto('/settings')
     await page.getByRole('button', { name: /^blocked$/i }).click()
-    if (artistName) {
-      await expect(page.getByText(artistName)).toBeVisible()
-    }
+    await expect(page.getByText(artistName)).toBeVisible({ timeout: 5_000 })
 
     // Unblock removes it
     await page
       .getByRole('button', { name: /unblock/i })
       .first()
       .click()
-    if (artistName) {
-      await expect(page.getByText(artistName)).toBeHidden({ timeout: 3_000 })
-    }
+    await expect(page.getByText(artistName)).toBeHidden({ timeout: 5_000 })
   })
 
-  test.fixme('not_right_now disables the permanent checkbox', async ({ page }) => {
+  test('not_right_now disables the permanent checkbox', async ({ page }) => {
     await page.goto('/discover')
-    const card = page.locator('[role="button"]').first()
-    await expect(card).toBeVisible({ timeout: 5_000 })
-    await card.hover()
-    await card.getByRole('button', { name: /reject/i }).click()
+    await page
+      .getByRole('button', { name: /^reject$/i })
+      .first()
+      .click()
 
     const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible({ timeout: 10_000 })
     await dialog.getByRole('button', { name: /maybe later, not now/i }).click()
     const checkbox = dialog.getByLabel(/don't show this artist again/i)
     await expect(checkbox).toBeDisabled()

--- a/tests/e2e/browser/seed.ts
+++ b/tests/e2e/browser/seed.ts
@@ -1,0 +1,48 @@
+import type { APIRequestContext, Page } from '@playwright/test'
+
+export type SeededArtist = { id: number; mbid: string; name: string }
+
+export type SeedResult = {
+  batchId: number
+  seeded: number
+  artists: SeededArtist[]
+}
+
+/**
+ * Calls the test-only seed route to create a fixed set of pending
+ * recommendations for the authenticated user. The route only exists when the
+ * backend runs with NODE_ENV=test (see playwright.config.ts webServer env).
+ */
+export async function seedRecommendations(
+  request: APIRequestContext,
+  token: string,
+): Promise<SeedResult> {
+  const res = await request.post('/api/v1/test/seed-recommendations', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok()) {
+    throw new Error(`seed-recommendations failed: ${res.status()} ${await res.text()}`)
+  }
+  return (await res.json()) as SeedResult
+}
+
+/**
+ * Force a specific discover view before navigation (like installAuthToken).
+ * - 'list'/'grid' render RecommendationCard (data-testid="rec-card-button") with
+ *   direct approve/reject + an expandable enrichment panel.
+ * - 'stack' renders the swipe CardStack, whose reject button opens the
+ *   RejectionPicker dialog (reason + permanent block).
+ */
+async function installDiscoverView(page: Page, mode: 'grid' | 'list' | 'stack'): Promise<void> {
+  await page.addInitScript((value) => {
+    window.localStorage.setItem('digarr:discover-view', value)
+  }, mode)
+}
+
+export function installDiscoverListView(page: Page): Promise<void> {
+  return installDiscoverView(page, 'list')
+}
+
+export function installDiscoverStackView(page: Page): Promise<void> {
+  return installDiscoverView(page, 'stack')
+}


### PR DESCRIPTION
Implements spec phase 4: a NODE_ENV-gated seed harness that unblocks the four `test.fixme` browser specs, then enables them.

## Backend
- New `POST /api/v1/test/seed-recommendations` (`src/server/routes/test-seed.ts`) inserts a fixed set of 3 artists + pending recommendations for the authenticated user. Artists carry a cached Wikidata enrichment (bio + external links + `wikidataFetchedAt`) so the enrichment endpoint serves from cache with no live upstream call. Idempotent (clears prior seeded recs).
- Registered in `createApp` **only** under `process.env.NODE_ENV === 'test'`, mirroring the existing prod-static branch.

## Security invariant (verified)
The prod Docker image sets `NODE_ENV=production` before `bun run build`, so Bun inlines the guard to `false` and tree-shakes the route out. Confirmed against a local prod build: `seed-recommendations`, `testSeedRoutes`, and `SEED_ARTISTS` are all **absent from `dist/`**. The route cannot exist in a production bundle.

## E2E
- `playwright.config.ts`: backend webServer now runs with `NODE_ENV: test`.
- Dropped `test.fixme` and implemented all four specs: approve-reject, rejection-blocklist (reject+reason+permanent block+unblock, and `not_right_now` disables the permanent checkbox), metadata-enrichment (cached bio + MusicBrainz pill, plus the settings toggle hiding the bio), and pipeline-progress.
- Corrected stale selectors the old fixmes carried: real card testid is `rec-card-button`; the picker only renders in the swipe **stack** view; pipeline stage copy is "Reading library / ..." not "collecting"; and the stack reject defers its PATCH behind a 250ms animation (the block-then-navigate test now awaits the PATCH).

## Verification
- `bun run test:e2e` (these 4 specs) — **6/6 passed** locally
- `bun run test` — 2217 passed / 25 skipped
- `bun run typecheck`, `bun run lint` — clean
- `NODE_ENV=production bun run build` — seed route absent from bundle