### PR TITLE
chore(release): sync deploy digests to v1.0.0-rc.10

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.10"
-  digest: "sha256:cdf4d140157fedc31d1c86543701f6037516baa6300d81ca23e5e61db9779b77"
+  digest: "sha256:b319e236c6fac9440b293dacac27bd713ee86127b788b355bc71be5183efe10e"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:cdf4d140157fedc31d1c86543701f6037516baa6300d81ca23e5e61db9779b77
+          image: ghcr.io/iuliandita/digarr@sha256:b319e236c6fac9440b293dacac27bd713ee86127b788b355bc71be5183efe10e
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:cdf4d140157fedc31d1c86543701f6037516baa6300d81ca23e5e61db9779b77"
+          image: "ghcr.io/iuliandita/digarr@sha256:b319e236c6fac9440b293dacac27bd713ee86127b788b355bc71be5183efe10e"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:cdf4d140157fedc31d1c86543701f6037516baa6300d81ca23e5e61db9779b77 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:b319e236c6fac9440b293dacac27bd713ee86127b788b355bc71be5183efe10e -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.9</Repository>
    <Tag>1.0.0-rc.9</Tag>
    <TagDescription>v1.0.0-rc.9 prerelease</TagDescription>


### PR DESCRIPTION
Post-release digest sync for v1.0.0-rc.10. Repoints the published image digest (`sha256:b319e236...`) in `deploy/k8s/deployment.yaml`, `deploy/helm/digarr/values.yaml`, `deploy/unraid/digarr.xml`, and regenerates `deploy/k8s/rendered.yaml` (helm 3.16.4). Reproducibility follow-up, not a gate.