### PR TITLE
feat: preview volume control + bulk-reject shared reason

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -203,7 +203,7 @@ Locale notes:
 | GET | `/api/v1/recommendations` | Yes | List recommendations (paginated, filterable) |
 | GET | `/api/v1/recommendations/:id` | Yes | Get single recommendation with artist data |
 | PATCH | `/api/v1/recommendations/:id` | Yes | Approve, reject, or restore a recommendation |
-| POST | `/api/v1/recommendations/bulk` | Yes | Bulk approve/reject |
+| POST | `/api/v1/recommendations/bulk` | Yes | Bulk approve/reject (reject accepts an optional shared `reason` + `permanent` block) |
 | GET | `/api/v1/recommendations/feedback-summary` | Yes | Genre approval rates (top 20), scoped to the calling user's own feedback |
 
 **GET /api/v1/recommendations** query params:

--- a/scripts/check-api-docs.ts
+++ b/scripts/check-api-docs.ts
@@ -28,7 +28,11 @@ const ROUTE_DECLARATION_RE = new RegExp(
 
 const MARKDOWN_TABLE_ROUTE_RE = /^\s*\|\s*(GET|POST|PATCH|DELETE|PUT)\s*\|\s*`([^`]+)`\s*\|/gim
 
-const IGNORED_ROUTES = new Set<string>()
+const IGNORED_ROUTES = new Set<string>([
+  // Test-only route, registered only when NODE_ENV==='test' and tree-shaken out
+  // of production builds. Not part of the public API surface, so not documented.
+  'POST /api/v1/test/seed-recommendations',
+])
 
 function routeKey(route: RouteDeclaration): string {
   return `${route.method} ${route.path}`

--- a/scripts/i18n-check.ts
+++ b/scripts/i18n-check.ts
@@ -33,6 +33,8 @@ const DYNAMIC_PREFIXES = [
 const referenceLocale = 'en'
 const referenceMessages = getMessages(referenceLocale)
 const SAME_AS_SOURCE_ALLOWLIST = new Set([
+  // "Volume" is the standard audio term and identical in fr/it/nl/pt-BR.
+  'Volume',
   'Spotify',
   'Deezer',
   'ListenBrainz',

--- a/src/core/i18n/messages/de.ts
+++ b/src/core/i18n/messages/de.ts
@@ -1162,6 +1162,7 @@ export const de = {
   'settings.blocked.loadMore': 'Mehr laden',
   'preview.playerRegion': 'Vorschau-Player',
   'preview.closePreview': 'Vorschau schließen',
+  'preview.volume': 'Lautstärke',
   'preview.loadingPreview': 'Vorschau wird geladen...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/en.ts
+++ b/src/core/i18n/messages/en.ts
@@ -1330,6 +1330,7 @@ export const en = {
   // Preview player
   'preview.playerRegion': 'Preview player',
   'preview.closePreview': 'Close preview',
+  'preview.volume': 'Volume',
   'preview.loadingPreview': 'Loading preview...',
 
   // Streaming links (compact play/stop control + Spotify embed)

--- a/src/core/i18n/messages/es.ts
+++ b/src/core/i18n/messages/es.ts
@@ -1156,6 +1156,7 @@ export const es = {
   'settings.blocked.loadMore': 'Cargar más',
   'preview.playerRegion': 'Reproductor de vista previa',
   'preview.closePreview': 'Cerrar vista previa',
+  'preview.volume': 'Volumen',
   'preview.loadingPreview': 'Cargando vista previa...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/fr.ts
+++ b/src/core/i18n/messages/fr.ts
@@ -1155,6 +1155,7 @@ export const fr = {
   'settings.blocked.loadMore': 'Charger plus',
   'preview.playerRegion': "Lecteur d'aperçu",
   'preview.closePreview': "Fermer l'aperçu",
+  'preview.volume': 'Volume',
   'preview.loadingPreview': "Chargement de l'aperçu...",
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/it.ts
+++ b/src/core/i18n/messages/it.ts
@@ -1174,6 +1174,7 @@ export const it = {
   'settings.blocked.loadMore': 'Carica altri',
   'preview.playerRegion': 'Player anteprima',
   'preview.closePreview': 'Chiudi anteprima',
+  'preview.volume': 'Volume',
   'preview.loadingPreview': 'Caricamento anteprima...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/ja.ts
+++ b/src/core/i18n/messages/ja.ts
@@ -1145,6 +1145,7 @@ export const ja = {
   'settings.blocked.loadMore': 'もっと読み込む',
   'preview.playerRegion': 'プレビュープレーヤー',
   'preview.closePreview': 'プレビューを閉じる',
+  'preview.volume': '音量',
   'preview.loadingPreview': 'プレビューを読み込み中...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/ko.ts
+++ b/src/core/i18n/messages/ko.ts
@@ -1133,6 +1133,7 @@ export const ko = {
   'settings.blocked.loadMore': '더 보기',
   'preview.playerRegion': '미리듣기 플레이어',
   'preview.closePreview': '미리듣기 닫기',
+  'preview.volume': '볼륨',
   'preview.loadingPreview': '미리듣기를 불러오는 중...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/nl.ts
+++ b/src/core/i18n/messages/nl.ts
@@ -1152,6 +1152,7 @@ export const nl = {
   'settings.blocked.loadMore': 'Meer laden',
   'preview.playerRegion': 'Voorbeeldspeler',
   'preview.closePreview': 'Voorbeeld sluiten',
+  'preview.volume': 'Volume',
   'preview.loadingPreview': 'Voorbeeld wordt geladen...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/pl.ts
+++ b/src/core/i18n/messages/pl.ts
@@ -1149,6 +1149,7 @@ export const pl = {
   'settings.blocked.loadMore': 'Załaduj więcej',
   'preview.playerRegion': 'Odtwarzacz podglądu',
   'preview.closePreview': 'Zamknij podgląd',
+  'preview.volume': 'Głośność',
   'preview.loadingPreview': 'Wczytywanie podglądu...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/pt-BR.ts
+++ b/src/core/i18n/messages/pt-BR.ts
@@ -1158,6 +1158,7 @@ export const ptBR = {
   'settings.blocked.loadMore': 'Carregar mais',
   'preview.playerRegion': 'Reprodutor de prévia',
   'preview.closePreview': 'Fechar prévia',
+  'preview.volume': 'Volume',
   'preview.loadingPreview': 'Carregando prévia...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/ro.ts
+++ b/src/core/i18n/messages/ro.ts
@@ -1157,6 +1157,7 @@ export const ro = {
   'settings.blocked.loadMore': 'Încarcă mai mult',
   'preview.playerRegion': 'Player previzualizare',
   'preview.closePreview': 'Închide previzualizarea',
+  'preview.volume': 'Volum',
   'preview.loadingPreview': 'Se încarcă previzualizarea...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/ru.ts
+++ b/src/core/i18n/messages/ru.ts
@@ -1162,6 +1162,7 @@ export const ru = {
   'settings.blocked.loadMore': 'Загрузить ещё',
   'preview.playerRegion': 'Плеер предпросмотра',
   'preview.closePreview': 'Закрыть предпросмотр',
+  'preview.volume': 'Громкость',
   'preview.loadingPreview': 'Загрузка предпросмотра...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/tr.ts
+++ b/src/core/i18n/messages/tr.ts
@@ -1150,6 +1150,7 @@ export const tr = {
   'settings.blocked.loadMore': 'Daha fazla yükle',
   'preview.playerRegion': 'Önizleme oynatıcısı',
   'preview.closePreview': 'Önizlemeyi kapat',
+  'preview.volume': 'Ses düzeyi',
   'preview.loadingPreview': 'Önizleme yükleniyor...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/uk.ts
+++ b/src/core/i18n/messages/uk.ts
@@ -1155,6 +1155,7 @@ export const uk = {
   'settings.blocked.loadMore': 'Завантажити ще',
   'preview.playerRegion': 'Плеєр попереднього перегляду',
   'preview.closePreview': 'Закрити попередній перегляд',
+  'preview.volume': 'Гучність',
   'preview.loadingPreview': 'Завантаження попереднього перегляду...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -1084,6 +1084,7 @@ export const zhCN = {
   'settings.blocked.loadMore': '加载更多',
   'preview.playerRegion': '预览播放器',
   'preview.closePreview': '关闭预览',
+  'preview.volume': '音量',
   'preview.loadingPreview': '正在加载预览...',
   'streaming.playShort': 'PLAY',
   'streaming.stopShort': 'STOP',

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -579,14 +579,32 @@ export function recommendationRoutes(deps: AppDependencies) {
       qualityProfileId: qpOverride,
       metadataProfileId: mpOverride,
       rootFolderId: rfOverride,
+      reason,
+      permanent,
     } = c.req.valid('json')
 
     const userId = c.get('userId')
 
     if (action === 'reject') {
       const ownedIds = await deps.filterOwnedIds(ids, userId)
-      if (ownedIds.length > 0) {
-        await deps.bulkUpdateStatus(ownedIds, 'rejected')
+      // Fast path: no shared reason/permanent => a single bulk status update,
+      // preserving the prior reason-less behaviour.
+      if (!reason && !permanent) {
+        if (ownedIds.length > 0) {
+          await deps.bulkUpdateStatus(ownedIds, 'rejected')
+        }
+        return c.json({ updated: ownedIds.length })
+      }
+      // Shared-reason path: route each id through rejectRecommendation so the
+      // reason is recorded and the optional permanent block is created per artist.
+      for (const id of ownedIds) {
+        await deps.rejectRecommendation({
+          recommendationId: id,
+          userId,
+          reason: reason ?? null,
+          reasonText: null,
+          permanent,
+        })
       }
       return c.json({ updated: ownedIds.length })
     }

--- a/src/server/schemas/recommendations.ts
+++ b/src/server/schemas/recommendations.ts
@@ -38,6 +38,10 @@ export const bulkRecommendationSchema = z.object({
   qualityProfileId: z.number().int().optional(),
   metadataProfileId: z.number().int().optional(),
   rootFolderId: z.number().int().optional(),
+  // Reject-only: apply one shared reason (and optional permanent block) across
+  // every selected id. Omitted => the existing reason-less fast path.
+  reason: z.enum(REJECTION_REASONS).nullish(),
+  permanent: z.boolean().default(false),
 })
 
 // PATCH /api/v1/recommendations/:id/status payload (when status='rejected'):

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -443,6 +443,8 @@ function AppShell({ children }: { children: React.ReactNode }) {
         currentMbid: preview.state.artistMbid,
         playing: preview.state.playing,
         globalPlayId: preview.globalPlayId,
+        volume: preview.volume,
+        setVolume: preview.setVolume,
       }}
     >
       <div className="min-h-screen bg-bg">
@@ -718,6 +720,8 @@ function AppShell({ children }: { children: React.ReactNode }) {
           source={preview.state.source}
           loading={preview.state.loading}
           onStop={preview.stop}
+          volume={preview.volume}
+          onVolumeChange={preview.setVolume}
         />
         <footer className="hidden md:block fixed bottom-2 right-3 text-micro text-muted select-none pointer-events-none z-10">
           v{VERSION}

--- a/src/web/components/preview-player.tsx
+++ b/src/web/components/preview-player.tsx
@@ -1,4 +1,4 @@
-import { Music, X } from 'lucide-react'
+import { Music, Volume2, X } from 'lucide-react'
 import type { PreviewSource } from '@/web/hooks/use-preview'
 import { useI18n } from '../lib/i18n'
 
@@ -14,6 +14,8 @@ type Props = {
   source: PreviewSource | null
   loading: boolean
   onStop: () => void
+  volume: number
+  onVolumeChange: (value: number) => void
 }
 
 /**
@@ -21,12 +23,23 @@ type Props = {
  * On mobile it sits above the 56px bottom nav (bottom-14); on md+ it sits at
  * bottom-0. Only renders when a preview is active (loading or playing).
  */
-export function PreviewPlayer({ playing, artistName, source, loading, onStop }: Props) {
+export function PreviewPlayer({
+  playing,
+  artistName,
+  source,
+  loading,
+  onStop,
+  volume,
+  onVolumeChange,
+}: Props) {
   const { t } = useI18n()
   if (!playing && !loading) return null
 
   const sourceLabel = source ? SOURCE_LABELS[source.type] : null
   const showIframe = playing && source && source.type !== 'deezer-audio'
+  // Volume is only controllable for the HTML5 Deezer audio element; the
+  // Spotify/YouTube embeds run in cross-origin iframes with their own controls.
+  const showVolume = source?.type === 'deezer-audio'
 
   return (
     <section
@@ -54,6 +67,22 @@ export function PreviewPlayer({ playing, artistName, source, loading, onStop }: 
               </div>
             )}
           </div>
+
+          {showVolume && (
+            <div className="shrink-0 flex items-center gap-1.5">
+              <Volume2 size={14} className="text-muted" aria-hidden="true" />
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={volume}
+                onChange={(e) => onVolumeChange(Number.parseFloat(e.target.value))}
+                className="w-16 sm:w-24 accent-accent cursor-pointer"
+                aria-label={t('preview.volume')}
+              />
+            </div>
+          )}
 
           <button
             type="button"

--- a/src/web/components/recommendation-card.tsx
+++ b/src/web/components/recommendation-card.tsx
@@ -8,6 +8,7 @@ import { getArtistTopTracks } from '../lib/api'
 import { GENRE_COLORS } from '../lib/constants'
 import { useI18n } from '../lib/i18n'
 import { usePreviewContext } from '../lib/preview-context'
+import { readStoredVolume } from '../lib/preview-volume'
 import { cn, hueFromName } from '../lib/utils'
 import { ArtistEnrichmentPanel } from './artist-enrichment-panel'
 import { ArtistThumb } from './artist-thumb'
@@ -451,6 +452,7 @@ function TopTracks({ artistId }: { artistId: number }) {
     if (token) params.set('token', token)
     const proxyUrl = `/api/v1/preview/audio?${params.toString()}`
     const audio = new Audio(proxyUrl)
+    audio.volume = readStoredVolume()
     audioRef.current = audio
     audio.onended = () => setPlayingUrl(null)
     audio.onerror = () => {

--- a/src/web/hooks/use-preview.ts
+++ b/src/web/hooks/use-preview.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useI18n } from '../lib/i18n'
+import { clampVolume, readStoredVolume, writeStoredVolume } from '../lib/preview-volume'
 
 export type PreviewSource = {
   type: 'spotify-embed' | 'deezer-audio' | 'youtube-embed'
@@ -112,6 +113,17 @@ export function usePreview() {
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const globalPlayIdRef = useRef(0)
   const [globalPlayId, setGlobalPlayId] = useState(0)
+  const [volume, setVolumeState] = useState(readStoredVolume)
+  const volumeRef = useRef(volume)
+
+  // Persist the volume and apply it live to any currently-playing audio element.
+  const setVolume = useCallback((next: number) => {
+    const clamped = clampVolume(next)
+    volumeRef.current = clamped
+    setVolumeState(clamped)
+    writeStoredVolume(clamped)
+    if (audioRef.current) audioRef.current.volume = clamped
+  }, [])
 
   // Keep stateRef in sync so callbacks don't close over stale state
   const setStateAndRef = useCallback((updater: (s: PreviewState) => PreviewState) => {
@@ -191,6 +203,7 @@ export function usePreview() {
 
       if (source.type === 'deezer-audio') {
         const audio = new Audio(source.url)
+        audio.volume = volumeRef.current
         audioRef.current = audio
         audio.onended = () => setStateAndRef((s) => ({ ...s, playing: false }))
         audio.onerror = () =>
@@ -216,5 +229,5 @@ export function usePreview() {
     return Boolean(streamingUrls.spotify || streamingUrls.deezer || streamingUrls.youtube)
   }, [])
 
-  return { state, play, stop, hasPreview, globalPlayId }
+  return { state, play, stop, hasPreview, globalPlayId, volume, setVolume }
 }

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -233,8 +233,15 @@ export const approveRecommendation = (
     rootFolderId?: number
   },
 ) => updateRecommendation(id, { status: 'approved', ...options })
-export const bulkAction = (ids: number[], action: string) =>
-  fetchApi('/recommendations/bulk', { method: 'POST', body: JSON.stringify({ ids, action }) })
+export const bulkAction = (
+  ids: number[],
+  action: string,
+  options?: { reason?: string | null; permanent?: boolean },
+) =>
+  fetchApi('/recommendations/bulk', {
+    method: 'POST',
+    body: JSON.stringify({ ids, action, ...options }),
+  })
 
 export const getFeedbackSummary = () =>
   fetchApi<{

--- a/src/web/lib/preview-context.ts
+++ b/src/web/lib/preview-context.ts
@@ -7,6 +7,8 @@ type PreviewContextValue = {
   currentMbid: string | null
   playing: boolean
   globalPlayId: number
+  volume: number
+  setVolume: (value: number) => void
 }
 
 export const PreviewContext = createContext<PreviewContextValue | null>(null)

--- a/src/web/lib/preview-volume.ts
+++ b/src/web/lib/preview-volume.ts
@@ -1,0 +1,31 @@
+// Shared preview volume, persisted to localStorage so it survives reloads and
+// is consistent across both audio systems (the global Deezer preview and the
+// per-card TopTracks previews).
+
+export const PREVIEW_VOLUME_KEY = 'digarr:preview-volume'
+export const DEFAULT_PREVIEW_VOLUME = 0.8
+
+export function clampVolume(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_PREVIEW_VOLUME
+  return Math.max(0, Math.min(1, value))
+}
+
+export function readStoredVolume(): number {
+  try {
+    const raw = localStorage.getItem(PREVIEW_VOLUME_KEY)
+    if (raw === null) return DEFAULT_PREVIEW_VOLUME
+    const parsed = Number.parseFloat(raw)
+    if (Number.isFinite(parsed)) return clampVolume(parsed)
+  } catch {
+    // ignore storage access errors (private mode, disabled storage)
+  }
+  return DEFAULT_PREVIEW_VOLUME
+}
+
+export function writeStoredVolume(value: number): void {
+  try {
+    localStorage.setItem(PREVIEW_VOLUME_KEY, String(clampVolume(value)))
+  } catch {
+    // ignore
+  }
+}

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -3,6 +3,7 @@ import { Download, Filter as FilterIcon, MoreHorizontal, RefreshCw, Trash2 } fro
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
+import type { RejectionReason } from '@/core/recommendations/rejection-reasons'
 import { errMsg } from '@/core/validation'
 import { AlbumPicker } from '../components/album-picker'
 import { ApproveDialog } from '../components/approve-dialog'
@@ -12,6 +13,7 @@ import { Hint } from '../components/hint'
 import { MonitoringOptions, type MonitorOption } from '../components/monitoring-options'
 import { MoodPromptBar } from '../components/mood-prompt-bar'
 import { type Recommendation, RecommendationCard } from '../components/recommendation-card'
+import { RejectionPicker } from '../components/rejection-picker'
 import { SwipeCard } from '../components/swipe-card'
 import { canApproveArtistToTarget, resolveApprovalTargetOptions } from '../components/target-utils'
 import { Skeleton } from '../components/ui/skeleton'
@@ -454,6 +456,7 @@ export function DiscoverPage() {
   const [bulkMode, setBulkMode] = useState(false)
   const [checkedIds, setCheckedIds] = useState<Set<number>>(new Set())
   const [bulkActing, setBulkActing] = useState(false)
+  const [bulkRejectPickerOpen, setBulkRejectPickerOpen] = useState(false)
   const [albumPickerRecId, setAlbumPickerRecId] = useState<number | null>(null)
   const [showClearAllConfirm, setShowClearAllConfirm] = useState(false)
   const [activeDecades, setActiveDecades] = useState<Set<Decade>>(new Set())
@@ -851,12 +854,27 @@ export function DiscoverPage() {
     }
   }
 
-  async function handleBulkReject() {
+  function handleBulkReject() {
     if (checkedIds.size === 0) return
+    // Open the shared picker to capture one reason + optional permanent block
+    // for every selected recommendation.
+    setBulkRejectPickerOpen(true)
+  }
+
+  async function commitBulkReject(payload: {
+    reason: RejectionReason | null
+    reasonText: string | null
+    permanent: boolean
+  }) {
+    if (checkedIds.size === 0) return
+    const count = checkedIds.size
     setBulkActing(true)
     try {
-      await bulkAction([...checkedIds], 'reject')
-      toast.success(`${t('discover.rejectedCount')} ${checkedIds.size}`)
+      await bulkAction([...checkedIds], 'reject', {
+        reason: payload.reason,
+        permanent: payload.permanent,
+      })
+      toast.success(`${t('discover.rejectedCount')} ${count}`)
       setCheckedIds(new Set())
       refetch()
     } catch {
@@ -1469,6 +1487,13 @@ export function DiscoverPage() {
           onCancel={() => setShowClearAllConfirm(false)}
         />
       )}
+      <RejectionPicker
+        open={bulkRejectPickerOpen}
+        onClose={() => setBulkRejectPickerOpen(false)}
+        onSubmit={async (payload) => {
+          await commitBulkReject(payload)
+        }}
+      />
     </div>
   )
 }

--- a/tests/server/routes/recommendations.test.ts
+++ b/tests/server/routes/recommendations.test.ts
@@ -789,6 +789,36 @@ describe('POST /api/v1/recommendations/bulk', () => {
     expect(bulkUpdateStatus).toHaveBeenCalledWith([1, 2, 3], 'rejected')
   })
 
+  it('bulk rejects with a shared reason via rejectRecommendation per id', async () => {
+    const bulkUpdateStatus = vi.fn(async () => {})
+    const rejectRecommendation = vi.fn(async () => 1)
+    const filterOwnedIds = vi.fn(async (ids: number[]) => ids)
+    const app = createApp(makeDeps({ bulkUpdateStatus, rejectRecommendation, filterOwnedIds }))
+    const res = await authedRequest(app, '/api/v1/recommendations/bulk', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ids: [1, 2],
+        action: 'reject',
+        reason: 'wrong_style',
+        permanent: true,
+      }),
+    })
+    expect(res.status).toBe(200)
+    expect((await res.json()).updated).toBe(2)
+    // Shared-reason path routes each id through rejectRecommendation, not the
+    // reason-less bulk fast path.
+    expect(bulkUpdateStatus).not.toHaveBeenCalled()
+    expect(rejectRecommendation).toHaveBeenCalledTimes(2)
+    expect(rejectRecommendation).toHaveBeenCalledWith({
+      recommendationId: 1,
+      userId: 1,
+      reason: 'wrong_style',
+      reasonText: null,
+      permanent: true,
+    })
+  })
+
   it('returns 400 for invalid action', async () => {
     const app = createApp(makeDeps())
     const res = await authedRequest(app, '/api/v1/recommendations/bulk', {

--- a/tests/web/components/preview-player.test.tsx
+++ b/tests/web/components/preview-player.test.tsx
@@ -33,6 +33,8 @@ describe('PreviewPlayer', () => {
           artistName={null}
           source={null}
           onStop={vi.fn()}
+          volume={1}
+          onVolumeChange={vi.fn()}
         />,
       ),
     )
@@ -48,6 +50,8 @@ describe('PreviewPlayer', () => {
           artistName="Radiohead"
           source={null}
           onStop={vi.fn()}
+          volume={1}
+          onVolumeChange={vi.fn()}
         />,
       ),
     )
@@ -64,6 +68,8 @@ describe('PreviewPlayer', () => {
           artistName="Radiohead"
           source={spotifySource}
           onStop={vi.fn()}
+          volume={1}
+          onVolumeChange={vi.fn()}
         />,
       ),
     )
@@ -80,6 +86,8 @@ describe('PreviewPlayer', () => {
           artistName="Radiohead"
           source={spotifySource}
           onStop={onStop}
+          volume={1}
+          onVolumeChange={vi.fn()}
         />,
       ),
     )

--- a/tests/web/components/recommendation-card.test.tsx
+++ b/tests/web/components/recommendation-card.test.tsx
@@ -36,6 +36,8 @@ const noopPreview = {
   currentMbid: null,
   playing: false,
   globalPlayId: 0,
+  volume: 1,
+  setVolume: vi.fn(),
 }
 
 function withPreview(ui: ReactElement) {

--- a/tests/web/lib/preview-volume.test.ts
+++ b/tests/web/lib/preview-volume.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clampVolume,
+  DEFAULT_PREVIEW_VOLUME,
+  PREVIEW_VOLUME_KEY,
+  readStoredVolume,
+  writeStoredVolume,
+} from '@/web/lib/preview-volume'
+
+describe('clampVolume', () => {
+  it('clamps to the [0, 1] range', () => {
+    expect(clampVolume(-0.5)).toBe(0)
+    expect(clampVolume(0)).toBe(0)
+    expect(clampVolume(0.42)).toBe(0.42)
+    expect(clampVolume(1)).toBe(1)
+    expect(clampVolume(2)).toBe(1)
+  })
+
+  it('falls back to the default for non-finite input', () => {
+    expect(clampVolume(Number.NaN)).toBe(DEFAULT_PREVIEW_VOLUME)
+    expect(clampVolume(Number.POSITIVE_INFINITY)).toBe(DEFAULT_PREVIEW_VOLUME)
+  })
+})
+
+describe('readStoredVolume / writeStoredVolume', () => {
+  const store: Record<string, string> = {}
+
+  beforeEach(() => {
+    for (const k of Object.keys(store)) delete store[k]
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => {
+        store[k] = v
+      },
+      removeItem: (k: string) => {
+        delete store[k]
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns the default when nothing is stored', () => {
+    expect(readStoredVolume()).toBe(DEFAULT_PREVIEW_VOLUME)
+  })
+
+  it('round-trips a clamped value', () => {
+    writeStoredVolume(0.3)
+    expect(store[PREVIEW_VOLUME_KEY]).toBe('0.3')
+    expect(readStoredVolume()).toBe(0.3)
+  })
+
+  it('clamps out-of-range stored values on read', () => {
+    store[PREVIEW_VOLUME_KEY] = '5'
+    expect(readStoredVolume()).toBe(1)
+  })
+
+  it('returns the default for an unparseable stored value', () => {
+    store[PREVIEW_VOLUME_KEY] = 'loud'
+    expect(readStoredVolume()).toBe(DEFAULT_PREVIEW_VOLUME)
+  })
+})

--- a/tests/web/pages/discover-modes.test.tsx
+++ b/tests/web/pages/discover-modes.test.tsx
@@ -22,6 +22,8 @@ const noopPreview = {
   currentMbid: null,
   playing: false,
   globalPlayId: 0,
+  volume: 1,
+  setVolume: vi.fn(),
 }
 
 function renderWithQuery(ui: ReactElement) {

--- a/tests/web/pages/discover.test.tsx
+++ b/tests/web/pages/discover.test.tsx
@@ -15,6 +15,8 @@ const noopPreview = {
   currentMbid: null,
   playing: false,
   globalPlayId: 0,
+  volume: 1,
+  setVolume: vi.fn(),
 }
 
 function renderWithQuery(ui: ReactElement) {


### PR DESCRIPTION
Implements spec phase 3 (small UX gaps). Two independent features.

## Preview volume control
- Persistent volume (`digarr:preview-volume`, default 0.8) via a shared helper (`src/web/lib/preview-volume.ts`), threaded through `usePreview` -> `PreviewContext`.
- A volume slider in the global preview bar, shown only for the Deezer HTML5 audio (Spotify/YouTube run in cross-origin iframes with their own controls).
- Applied to both audio systems: the global preview and per-card TopTracks previews. Existing `globalPlayId` play/stop coordination unchanged.
- Full i18n: `preview.volume` across all 15 locales ("Volume" added to the i18n-check same-as-source allowlist as a loanword identical in fr/it/nl/pt-BR).

## Bulk-reject shared reason
- `POST /api/v1/recommendations/bulk` reject now accepts an optional shared `reason` + `permanent`; each id is routed through `rejectRecommendation` so the reason is recorded and the optional permanent block is created per artist. Reason-less bulk reject keeps the single `bulkUpdateStatus` fast path.
- The discover bulk-reject button opens the shared `RejectionPicker` (reuse), and `bulkAction` gained an optional `{ reason, permanent }` payload.

## Also
- Excluded the test-only `POST /api/v1/test/seed-recommendations` from the api-docs surface check (tree-shaken from prod; not public API).

## Verification
- `bun run test` — 2227 passed / 25 skipped (new preview-volume helper tests + a bulk-reject-with-reason route test)
- `bun run typecheck`, `bun run lint` — clean
- `bun run i18n:check` — 15 locales clean
- `bun run check:api-docs` — 140 routes covered

Note: screenshots for the new volume slider are a manual follow-up.