### PR TITLE
fix(api): sanitize internal error messages in API responses

### DIFF
--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -6,6 +6,11 @@ export function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
+export function logAndSanitize(err: unknown, context: string): string {
+  console.error(`[${context}]`, err)
+  return 'An unexpected error occurred'
+}
+
 export function normalizeIp(address: string): string {
   const bare =
     address

--- a/src/server/routes/admin.ts
+++ b/src/server/routes/admin.ts
@@ -12,6 +12,7 @@ import {
 import type { BackupFile, OpsDb } from '@/core/ops/types'
 import { getPendingMigrations } from '@/core/ops/upgrade'
 import { isValidStatus } from '@/core/recommendations/statuses'
+import { logAndSanitize } from '@/core/validation'
 import { mergePreferences, type Preferences } from '@/db/schema'
 import { backupFileSchema } from '@/server/schemas/admin'
 import type { HonoEnv } from '@/server/types'
@@ -103,8 +104,8 @@ export function adminRoutes(deps: AdminDeps) {
     try {
       result = await restoreBackup(deps.db, backup, { force })
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      return c.json({ error: `Restore failed (rolled back): ${msg}` }, 500)
+      const message = logAndSanitize(err, 'admin-restore')
+      return c.json({ error: `Restore failed (rolled back): ${message}` }, 500)
     }
 
     if (result.encryptionMismatch && !force) {

--- a/src/server/routes/library.ts
+++ b/src/server/routes/library.ts
@@ -5,7 +5,7 @@ import type { SkyHookWarmer } from '@/core/library/skyhook-warmer'
 import type { LibrarySyncStore } from '@/core/library/store'
 import { SOURCE_NOT_CONFIGURED_ERROR, type SyncOrchestrator } from '@/core/library/sync'
 import type { HealthCheckId } from '@/core/library/types'
-import { errMsg } from '@/core/validation'
+import { errMsg, logAndSanitize } from '@/core/validation'
 import { requireAdmin, requireSessionUser } from '@/server/helpers/require-user'
 import { rateLimiter } from '@/server/middleware/rate-limit'
 import {
@@ -79,7 +79,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
       const progress = await deps.libraryHealth.fixCheck(checkId as HealthCheckId)
       return c.json(progress)
     } catch (err: unknown) {
-      return c.json({ error: errMsg(err) }, 400)
+      return c.json({ error: logAndSanitize(err, 'library-health-fix') }, 400)
     }
   })
 

--- a/src/server/routes/lidarr.ts
+++ b/src/server/routes/lidarr.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { createLidarrClient } from '@/core/clients/lidarr'
-import { errMsg } from '@/core/validation'
+import { logAndSanitize } from '@/core/validation'
 import type { AppDependencies } from '@/server'
 import { adminGuard } from '@/server/middleware/admin-guard'
 import { lidarrAddSchema } from '@/server/schemas/lidarr'
@@ -22,7 +22,7 @@ export function lidarrRoutes(deps: AppDependencies) {
     )
   }
 
-  router.onError((err, c) => c.json({ error: errMsg(err) }, 500))
+  router.onError((err, c) => c.json({ error: logAndSanitize(err, 'lidarr-route') }, 500))
 
   router.get('/api/v1/lidarr/stats', adminGuard(deps.getUserById), async (c) => {
     const client = await getClient()

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -21,7 +21,7 @@ import { resolve } from '@/core/pipeline/resolve'
 import { score } from '@/core/pipeline/score'
 import { store } from '@/core/pipeline/store'
 import { resolveSpotifyToken } from '@/core/spotify-auth'
-import { errMsg } from '@/core/validation'
+import { errMsg, logAndSanitize } from '@/core/validation'
 import { upsertArtist } from '@/db/queries/artists'
 import { getUserConnections } from '@/db/queries/users'
 import { mergePreferences } from '@/db/schema'
@@ -181,7 +181,7 @@ export function pipelineRoutes(deps: AppDependencies) {
 
       return c.json({ message: 'Discovery run started', jobId }, 202)
     } catch (err: unknown) {
-      return c.json({ error: errMsg(err) }, 400)
+      return c.json({ error: logAndSanitize(err, 'discovery-mode') }, 400)
     }
   })
 

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -5,7 +5,7 @@ import { createLidarrClient } from '@/core/clients/lidarr'
 import { createListenBrainzClient } from '@/core/clients/listenbrainz'
 import { sendWebhook } from '@/core/notifications'
 import { validateAiBaseUrl } from '@/core/url-safety'
-import { errMsg } from '@/core/validation'
+import { logAndSanitize } from '@/core/validation'
 import { getUserConnections, updateUserConnections } from '@/db/queries/users'
 import type { Preferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
@@ -613,7 +613,7 @@ export function settingsRoutes(deps: AppDependencies) {
         'webhook-test-failed',
         'Webhook test failed',
         502,
-        errMsg(err),
+        logAndSanitize(err, 'webhook-test'),
         undefined,
         'common.unknownError',
       )

--- a/src/server/routes/slskd.ts
+++ b/src/server/routes/slskd.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { errMsg } from '@/core/validation'
+import { logAndSanitize } from '@/core/validation'
 import type { AppDependencies } from '@/server'
 import { adminGuard } from '@/server/middleware/admin-guard'
 import type { HonoEnv } from '@/server/types'
@@ -41,8 +41,7 @@ export function slskdRoutes(deps: SlskdRouteDeps) {
         console.error('[slskd] manual sync failed:', error)
       })
     } catch (error) {
-      console.error('[slskd] manual sync failed:', error)
-      return c.json({ error: errMsg(error) }, 500)
+      return c.json({ error: logAndSanitize(error, 'slskd-sync') }, 500)
     }
 
     return c.body(null, 202)

--- a/tests/server/routes/library.test.ts
+++ b/tests/server/routes/library.test.ts
@@ -406,7 +406,7 @@ describe('POST /api/v1/library/health/:checkId/fix', () => {
     })
     expect(res.status).toBe(400)
     const body = await res.json()
-    expect(body.error).toMatch(/not fixable/i)
+    expect(body.error).toBe('An unexpected error occurred')
   })
 })
 

--- a/tests/server/routes/lidarr.test.ts
+++ b/tests/server/routes/lidarr.test.ts
@@ -182,3 +182,24 @@ describe('GET /api/v1/lidarr/approve-options (non-admin picker)', () => {
     expect(res.status).toBe(200)
   })
 })
+
+describe('Lidarr onError sanitization', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('does not leak internal error details in the response', async () => {
+    const { createLidarrClient } = await import('@/core/clients/lidarr')
+    vi.mocked(createLidarrClient).mockReturnValueOnce({
+      getArtists: vi.fn(async () => {
+        throw new Error('connect ECONNREFUSED 10.0.0.5:8686')
+      }),
+    } as never)
+
+    const app = createTestApp({ userId: 1 })
+    const res = await app.request('/api/v1/lidarr/stats')
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('An unexpected error occurred')
+    expect(JSON.stringify(body)).not.toContain('10.0.0.5')
+    expect(JSON.stringify(body)).not.toContain('8686')
+  })
+})

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -95,6 +95,10 @@ vi.mock('@/core/auth/oidc', () => ({
   },
 }))
 
+vi.mock('@/core/notifications', () => ({
+  sendWebhook: vi.fn(),
+}))
+
 const mockSettings = {
   id: 1,
   lidarrUrl: 'http://lidarr:8686',
@@ -1129,5 +1133,37 @@ describe('per-user listening source connections', () => {
         lastfmApiKey: 'my-key',
       }),
     )
+  })
+})
+
+describe('POST /api/v1/settings/test-webhook error sanitization', () => {
+  it('does not leak the upstream URL or raw error in the 502 response', async () => {
+    const { sendWebhook } = await import('@/core/notifications')
+    vi.mocked(sendWebhook).mockRejectedValueOnce(
+      new Error('connect ECONNREFUSED 10.9.8.7:9000 (http://hooks.internal:9000/notify)'),
+    )
+
+    const app = createApp(
+      makeDeps({
+        getSettings: vi.fn(
+          async () =>
+            ({
+              ...mockSettings,
+              preferences: { webhookUrl: 'http://hooks.internal:9000/notify' },
+            }) as unknown as SettingsRow,
+        ),
+      }),
+    )
+
+    const res = await authedRequest(app, '/api/v1/settings/test-webhook', { method: 'POST' })
+
+    expect(res.status).toBe(502)
+    const body = (await res.json()) as { detail?: string }
+    // detail must be the generic message, not the raw error from sendWebhook
+    expect(body.detail).toBe('An unexpected error occurred')
+    const serialized = JSON.stringify(body)
+    expect(serialized).not.toContain('10.9.8.7')
+    expect(serialized).not.toContain('hooks.internal')
+    expect(serialized).not.toContain('ECONNREFUSED')
   })
 })


### PR DESCRIPTION
## Summary
Stops raw internal error strings (stack details, host:port, connection errors) from leaking into API 500 responses. Adds `logAndSanitize(err, context)` helper in `src/core/validation.ts` that logs the real error server-side and returns a generic `An unexpected error occurred` to the client. Wires it into the six routes that previously echoed `errMsg(err)`/raw messages: admin, library, lidarr, pipeline, settings, slskd.

Recovered from the parked `fix/sanitize-api-errors` branch, rebased onto current main (rc.11). Conflict in `lidarr.test.ts` resolved additively (kept both the `approve-options` and new `onError sanitization` describe blocks).

## Test plan
- typecheck: clean
- lint: clean (exit 0)
- affected route tests: 91 passed
- full suite: 2242 passed, 25 skipped