### PR TITLE
feat(discovery): labels (Discogs) + artist-relationships (MusicBrainz) modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Digarr takes signals from up to 8 sources, runs them through an AI-assisted pipe
 Type "something like Boards of Canada but darker" or "upbeat 90s pop for a road trip" and Digarr turns that into a result set. You do not have to translate the idea into filters first.
 
 ### Discovery Modes
-Run focused discovery flows from Discover -> Discovery Modes (`/discover/modes`) for the currently shipped modes: ListenBrainz (Artist Radio, User Radio, Tag Radio, Similar Users Quick and Deep), Release Radar, and Similar Artist Web. Labels and Artist Relationships stay visible on that page so you can see what is planned, and unavailable cards explain why they are blocked while the server rejects those runs until real implementations ship. Manual runs now preflight invalid Artist Radio seeds before the job is accepted, and each accepted run is recorded in Jobs immediately so fast background failures are visible. Available discovery modes can be saved as subscriptions, and those subscriptions now reuse the same provider/fallback path as the manual run you configured.
+Run focused discovery flows from Discover -> Discovery Modes (`/discover/modes`) for the shipped modes: ListenBrainz (Artist Radio, User Radio, Tag Radio, Similar Users Quick and Deep), Release Radar, Similar Artist Web, Artist Relationships (MusicBrainz collaboration/membership/alias graph), and Labels (co-label artists via Discogs; needs a connected Discogs account). Manual runs now preflight invalid Artist Radio seeds before the job is accepted, and each accepted run is recorded in Jobs immediately so fast background failures are visible. Available discovery modes can be saved as subscriptions, and those subscriptions now reuse the same provider/fallback path as the manual run you configured.
 
 ### Auto-Playlists
 Build playlists from approved recommendations and send them to Navidrome, Jellyfin, Emby, Plex, or Spotify, or export them as M3U/XSPF. The built-in playlist types are Weekly Digest, Genre Focus, Mood Mix, and Rediscover.
@@ -70,7 +70,7 @@ Search across Spotify, Deezer, MusicBrainz, TIDAL, and Bandcamp in one pass. Dig
 - **8 data sources:** ListenBrainz, Last.fm, Spotify (OAuth), Deezer (OAuth), Plex, Jellyfin, Emby, and Discogs
 - **Smart scoring:** weighted composite scoring across consensus, similarity, genre overlap, AI confidence, feedback learning, and popularity
 - **Auto-approve:** send high-scoring recommendations to your targets automatically
-- **Discovery modes:** manual and subscription flows for ListenBrainz (Artist Radio, User Radio, Tag Radio, Similar Users Quick/Deep), Release Radar, and Similar Artist Web, with unavailable planned modes exposed in metadata but blocked from execution until they ship
+- **Discovery modes:** manual and subscription flows for ListenBrainz (Artist Radio, User Radio, Tag Radio, Similar Users Quick/Deep), Release Radar, Similar Artist Web, Artist Relationships (MusicBrainz graph), and Labels (Discogs co-label artists)
 - **Subscriptions:** scheduled discovery from discovery modes, Spotify Liked Songs, playlists and charts, Deezer favorites, followed artists and Flow, Last.fm tags and charts, ListenBrainz feeds, genre searches, and similar-artist seeds
 - **Genre deep dive:** browse by genre with Recommended, Trending, and Deep Cuts tabs
 - **Library sync and reconciliation:** background artist and album sync, per-source status, album sync coverage, unreconciled artist and album review, album coverage badges on recommendation cards, and 6 automated health checks with one-click fixes

--- a/src/core/clients/discogs.ts
+++ b/src/core/clients/discogs.ts
@@ -43,6 +43,14 @@ type DiscogsSearchResponse = {
   }>
 }
 
+type DiscogsReleaseSearchResponse = {
+  results: Array<{
+    // "Artist - Release Title" for release/master results.
+    title: string
+    label?: string[]
+  }>
+}
+
 type DiscogsIdentityResponse = {
   username: string
   id: number
@@ -143,6 +151,59 @@ export function createDiscogsClient(
     return res.results.map((r) => ({ name: r.title, id: r.id }))
   }
 
+  // Extract the artist portion of a Discogs "Artist - Title" release string.
+  function artistFromReleaseTitle(title: string): string | null {
+    const idx = title.indexOf(' - ')
+    const artist = (idx === -1 ? title : title.slice(0, idx)).trim()
+    return artist.length > 0 ? artist : null
+  }
+
+  // Labels mode step 1: the labels a seed artist's releases appear on, most
+  // frequent first. One search call.
+  async function getLabelsForArtist(artistName: string, limit = 3): Promise<string[]> {
+    const params = new URLSearchParams({
+      type: 'release',
+      artist: artistName,
+      per_page: '50',
+    })
+    const res = await get<DiscogsReleaseSearchResponse>(`/database/search?${params.toString()}`)
+    const counts = new Map<string, number>()
+    for (const r of res.results) {
+      for (const label of r.label ?? []) {
+        const name = label.trim()
+        if (!name || name.toLowerCase() === 'not on label') continue
+        counts.set(name, (counts.get(name) ?? 0) + 1)
+      }
+    }
+    return [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([name]) => name)
+  }
+
+  // Labels mode step 2: artist names appearing on a label's releases. One
+  // search call; co-artist names are parsed from the "Artist - Title" string.
+  async function getArtistsForLabel(labelName: string, limit = 50): Promise<string[]> {
+    const params = new URLSearchParams({
+      type: 'release',
+      label: labelName,
+      per_page: String(Math.min(Math.max(limit, 1), 100)),
+    })
+    const res = await get<DiscogsReleaseSearchResponse>(`/database/search?${params.toString()}`)
+    const seen = new Set<string>()
+    const artists: string[] = []
+    for (const r of res.results) {
+      const artist = artistFromReleaseTitle(r.title)
+      if (!artist) continue
+      const key = artist.toLowerCase()
+      if (key === 'various' || seen.has(key)) continue
+      seen.add(key)
+      artists.push(artist)
+      if (artists.length >= limit) break
+    }
+    return artists
+  }
+
   async function testConnection(): Promise<ServiceTestResult> {
     try {
       const identity = await get<DiscogsIdentityResponse>('/oauth/identity')
@@ -166,6 +227,8 @@ export function createDiscogsClient(
     getCollectionArtists,
     getWantlistArtists,
     searchByGenre,
+    getLabelsForArtist,
+    getArtistsForLabel,
     testConnection,
   }
 }

--- a/src/core/clients/musicbrainz.ts
+++ b/src/core/clients/musicbrainz.ts
@@ -26,7 +26,10 @@ export function parseYear(dateStr?: string): number | undefined {
 
 export type MBRelation = {
   type: string
+  direction?: 'forward' | 'backward'
   url?: { resource: string }
+  // Present on artist-artist relations (inc=artist-rels): the related artist.
+  artist?: { id: string; name: string; disambiguation?: string }
 }
 
 export type MBSearchResult = {
@@ -186,6 +189,13 @@ export function createMusicBrainzClient() {
     return request<MBArtist>(`/artist/${mbid}?${params}`)
   }
 
+  // Artist-artist relations (member-of-band, collaboration, aliases, etc.) for
+  // the artist-relationships discovery mode. One request per artist.
+  function lookupArtistRelations(mbid: string): Promise<MBArtist> {
+    const params = new URLSearchParams({ inc: 'artist-rels', fmt: 'json' })
+    return request<MBArtist>(`/artist/${mbid}?${params}`)
+  }
+
   function searchArtist(query: string): Promise<MBSearchResult> {
     const params = new URLSearchParams({ query, fmt: 'json' })
     return request<MBSearchResult>(`/artist/?${params}`)
@@ -275,6 +285,7 @@ export function createMusicBrainzClient() {
 
   return {
     lookupArtist,
+    lookupArtistRelations,
     searchArtist,
     getReleaseGroups,
     getRecordings,

--- a/src/core/discovery-modes/availability.ts
+++ b/src/core/discovery-modes/availability.ts
@@ -37,7 +37,7 @@ const LISTENBRAINZ_MODE_IDS = new Set([
   'lb-tag-radio',
 ])
 
-const NOT_IMPLEMENTED_MODE_IDS = new Set(['artist-relationships', 'labels'])
+const NOT_IMPLEMENTED_MODE_IDS = new Set<string>()
 
 export function buildDiscoveryModeExecutionContext(
   availability: DiscoveryAvailabilityResult,
@@ -92,6 +92,22 @@ export function evaluateDiscoveryModeAvailability(
       providerPath: [],
       reason: 'Connect a listening source first.',
     }
+  }
+
+  if (modeId === 'artist-relationships') {
+    // MusicBrainz needs no user connection, so this mode is always available.
+    return { enabled: true, fallbackUsed: false, providerPath: ['musicbrainz'] }
+  }
+
+  if (modeId === 'labels') {
+    return snapshot.hasDiscogs
+      ? { enabled: true, fallbackUsed: true, providerPath: ['discogs'] }
+      : {
+          enabled: false,
+          fallbackUsed: false,
+          providerPath: [],
+          reason: 'Connect Discogs to use this mode.',
+        }
   }
 
   if (modeId === 'similar-artist-web') {

--- a/src/core/discovery-modes/modes/artist-relationships.ts
+++ b/src/core/discovery-modes/modes/artist-relationships.ts
@@ -1,4 +1,48 @@
-import type { DiscoveryModeDefinition } from '../types'
+import { createMusicBrainzClient } from '@/core/clients/musicbrainz'
+import type { DiscoveryModeDefinition, RawDiscoveryCandidate } from '../types'
+import { getNormalizedLimit, normalizeDiscoveryName } from './runtime'
+
+type SeedArtist = { name: string; mbid?: string }
+
+// Artist-artist relation types MusicBrainz exposes that are useful for
+// discovery. Used to populate the picker and bound which edges we follow.
+const SUPPORTED_RELATIONSHIP_TYPES = [
+  'member of band',
+  'collaboration',
+  'supporting musician',
+  'is person',
+  'sibling',
+  'married',
+  'involved with',
+] as const
+
+function parseSeeds(raw: unknown): SeedArtist[] {
+  const items = Array.isArray(raw)
+    ? raw
+    : typeof raw === 'string'
+      ? raw.split(',').map((s) => s.trim())
+      : []
+  const seeds: SeedArtist[] = []
+  for (const item of items) {
+    if (typeof item === 'string') {
+      if (item.trim()) seeds.push({ name: item.trim() })
+    } else if (item && typeof item === 'object' && 'name' in item) {
+      const rec = item as Record<string, unknown>
+      const name = String(rec.name ?? '').trim()
+      if (name) seeds.push({ name, mbid: typeof rec.mbid === 'string' ? rec.mbid : undefined })
+    }
+  }
+  return seeds
+}
+
+function parseRelationshipTypes(raw: unknown): Set<string> {
+  const items = Array.isArray(raw)
+    ? raw
+    : typeof raw === 'string'
+      ? raw.split(',').map((s) => s.trim())
+      : []
+  return new Set(items.filter((v): v is string => typeof v === 'string' && v.trim().length > 0))
+}
 
 export function createArtistRelationshipsMode(): DiscoveryModeDefinition {
   return {
@@ -15,9 +59,52 @@ export function createArtistRelationshipsMode(): DiscoveryModeDefinition {
         key: 'relationshipTypes',
         label: 'Relationships',
         type: 'multiselect',
-        required: true,
+        required: false,
+        options: SUPPORTED_RELATIONSHIP_TYPES.map((t) => ({ value: t, label: t })),
       },
+      { key: 'limit', label: 'Limit', type: 'number', required: true },
     ],
-    executor: async () => ({ candidates: [] }),
+    executor: async (request) => {
+      const seeds = parseSeeds(request.normalizedSettings.seedArtists)
+      if (seeds.length === 0) {
+        throw new Error('Add at least one seed artist to use this mode.')
+      }
+      const limit = getNormalizedLimit(request, 25)
+      const selectedTypes = parseRelationshipTypes(request.normalizedSettings.relationshipTypes)
+      const mb = createMusicBrainzClient()
+
+      const seedNames = new Set(seeds.map((s) => normalizeDiscoveryName(s.name)))
+      const byMbid = new Map<string, RawDiscoveryCandidate>()
+
+      for (const seed of seeds) {
+        // Resolve to an MBID when the seed only carries a name (one extra call).
+        let mbid = seed.mbid
+        if (!mbid) {
+          const search = await mb.searchArtist(seed.name)
+          mbid = search.artists[0]?.id
+        }
+        if (!mbid) continue
+
+        const artist = await mb.lookupArtistRelations(mbid)
+        for (const rel of artist.relations ?? []) {
+          if (!rel.artist) continue
+          if (selectedTypes.size > 0 && !selectedTypes.has(rel.type)) continue
+          const related = rel.artist
+          if (seedNames.has(normalizeDiscoveryName(related.name))) continue
+          if (byMbid.has(related.id)) continue
+          byMbid.set(related.id, {
+            candidateType: 'artist',
+            name: related.name,
+            mbid: related.id,
+            provenanceProvider: 'musicbrainz',
+            explanationHint: rel.type,
+            fallbackUsed: false,
+          })
+        }
+        if (byMbid.size >= limit) break
+      }
+
+      return { candidates: [...byMbid.values()].slice(0, limit) }
+    },
   }
 }

--- a/src/core/discovery-modes/modes/labels.ts
+++ b/src/core/discovery-modes/modes/labels.ts
@@ -1,4 +1,32 @@
-import type { DiscoveryModeDefinition } from '../types'
+import { createDiscogsClient } from '@/core/clients/discogs'
+import type { DiscoveryModeDefinition, RawDiscoveryCandidate } from '../types'
+import { getDiscoveryModeConnections, getNormalizedLimit, normalizeDiscoveryName } from './runtime'
+
+type SeedArtist = { name: string; mbid?: string }
+
+// Bounded traversal so a label fan-out stays cheap on the Discogs 60/min limit:
+// at most 3 seeds, one label per seed => ~2 search calls per seed (~6 total).
+const MAX_SEEDS = 3
+const LABELS_PER_SEED = 1
+
+function parseSeeds(raw: unknown): SeedArtist[] {
+  const items = Array.isArray(raw)
+    ? raw
+    : typeof raw === 'string'
+      ? raw.split(',').map((s) => s.trim())
+      : []
+  const seeds: SeedArtist[] = []
+  for (const item of items) {
+    if (typeof item === 'string') {
+      if (item.trim()) seeds.push({ name: item.trim() })
+    } else if (item && typeof item === 'object' && 'name' in item) {
+      const rec = item as Record<string, unknown>
+      const name = String(rec.name ?? '').trim()
+      if (name) seeds.push({ name, mbid: typeof rec.mbid === 'string' ? rec.mbid : undefined })
+    }
+  }
+  return seeds
+}
 
 export function createLabelsMode(): DiscoveryModeDefinition {
   return {
@@ -13,6 +41,45 @@ export function createLabelsMode(): DiscoveryModeDefinition {
       { key: 'seedArtists', label: 'Seed artists', type: 'multiselect', required: true },
       { key: 'limit', label: 'Limit', type: 'number', required: true },
     ],
-    executor: async () => ({ candidates: [] }),
+    executor: async (request) => {
+      const connections = await getDiscoveryModeConnections(request.userId)
+      if (!connections?.discogsToken) {
+        throw new Error('Connect Discogs to use this mode.')
+      }
+
+      const seeds = parseSeeds(request.normalizedSettings.seedArtists).slice(0, MAX_SEEDS)
+      if (seeds.length === 0) {
+        throw new Error('Add at least one seed artist to use this mode.')
+      }
+      const limit = getNormalizedLimit(request, 25)
+      const discogs = createDiscogsClient(
+        connections.discogsToken,
+        connections.discogsUsername ?? '',
+      )
+
+      const seedNames = new Set(seeds.map((s) => normalizeDiscoveryName(s.name)))
+      const byName = new Map<string, RawDiscoveryCandidate>()
+
+      for (const seed of seeds) {
+        const labels = await discogs.getLabelsForArtist(seed.name, LABELS_PER_SEED)
+        for (const label of labels) {
+          const artistNames = await discogs.getArtistsForLabel(label, limit)
+          for (const name of artistNames) {
+            const key = normalizeDiscoveryName(name)
+            if (seedNames.has(key) || byName.has(key)) continue
+            byName.set(key, {
+              candidateType: 'artist',
+              name,
+              provenanceProvider: 'discogs',
+              explanationHint: label,
+              fallbackUsed: true,
+            })
+          }
+        }
+        if (byName.size >= limit) break
+      }
+
+      return { candidates: [...byName.values()].slice(0, limit) }
+    },
   }
 }

--- a/src/core/i18n/messages/de.ts
+++ b/src/core/i18n/messages/de.ts
@@ -693,6 +693,7 @@ export const de = {
   'discoveryMode.reason.connectListeningSource': 'Verbinde zuerst eine Hörquelle.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Verbinde ListenBrainz oder Last.fm, um diesen Modus zu verwenden.',
+  'discoveryMode.reason.connectDiscogs': 'Verbinde Discogs, um diesen Modus zu nutzen.',
   'discoveryMode.reason.notImplementedYet': 'Dieser Modus ist noch nicht implementiert.',
   'discoveryMode.reason.releaseRadarFallback':
     'Fallback-Anbieter werden für die Release-Entdeckung verwendet.',

--- a/src/core/i18n/messages/en.ts
+++ b/src/core/i18n/messages/en.ts
@@ -793,6 +793,7 @@ export const en = {
   'discoveryMode.reason.connectListeningSource': 'Connect a listening source first.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Connect ListenBrainz or Last.fm to use this mode.',
+  'discoveryMode.reason.connectDiscogs': 'Connect Discogs to use this mode.',
   'discoveryMode.reason.notImplementedYet': 'This mode is not implemented yet.',
   'discoveryMode.reason.releaseRadarFallback': 'Using fallback providers for release discovery.',
   'discoveryMode.field.feed': 'Feed',

--- a/src/core/i18n/messages/es.ts
+++ b/src/core/i18n/messages/es.ts
@@ -682,6 +682,7 @@ export const es = {
   'discoveryMode.reason.connectListeningSource': 'Conecta primero una fuente de escucha.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Conecta ListenBrainz o Last.fm para usar este modo.',
+  'discoveryMode.reason.connectDiscogs': 'Conecta Discogs para usar este modo.',
   'discoveryMode.reason.notImplementedYet': 'Este modo aún no está implementado.',
   'discoveryMode.reason.releaseRadarFallback':
     'Usando proveedores de respaldo para descubrir lanzamientos.',

--- a/src/core/i18n/messages/fr.ts
+++ b/src/core/i18n/messages/fr.ts
@@ -678,6 +678,7 @@ export const fr = {
   'discoveryMode.reason.connectListeningSource': 'Connectez d’abord une source d’écoute.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Connectez ListenBrainz ou Last.fm pour utiliser ce mode.',
+  'discoveryMode.reason.connectDiscogs': 'Connectez Discogs pour utiliser ce mode.',
   'discoveryMode.reason.notImplementedYet': "Ce mode n'est pas encore implémenté.",
   'discoveryMode.reason.releaseRadarFallback':
     'Utilisation de fournisseurs de secours pour la découverte des sorties.',

--- a/src/core/i18n/messages/it.ts
+++ b/src/core/i18n/messages/it.ts
@@ -682,6 +682,7 @@ export const it = {
   'discoveryMode.reason.connectListeningSource': "Collega prima una sorgente d'ascolto.",
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Collega ListenBrainz o Last.fm per usare questa modalità.',
+  'discoveryMode.reason.connectDiscogs': 'Collega Discogs per usare questa modalità.',
   'discoveryMode.reason.notImplementedYet': 'Questa modalità non è ancora implementata.',
   'discoveryMode.reason.releaseRadarFallback':
     'Uso di provider di fallback per la scoperta delle uscite.',

--- a/src/core/i18n/messages/ja.ts
+++ b/src/core/i18n/messages/ja.ts
@@ -673,6 +673,7 @@ export const ja = {
   'discoveryMode.reason.connectListeningSource': '先に再生ソースを接続してください。',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'このモードを使うには ListenBrainz または Last.fm を接続してください。',
+  'discoveryMode.reason.connectDiscogs': 'このモードを使うには Discogs を接続してください。',
   'discoveryMode.reason.notImplementedYet': 'このモードはまだ実装されていません。',
   'discoveryMode.reason.releaseRadarFallback':
     'リリース探索にはフォールバックプロバイダーが使われます。',

--- a/src/core/i18n/messages/ko.ts
+++ b/src/core/i18n/messages/ko.ts
@@ -667,6 +667,7 @@ export const ko = {
   'discoveryMode.reason.connectListeningSource': '먼저 청취 소스를 연결하세요.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     '이 모드를 사용하려면 ListenBrainz 또는 Last.fm을 연결하세요.',
+  'discoveryMode.reason.connectDiscogs': '이 모드를 사용하려면 Discogs를 연결하세요.',
   'discoveryMode.reason.notImplementedYet': '이 모드는 아직 구현되지 않았습니다.',
   'discoveryMode.reason.releaseRadarFallback': '릴리스 탐색에는 대체 제공자가 사용됩니다.',
   'discoveryMode.field.feed': '피드',

--- a/src/core/i18n/messages/nl.ts
+++ b/src/core/i18n/messages/nl.ts
@@ -686,6 +686,7 @@ export const nl = {
   'discoveryMode.reason.connectListeningSource': 'Verbind eerst een luisterbron.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Verbind ListenBrainz of Last.fm om deze modus te gebruiken.',
+  'discoveryMode.reason.connectDiscogs': 'Verbind Discogs om deze modus te gebruiken.',
   'discoveryMode.reason.notImplementedYet': 'Deze modus is nog niet geïmplementeerd.',
   'discoveryMode.reason.releaseRadarFallback':
     'Fallbackproviders worden gebruikt voor release-ontdekking.',

--- a/src/core/i18n/messages/pl.ts
+++ b/src/core/i18n/messages/pl.ts
@@ -688,6 +688,7 @@ export const pl = {
   'discoveryMode.reason.connectListeningSource': 'Najpierw połącz źródło odsluchu.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Połącz ListenBrainz lub Last.fm, aby użyć tego trybu.',
+  'discoveryMode.reason.connectDiscogs': 'Połącz Discogs, aby użyć tego trybu.',
   'discoveryMode.reason.notImplementedYet': 'Ten tryb nie jest jeszcze zaimplementowany.',
   'discoveryMode.reason.releaseRadarFallback': 'Do odkrywania wydan używane sa źródła zapasowe.',
   'discoveryMode.field.feed': 'Feed',

--- a/src/core/i18n/messages/pt-BR.ts
+++ b/src/core/i18n/messages/pt-BR.ts
@@ -686,6 +686,7 @@ export const ptBR = {
   'discoveryMode.reason.connectListeningSource': 'Conecte primeiro uma fonte de escuta.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Conecte o ListenBrainz ou o Last.fm para usar este modo.',
+  'discoveryMode.reason.connectDiscogs': 'Conecte o Discogs para usar este modo.',
   'discoveryMode.reason.notImplementedYet': 'Este modo ainda não foi implementado.',
   'discoveryMode.reason.releaseRadarFallback':
     'Usando provedores de fallback para descobrir lançamentos.',

--- a/src/core/i18n/messages/ro.ts
+++ b/src/core/i18n/messages/ro.ts
@@ -685,6 +685,7 @@ export const ro = {
   'discoveryMode.reason.connectListeningSource': 'Conectați mai întâi o sursă de ascultare.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Conectați ListenBrainz sau Last.fm pentru a folosi acest mod.',
+  'discoveryMode.reason.connectDiscogs': 'Conectează Discogs pentru a folosi acest mod.',
   'discoveryMode.reason.notImplementedYet': 'Acest mod nu este încă implementat.',
   'discoveryMode.reason.releaseRadarFallback':
     'Se folosesc furnizori de rezervă pentru descoperirea lansărilor.',

--- a/src/core/i18n/messages/ru.ts
+++ b/src/core/i18n/messages/ru.ts
@@ -694,6 +694,7 @@ export const ru = {
   'discoveryMode.reason.connectListeningSource': 'Сначала подключите источник прослушивания.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Подключите ListenBrainz или Last.fm, чтобы использовать этот режим.',
+  'discoveryMode.reason.connectDiscogs': 'Подключите Discogs, чтобы использовать этот режим.',
   'discoveryMode.reason.notImplementedYet': 'Этот режим ещё не реализован.',
   'discoveryMode.reason.releaseRadarFallback':
     'Для поиска релизов используются резервные провайдеры.',

--- a/src/core/i18n/messages/tr.ts
+++ b/src/core/i18n/messages/tr.ts
@@ -683,6 +683,7 @@ export const tr = {
   'discoveryMode.reason.connectListeningSource': 'Once bir dinleme kaynagi baglayin.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Bu modu kullanmak için ListenBrainz veya Last.fm baglayin.',
+  'discoveryMode.reason.connectDiscogs': "Bu modu kullanmak için Discogs'u bağlayın.",
   'discoveryMode.reason.notImplementedYet': 'Bu mod henüz uygulanmadı.',
   'discoveryMode.reason.releaseRadarFallback': 'Yayin kesfi için yedek saglayicilar kullaniliyor.',
   'discoveryMode.field.feed': 'Feed',

--- a/src/core/i18n/messages/uk.ts
+++ b/src/core/i18n/messages/uk.ts
@@ -689,6 +689,7 @@ export const uk = {
   'discoveryMode.reason.connectListeningSource': 'Спочатку підключіть джерело прослуховування.',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     'Підключіть ListenBrainz або Last.fm, щоб користуватися цим режимом.',
+  'discoveryMode.reason.connectDiscogs': 'Підключіть Discogs, щоб використовувати цей режим.',
   'discoveryMode.reason.notImplementedYet': 'Цей режим ще не реалізовано.',
   'discoveryMode.reason.releaseRadarFallback':
     'Для пошуку релізів використовуються резервні постачальники.',

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -634,6 +634,7 @@ export const zhCN = {
   'discoveryMode.reason.connectListeningSource': '请先连接一个听歌来源。',
   'discoveryMode.reason.connectListenBrainzOrLastfm':
     '连接 ListenBrainz 或 Last.fm 后才能使用此模式。',
+  'discoveryMode.reason.connectDiscogs': '连接 Discogs 以使用此模式。',
   'discoveryMode.reason.notImplementedYet': '此模式尚未实现。',
   'discoveryMode.reason.releaseRadarFallback': '正在使用后备提供方来发现新发行。',
   'discoveryMode.field.feed': '订阅源',

--- a/src/web/lib/discovery-i18n.ts
+++ b/src/web/lib/discovery-i18n.ts
@@ -34,6 +34,7 @@ const REASON_KEY_ALIASES: Record<string, MessageKey> = {
   'Connect a listening source first.': 'discoveryMode.reason.connectListeningSource',
   'Connect ListenBrainz or Last.fm to use this mode.':
     'discoveryMode.reason.connectListenBrainzOrLastfm',
+  'Connect Discogs to use this mode.': 'discoveryMode.reason.connectDiscogs',
   'Using fallback providers for release discovery.': 'discoveryMode.reason.releaseRadarFallback',
   'This mode is not implemented yet.': 'discoveryMode.notImplementedYet',
   'This mode is not shipped yet.': 'discoveryMode.notShippedYet',

--- a/tests/api-routes/pipeline-discovery-modes.test.ts
+++ b/tests/api-routes/pipeline-discovery-modes.test.ts
@@ -112,7 +112,7 @@ describe('API routes: discovery mode pipeline runs', () => {
     })
 
     expect(res.status).toBe(400)
-    expect(await res.json()).toEqual({ error: 'This mode is not implemented yet.' })
+    expect(await res.json()).toEqual({ error: 'Connect Discogs to use this mode.' })
   })
 
   it('returns 400 for request validation failures', async () => {

--- a/tests/api-routes/subscriptions-discovery-modes.test.ts
+++ b/tests/api-routes/subscriptions-discovery-modes.test.ts
@@ -138,7 +138,7 @@ describe('API routes: discovery mode subscriptions', () => {
     )
   })
 
-  it('rejects unshipped discovery mode subscriptions even when the mode exists in the registry', async () => {
+  it('rejects discovery mode subscriptions for a mode whose connection is missing', async () => {
     const createSubscription = vi.fn()
     const { app } = createTestApp({
       subscriptionQueries: {
@@ -168,7 +168,7 @@ describe('API routes: discovery mode subscriptions', () => {
     })
 
     expect(res.status).toBe(400)
-    expect(await res.json()).toEqual({ error: 'This mode is not implemented yet.' })
+    expect(await res.json()).toEqual({ error: 'Connect Discogs to use this mode.' })
     expect(createSubscription).not.toHaveBeenCalled()
   })
 

--- a/tests/core/discovery-modes/artist-relationships.test.ts
+++ b/tests/core/discovery-modes/artist-relationships.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSearchArtist = vi.fn()
+const mockLookupArtistRelations = vi.fn()
+vi.mock('@/core/clients/musicbrainz', () => ({
+  createMusicBrainzClient: vi.fn(() => ({
+    searchArtist: mockSearchArtist,
+    lookupArtistRelations: mockLookupArtistRelations,
+  })),
+}))
+
+import { createArtistRelationshipsMode } from '@/core/discovery-modes/modes/artist-relationships'
+import type { DiscoveryModeRequest } from '@/core/discovery-modes/request'
+
+function makeRequest(settings: Record<string, unknown>): DiscoveryModeRequest {
+  return {
+    modeId: 'artist-relationships',
+    triggerType: 'manual',
+    settingsMode: 'advanced',
+    userId: 1,
+    rawUserSettings: settings,
+    normalizedSettings: settings,
+    providerContext: { providerPath: ['musicbrainz'] },
+    fallbackPolicy: 'strict',
+  }
+}
+
+describe('artist-relationships mode', () => {
+  beforeEach(() => {
+    mockSearchArtist.mockReset()
+    mockLookupArtistRelations.mockReset()
+  })
+
+  it('returns related artists from MB artist-artist relations, excluding seeds', async () => {
+    mockLookupArtistRelations.mockResolvedValue({
+      id: 'seed-mbid',
+      name: 'Seed Band',
+      relations: [
+        { type: 'member of band', artist: { id: 'm1', name: 'Member One' } },
+        { type: 'collaboration', artist: { id: 'c1', name: 'Collaborator' } },
+        { type: 'member of band', artist: { id: 'seed-mbid', name: 'Seed Band' } }, // self
+        { type: 'url', url: { resource: 'https://example.com' } }, // non-artist
+      ],
+    })
+
+    const mode = createArtistRelationshipsMode()
+    const result = await mode.executor(
+      makeRequest({ seedArtists: [{ name: 'Seed Band', mbid: 'seed-mbid' }] }),
+    )
+
+    expect(mockSearchArtist).not.toHaveBeenCalled() // mbid supplied, no resolve needed
+    expect(result.candidates.map((c) => c.name)).toEqual(['Member One', 'Collaborator'])
+    expect(result.candidates[0]).toMatchObject({
+      candidateType: 'artist',
+      mbid: 'm1',
+      provenanceProvider: 'musicbrainz',
+      explanationHint: 'member of band',
+    })
+  })
+
+  it('filters by selected relationship types', async () => {
+    mockLookupArtistRelations.mockResolvedValue({
+      id: 'seed-mbid',
+      name: 'Seed',
+      relations: [
+        { type: 'member of band', artist: { id: 'm1', name: 'Member One' } },
+        { type: 'collaboration', artist: { id: 'c1', name: 'Collaborator' } },
+      ],
+    })
+
+    const mode = createArtistRelationshipsMode()
+    const result = await mode.executor(
+      makeRequest({
+        seedArtists: [{ name: 'Seed', mbid: 'seed-mbid' }],
+        relationshipTypes: ['collaboration'],
+      }),
+    )
+
+    expect(result.candidates.map((c) => c.name)).toEqual(['Collaborator'])
+  })
+
+  it('resolves a seed name to an MBID via search when none is supplied', async () => {
+    mockSearchArtist.mockResolvedValue({ artists: [{ id: 'resolved', name: 'Seed', score: 100 }] })
+    mockLookupArtistRelations.mockResolvedValue({
+      id: 'resolved',
+      name: 'Seed',
+      relations: [{ type: 'collaboration', artist: { id: 'c1', name: 'Collaborator' } }],
+    })
+
+    const mode = createArtistRelationshipsMode()
+    const result = await mode.executor(makeRequest({ seedArtists: ['Seed'] }))
+
+    expect(mockSearchArtist).toHaveBeenCalledWith('Seed')
+    expect(mockLookupArtistRelations).toHaveBeenCalledWith('resolved')
+    expect(result.candidates.map((c) => c.name)).toEqual(['Collaborator'])
+  })
+
+  it('throws when no seed artists are provided', async () => {
+    const mode = createArtistRelationshipsMode()
+    await expect(mode.executor(makeRequest({ seedArtists: [] }))).rejects.toThrow(/seed artist/i)
+  })
+})

--- a/tests/core/discovery-modes/availability.test.ts
+++ b/tests/core/discovery-modes/availability.test.ts
@@ -68,7 +68,7 @@ describe('evaluateDiscoveryModeAvailability', () => {
     expect(result.fallbackUsed).toBe(true)
   })
 
-  it('disables unfinished modes instead of advertising fake availability', () => {
+  it('enables artist-relationships (MusicBrainz) always and labels when Discogs is connected', () => {
     const snapshot = {
       hasListenBrainz: true,
       hasSpotify: true,
@@ -78,16 +78,14 @@ describe('evaluateDiscoveryModeAvailability', () => {
     }
 
     expect(evaluateDiscoveryModeAvailability('artist-relationships', snapshot)).toMatchObject({
-      enabled: false,
+      enabled: true,
       fallbackUsed: false,
-      providerPath: [],
-      reason: 'This mode is not implemented yet.',
+      providerPath: ['musicbrainz'],
     })
     expect(evaluateDiscoveryModeAvailability('labels', snapshot)).toMatchObject({
-      enabled: false,
-      fallbackUsed: false,
-      providerPath: [],
-      reason: 'This mode is not implemented yet.',
+      enabled: true,
+      fallbackUsed: true,
+      providerPath: ['discogs'],
     })
   })
 
@@ -130,7 +128,7 @@ describe('evaluateDiscoveryModeAvailability', () => {
     })
   })
 
-  it('reports unfinished labels mode as unavailable', () => {
+  it('reports labels mode unavailable when Discogs is not connected', () => {
     const result = evaluateDiscoveryModeAvailability('labels', {
       hasListenBrainz: false,
       hasSpotify: false,
@@ -144,6 +142,6 @@ describe('evaluateDiscoveryModeAvailability', () => {
       fallbackUsed: false,
       providerPath: [],
     })
-    expect(result.reason).toBe('This mode is not implemented yet.')
+    expect(result.reason).toBe('Connect Discogs to use this mode.')
   })
 })

--- a/tests/core/discovery-modes/labels.test.ts
+++ b/tests/core/discovery-modes/labels.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetLabelsForArtist, mockGetArtistsForLabel, mockGetConnections } = vi.hoisted(() => ({
+  mockGetLabelsForArtist: vi.fn(),
+  mockGetArtistsForLabel: vi.fn(),
+  mockGetConnections: vi.fn(),
+}))
+
+vi.mock('@/core/clients/discogs', () => ({
+  createDiscogsClient: vi.fn(() => ({
+    getLabelsForArtist: mockGetLabelsForArtist,
+    getArtistsForLabel: mockGetArtistsForLabel,
+  })),
+}))
+
+vi.mock('@/core/discovery-modes/modes/runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/discovery-modes/modes/runtime')>()
+  return { ...actual, getDiscoveryModeConnections: mockGetConnections }
+})
+
+import { createLabelsMode } from '@/core/discovery-modes/modes/labels'
+import type { DiscoveryModeRequest } from '@/core/discovery-modes/request'
+
+function makeRequest(settings: Record<string, unknown>): DiscoveryModeRequest {
+  return {
+    modeId: 'labels',
+    triggerType: 'manual',
+    settingsMode: 'advanced',
+    userId: 1,
+    rawUserSettings: settings,
+    normalizedSettings: settings,
+    providerContext: { providerPath: ['discogs'] },
+    fallbackPolicy: 'allow-fallback',
+  }
+}
+
+describe('labels mode', () => {
+  beforeEach(() => {
+    mockGetLabelsForArtist.mockReset()
+    mockGetArtistsForLabel.mockReset()
+    mockGetConnections.mockReset()
+    mockGetConnections.mockResolvedValue({ discogsToken: 'tok', discogsUsername: 'user' })
+  })
+
+  it('returns co-label artists, excluding seeds and duplicates', async () => {
+    mockGetLabelsForArtist.mockResolvedValue(['Warp Records'])
+    mockGetArtistsForLabel.mockResolvedValue(['Aphex Twin', 'Boards of Canada', 'Seed Artist'])
+
+    const mode = createLabelsMode()
+    const result = await mode.executor(makeRequest({ seedArtists: ['Seed Artist'] }))
+
+    expect(result.candidates.map((c) => c.name)).toEqual(['Aphex Twin', 'Boards of Canada'])
+    expect(result.candidates[0]).toMatchObject({
+      candidateType: 'artist',
+      provenanceProvider: 'discogs',
+      explanationHint: 'Warp Records',
+      fallbackUsed: true,
+    })
+  })
+
+  it('throws when Discogs is not connected', async () => {
+    mockGetConnections.mockResolvedValue({ discogsToken: null, discogsUsername: null })
+    const mode = createLabelsMode()
+    await expect(mode.executor(makeRequest({ seedArtists: ['Seed'] }))).rejects.toThrow(/discogs/i)
+  })
+
+  it('caps the traversal to at most 3 seeds', async () => {
+    mockGetLabelsForArtist.mockResolvedValue(['Label'])
+    mockGetArtistsForLabel.mockResolvedValue([])
+    const mode = createLabelsMode()
+    await mode.executor(makeRequest({ seedArtists: ['s1', 's2', 's3', 's4', 's5'] }))
+    expect(mockGetLabelsForArtist).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws when no seed artists are provided', async () => {
+    const mode = createLabelsMode()
+    await expect(mode.executor(makeRequest({ seedArtists: [] }))).rejects.toThrow(/seed artist/i)
+  })
+})

--- a/tests/core/plugins/discogs.test.ts
+++ b/tests/core/plugins/discogs.test.ts
@@ -23,6 +23,8 @@ describe('createDiscogsSource()', () => {
         { name: 'Massive Attack', id: 10 },
         { name: 'Tricky', id: 11 },
       ]),
+      getLabelsForArtist: vi.fn().mockResolvedValue([]),
+      getArtistsForLabel: vi.fn().mockResolvedValue([]),
       testConnection: vi.fn().mockResolvedValue({
         success: true,
         message: 'Connected to Discogs as testuser',


### PR DESCRIPTION
Implements spec phase 5: the two previously-stubbed discovery modes now run. Both removed from `NOT_IMPLEMENTED_MODE_IDS`.

## Artist Relationships (MusicBrainz)
- New `lookupArtistRelations(mbid)` on the MB client (`inc=artist-rels`); `MBRelation` extended with `direction` + `artist` target.
- Executor: resolves each seed (search only when no MBID), pulls artist-artist relations (member-of-band, collaboration, alias, ...), filterable by a `relationshipTypes` picker, dedupes and excludes seeds. **One call per seed.** MB needs no connection, so `availability: strict` (always enabled).

## Labels (Discogs)
- New `getLabelsForArtist` + `getArtistsForLabel` on the Discogs client, both using the `/database/search?type=release` endpoint (label names and "Artist - Title" come back inline, so no per-release fan-out).
- Executor: seed -> top label -> co-label artists. **Bounded per the spike: max 3 seeds, 1 label/seed (~2 search calls each, ~6 total)** to stay under the Discogs 60/min limit. Gated on a connected Discogs account (`availability: fallback`).

## Spike result (why these bounds)
`/artists/{id}/releases` only carries label info on `type:release` entries (not masters), so the structured-release search path avoids the per-release fan-out. Artist-relationships is cheap (1 call/seed); labels is the chatty one, hence the tight caps you chose. Candidates are name-only where appropriate — the pipeline's resolve stage maps them to MBIDs.

## i18n + docs
- New `discoveryMode.reason.connectDiscogs` across all 15 locales (mode label/description keys already existed). README discovery sections updated to list both as shipped.

## Verification
- `bun run test` — 2235 passed / 25 skipped (new executor tests with mocked MB/Discogs: happy path, type-filtering, seed resolution, caps, missing-connection; updated availability + api-route rejection tests)
- `bun run typecheck`, `bun run lint` — clean
- `bun run i18n:check` — 15 locales clean
- `bun run check:api-docs` — 140 routes (no new public routes)

Note: a live end-to-end "mode runs against real MB/Discogs" browser test would be non-deterministic (external APIs); coverage is via mocked-client unit tests + the existing discovery-modes page e2e.