### PR TITLE
feat(scoring): fold strong-negative rejections into feedbackBoost

### DIFF
--- a/src/core/pipeline/score.ts
+++ b/src/core/pipeline/score.ts
@@ -1,6 +1,27 @@
 import type { ResolvedArtist, ScoredArtist } from '@/core/types'
 import type { Preferences, ScoringWeights } from '@/db/schema'
 
+/** Per-genre feedback tally feeding the feedbackBoost score component. */
+export type GenreFeedback = {
+  approved: number
+  total: number
+  /**
+   * Count of acted-on recommendations rejected with a strong-negative reason
+   * (`tried_didnt_like` / `wrong_style`). Optional for backward compatibility;
+   * absent is treated as 0, leaving the score identical to the approve-rate-only
+   * behaviour.
+   */
+  strongNegative?: number
+}
+
+/**
+ * How hard a fully strong-negative genre is downweighted. The penalty scales
+ * with the fraction of acted-on recs that were strong-negative rejections, so a
+ * genre the user actively disliked drops below an equivalent neutral genre
+ * without destabilising the curve. Kept conservative pending real rejection data.
+ */
+const STRONG_NEGATIVE_PENALTY = 0.5
+
 /** Compute a weighted composite score, clamped to [0, 1]. */
 export function computeWeightedScore(
   weights: ScoringWeights,
@@ -27,7 +48,7 @@ export function score(
   artists: ResolvedArtist[],
   libraryGenres: string[],
   weights: Preferences['scoringWeights'],
-  feedbackHistory: Map<string, { approved: number; total: number }>,
+  feedbackHistory: Map<string, GenreFeedback>,
   popularityMap?: Map<string, number>,
 ): ScoredArtist[] {
   const libraryGenreSet = new Set(libraryGenres.map((g) => g.toLowerCase()))
@@ -58,11 +79,18 @@ export function score(
         ? aiDiscoveries.reduce((sum, d) => sum + d.similarityScore, 0) / aiDiscoveries.length
         : 0.5
 
-    // Feedback boost: per-genre approve rate, default 0.5 if no history
+    // Feedback boost: per-genre approve rate, default 0.5 if no history.
+    // Strong-negative rejections (tried_didnt_like / wrong_style) apply an extra
+    // conservative penalty on top of the lower approve rate, so a genre the user
+    // actively disliked is downweighted further. With no strong-negative history
+    // this is exactly the approve rate (parity with the prior behaviour).
     const genreRates = artistGenres.map((genre) => {
       const history = feedbackHistory.get(genre)
       if (history === undefined || history.total === 0) return 0.5
-      return history.approved / history.total
+      const base = history.approved / history.total
+      const strongNegativeFraction = (history.strongNegative ?? 0) / history.total
+      const penalty = STRONG_NEGATIVE_PENALTY * strongNegativeFraction
+      return Math.max(0, base * (1 - penalty))
     })
     const feedbackBoost =
       genreRates.length > 0 ? genreRates.reduce((a, b) => a + b, 0) / genreRates.length : 0.5

--- a/src/core/pipeline/store.ts
+++ b/src/core/pipeline/store.ts
@@ -1,4 +1,5 @@
 import type { ScoredArtist } from '@/core/types'
+import type { GenreFeedback } from './score'
 
 // Minimal database interface - only what store() needs
 export interface StoreDb {
@@ -47,7 +48,7 @@ export interface StoreDb {
 
   getBlockedMbids: (userId: number) => Promise<Set<string>>
 
-  getFeedbackHistory: (userId?: number) => Promise<Map<string, { approved: number; total: number }>>
+  getFeedbackHistory: (userId?: number) => Promise<Map<string, GenreFeedback>>
 
   lookupArtistMetadata?: (name: string) => Promise<{
     spotifyGenres: string[] | null

--- a/src/db/queries/recommendations.ts
+++ b/src/db/queries/recommendations.ts
@@ -1,4 +1,5 @@
 import { and, count, desc, eq, gte, inArray, sql } from 'drizzle-orm'
+import type { GenreFeedback } from '@/core/pipeline/score'
 import type { RejectionReason } from '@/core/recommendations/rejection-reasons'
 import { isValidStatus, parseStatusFilter } from '@/core/recommendations/statuses'
 import type { Database, DbOrTx } from '@/db'
@@ -219,7 +220,7 @@ export async function bulkUpdateStatus(db: Database, ids: number[], status: stri
 export async function getGenreFeedbackHistory(
   db: Database,
   userId?: number,
-): Promise<Map<string, { approved: number; total: number }>> {
+): Promise<Map<string, GenreFeedback>> {
   // Pushing the per-genre tally into SQL via unnest lets Postgres do the
   // hash-aggregate work - JS side only walks the reduced result.
   const userFilter = userId !== undefined ? sql`AND r.user_id = ${userId}` : sql``
@@ -227,7 +228,10 @@ export async function getGenreFeedbackHistory(
     SELECT
       genre,
       COUNT(*)::int AS total,
-      COUNT(CASE WHEN r.status IN ('approved', 'added_to_lidarr') THEN 1 END)::int AS approved
+      COUNT(CASE WHEN r.status IN ('approved', 'added_to_lidarr') THEN 1 END)::int AS approved,
+      COUNT(CASE WHEN r.status = 'rejected'
+                  AND r.rejection_reason IN ('tried_didnt_like', 'wrong_style')
+                 THEN 1 END)::int AS strong_negative
     FROM recommendations r
     JOIN artists a ON a.id = r.artist_id
     CROSS JOIN LATERAL unnest(a.genres) AS genre
@@ -237,9 +241,18 @@ export async function getGenreFeedbackHistory(
     GROUP BY genre
   `)
 
-  const genreMap = new Map<string, { approved: number; total: number }>()
-  for (const row of result.rows as Array<{ genre: string; total: number; approved: number }>) {
-    genreMap.set(row.genre, { approved: row.approved, total: row.total })
+  const genreMap = new Map<string, GenreFeedback>()
+  for (const row of result.rows as Array<{
+    genre: string
+    total: number
+    approved: number
+    strong_negative: number
+  }>) {
+    genreMap.set(row.genre, {
+      approved: row.approved,
+      total: row.total,
+      strongNegative: row.strong_negative,
+    })
   }
   return genreMap
 }

--- a/src/server/deps.ts
+++ b/src/server/deps.ts
@@ -15,6 +15,7 @@ import type { SkyHookWarmer } from '@/core/library/skyhook-warmer'
 import type { LibrarySyncStore } from '@/core/library/store'
 import type { SyncOrchestrator } from '@/core/library/sync'
 import type { PipelineOrchestrator } from '@/core/pipeline/orchestrator'
+import type { GenreFeedback } from '@/core/pipeline/score'
 import type { SubscriptionScheduler } from '@/core/pipeline/subscription-scheduler'
 import type { AiProviderRegistry } from '@/core/providers/registry'
 import type { ServiceTestResult } from '@/core/types'
@@ -127,7 +128,7 @@ export interface RecommendationDeps {
   listBatches: (opts?: { limit?: number; cursor?: Cursor | null }) => Promise<BatchRow[]>
   getBatch: (id: number) => Promise<BatchRow | null>
   getArtistById: (id: number) => Promise<ArtistRow | null>
-  getFeedbackHistory: (userId?: number) => Promise<Map<string, { approved: number; total: number }>>
+  getFeedbackHistory: (userId?: number) => Promise<Map<string, GenreFeedback>>
   listArtistBlocks: (params: {
     userId: number
     limit?: number

--- a/tests/core/pipeline/score.test.ts
+++ b/tests/core/pipeline/score.test.ts
@@ -101,6 +101,48 @@ describe('score()', () => {
     expect(result[0]?.sourceScores.feedbackBoost).toBeCloseTo(0.6)
   })
 
+  it('feedbackBoost is unchanged when a genre has zero strong-negative rejections (parity)', () => {
+    const artist = makeArtist({ genres: ['jazz'] })
+    const withoutField = new Map([['jazz', { approved: 6, total: 10 }]])
+    const withZeroField = new Map([['jazz', { approved: 6, total: 10, strongNegative: 0 }]])
+    const a = score([artist], [], defaultWeights, withoutField)
+    const b = score([artist], [], defaultWeights, withZeroField)
+    // Both equal the plain approve rate, 0.6.
+    expect(a[0]?.sourceScores.feedbackBoost).toBeCloseTo(0.6)
+    expect(b[0]?.sourceScores.feedbackBoost).toBeCloseTo(0.6)
+  })
+
+  it('downweights a genre with strong-negative rejections below an all-neutral genre', () => {
+    const artist = makeArtist({ genres: ['jazz'] })
+    // Same 0.5 approve rate, but half of the acted-on recs were strong-negative.
+    const neutral = score(
+      [artist],
+      [],
+      defaultWeights,
+      new Map([['jazz', { approved: 5, total: 10, strongNegative: 0 }]]),
+    )
+    const disliked = score(
+      [artist],
+      [],
+      defaultWeights,
+      new Map([['jazz', { approved: 5, total: 10, strongNegative: 5 }]]),
+    )
+    expect(neutral[0]?.sourceScores.feedbackBoost).toBeCloseTo(0.5)
+    expect(disliked[0]?.sourceScores.feedbackBoost).toBeLessThan(0.5)
+  })
+
+  it('clamps feedbackBoost at 0 even when strong-negative penalty would push it lower', () => {
+    const artist = makeArtist({ genres: ['jazz'] })
+    // Every acted-on rec was a strong-negative rejection: approve rate 0, penalty applied.
+    const result = score(
+      [artist],
+      [],
+      defaultWeights,
+      new Map([['jazz', { approved: 0, total: 8, strongNegative: 8 }]]),
+    )
+    expect(result[0]?.sourceScores.feedbackBoost).toBe(0)
+  })
+
   it('computes genreOverlap correctly', () => {
     const artist = makeArtist({ genres: ['rock', 'metal', 'jazz'] })
     const libraryGenres = ['rock', 'jazz']


### PR DESCRIPTION
Implements spec phase 2: structured rejection reasons now feed negative signal into the recommendation scoring loop.

## Change
- `getGenreFeedbackHistory` (`src/db/queries/recommendations.ts`) now also counts, per genre, rejections whose reason is `tried_didnt_like` or `wrong_style` as `strongNegative` (one extra `COUNT(CASE ...)` in the existing `unnest` aggregate — no extra query).
- `score()` (`src/core/pipeline/score.ts`) applies a conservative multiplicative penalty to a genre's `feedbackBoost`: `base * (1 - 0.5 * strongNegative/total)`, clamped at 0. `not_right_now` is neutral (excluded by the SQL filter).
- New shared `GenreFeedback` type (`{ approved, total, strongNegative? }`) threads through `StoreDb` and the deps interface. `strongNegative` is optional, so existing callers/mocks and the no-history path are unchanged.

## Invariants
- **No-history parity**: with no strong-negative rejections, `feedbackBoost` is exactly the prior approve-rate (covered by a dedicated test + the existing approve-rate tests).
- The hygiene rescorer is unaffected (it already uses `feedbackBoost: 0`, since it has no feedback history in that context).

## Tests (TDD)
- parity when `strongNegative` is absent or 0
- a strong-negative genre scores below an equivalent all-neutral genre
- clamp holds at 0 when every acted-on rec was a strong-negative rejection

## Verification
- `bun run test` — 2220 passed / 25 skipped
- `bun run typecheck`, `bun run lint` — clean