### PR TITLE
fix(workers): isolate per-item errors in background workers

### DIFF
--- a/src/core/clients/tag-radio-resolver.ts
+++ b/src/core/clients/tag-radio-resolver.ts
@@ -34,7 +34,12 @@ export async function resolveTagRadioRecordings(
   // 3. Resolve misses via MB (client handles rate limiting internally)
   const resolved: (RecordingArtistCredit | null)[] = []
   for (const r of misses) {
-    resolved.push(await mbClient.lookupRecording(r.recordingMbid))
+    try {
+      resolved.push(await mbClient.lookupRecording(r.recordingMbid))
+    } catch (err) {
+      console.error(`[tag-radio] lookupRecording failed for ${r.recordingMbid}:`, err)
+      resolved.push(null)
+    }
   }
 
   // 4. Write newly resolved to cache

--- a/src/core/jobs/recorder.ts
+++ b/src/core/jobs/recorder.ts
@@ -71,20 +71,24 @@ export function createJobRecorder(db: Database): JobRecorder {
       let totalMarked = 0
       for (const [type, thresholdMs] of Object.entries(STUCK_THRESHOLDS_MS)) {
         const cutoff = new Date(Date.now() - thresholdMs)
-        const result = await db
-          .update(jobRuns)
-          .set({ status: 'stuck' })
-          .where(
-            and(
-              eq(jobRuns.type, type),
-              eq(jobRuns.status, 'running'),
-              lt(jobRuns.startedAt, cutoff),
-            ),
-          )
-          .returning({ id: jobRuns.id })
-        if (result.length > 0) {
-          console.warn(`[jobs] Marked ${result.length} stuck ${type} job(s)`)
-          totalMarked += result.length
+        try {
+          const result = await db
+            .update(jobRuns)
+            .set({ status: 'stuck' })
+            .where(
+              and(
+                eq(jobRuns.type, type),
+                eq(jobRuns.status, 'running'),
+                lt(jobRuns.startedAt, cutoff),
+              ),
+            )
+            .returning({ id: jobRuns.id })
+          if (result.length > 0) {
+            console.warn(`[jobs] Marked ${result.length} stuck ${type} job(s)`)
+            totalMarked += result.length
+          }
+        } catch (err) {
+          console.error(`[jobs] Failed to mark stuck ${type} jobs:`, err)
         }
       }
       return totalMarked

--- a/src/core/pipeline/enrich.ts
+++ b/src/core/pipeline/enrich.ts
@@ -15,7 +15,13 @@ export async function enrichGenres(
   return Promise.all(
     artists.map(async (artist) => {
       if (artist.genres.length > SPARSE_THRESHOLD) return artist
-      const meta = await lookup(artist.name)
+      let meta: Awaited<ReturnType<MetadataLookup>>
+      try {
+        meta = await lookup(artist.name)
+      } catch (err) {
+        console.error(`[enrich] metadata lookup failed for ${artist.name}:`, err)
+        return artist
+      }
       if (!meta?.spotifyGenres?.length) return artist
       const existing = new Set(artist.genres.map((g) => g.toLowerCase()))
       const merged = [...artist.genres]

--- a/src/core/slskd/orchestrator.ts
+++ b/src/core/slskd/orchestrator.ts
@@ -564,12 +564,23 @@ export function createSlskdOrchestrator<TJob extends SlskdPendingJobBase = Slskd
     for (const job of jobs) {
       const slskd = getSlskdClient(job.targetId)
 
-      if (job.state === 'pending' || job.state === 'searching') {
-        await processSearchableJob(job, slskd)
-        continue
-      }
+      try {
+        if (job.state === 'pending' || job.state === 'searching') {
+          await processSearchableJob(job, slskd)
+          continue
+        }
 
-      await processTransferJob(job, slskd, targets)
+        await processTransferJob(job, slskd, targets)
+      } catch (err: unknown) {
+        console.error(`[slskd] Job ${job.id} (${job.state}) failed:`, err)
+        try {
+          await deps.updateJobState?.(job.id, 'failed', {
+            lastError: err instanceof Error ? err.message : String(err),
+          })
+        } catch (markErr) {
+          console.error(`[slskd] Failed to mark job ${job.id} as failed:`, markErr)
+        }
+      }
     }
   }
 

--- a/tests/core/clients/tag-radio-resolver.test.ts
+++ b/tests/core/clients/tag-radio-resolver.test.ts
@@ -159,4 +159,25 @@ describe('resolveTagRadioRecordings', () => {
     expect(result[1]?.score).toBe(0.6)
     expect(result[2]?.score).toBe(0.3)
   })
+
+  it('continues resolving remaining recordings when one lookup throws', async () => {
+    const recordings: TagRadioRecording[] = [
+      { recordingMbid: 'rec-1', percent: 80, source: 'artist', tagCount: 5 },
+      { recordingMbid: 'rec-2', percent: 60, source: 'artist', tagCount: 3 },
+    ]
+
+    mockLookupRecording
+      .mockRejectedValueOnce(new Error('MB 503'))
+      .mockResolvedValueOnce({
+        recordingMbid: 'rec-2',
+        artistMbid: 'artist-B',
+        artistName: 'Artist B',
+      })
+
+    const result = await resolveTagRadioRecordings(recordings, mockMbClient, mockDb)
+
+    expect(mockLookupRecording).toHaveBeenCalledTimes(2)
+    expect(result).toHaveLength(1)
+    expect(result[0]?.artistMbid).toBe('artist-B')
+  })
 })

--- a/tests/core/clients/tag-radio-resolver.test.ts
+++ b/tests/core/clients/tag-radio-resolver.test.ts
@@ -166,13 +166,11 @@ describe('resolveTagRadioRecordings', () => {
       { recordingMbid: 'rec-2', percent: 60, source: 'artist', tagCount: 3 },
     ]
 
-    mockLookupRecording
-      .mockRejectedValueOnce(new Error('MB 503'))
-      .mockResolvedValueOnce({
-        recordingMbid: 'rec-2',
-        artistMbid: 'artist-B',
-        artistName: 'Artist B',
-      })
+    mockLookupRecording.mockRejectedValueOnce(new Error('MB 503')).mockResolvedValueOnce({
+      recordingMbid: 'rec-2',
+      artistMbid: 'artist-B',
+      artistName: 'Artist B',
+    })
 
     const result = await resolveTagRadioRecordings(recordings, mockMbClient, mockDb)
 

--- a/tests/core/jobs/recorder.test.ts
+++ b/tests/core/jobs/recorder.test.ts
@@ -206,5 +206,18 @@ describe('createJobRecorder', () => {
 
       expect(db._mocks.updateSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'stuck' }))
     })
+
+    it('continues processing remaining types when one type throws', async () => {
+      const db = makeDb({ updatedRows: 0 })
+      // First update call throws, subsequent ones succeed
+      db._mocks.update.mockRejectedValueOnce(new Error('DB timeout'))
+      const recorder = createJobRecorder(db as never)
+
+      const count = await recorder.markStuck()
+
+      // All 6 types attempted despite first failure
+      expect(db._mocks.update).toHaveBeenCalledTimes(6)
+      expect(count).toBe(0)
+    })
   })
 })

--- a/tests/core/pipeline/enrich.test.ts
+++ b/tests/core/pipeline/enrich.test.ts
@@ -67,4 +67,18 @@ describe('enrichGenres()', () => {
     const result = await enrichGenres(artists, lookup)
     expect(result[0]?.genres).toEqual(['rock'])
   })
+
+  it('returns artist unchanged when lookup throws, without aborting the batch', async () => {
+    const lookup: MetadataLookup = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('DB connection lost'))
+      .mockResolvedValueOnce({ spotifyGenres: ['jazz'], spotifyPopularity: 70 })
+    const artists = [
+      makeArtist({ name: 'Failing Artist', genres: ['rock'] }),
+      makeArtist({ name: 'OK Artist', genres: ['pop'] }),
+    ]
+    const result = await enrichGenres(artists, lookup)
+    expect(result[0]?.genres).toEqual(['rock'])
+    expect(result[1]?.genres).toEqual(['pop', 'jazz'])
+  })
 })

--- a/tests/core/pipeline/store.test.ts
+++ b/tests/core/pipeline/store.test.ts
@@ -216,21 +216,4 @@ describe('store()', () => {
       streamingUrls: { spotify: 'https://spotify.com/foo' },
     })
   })
-
-  it('calls failBatch and rethrows when completeBatch throws', async () => {
-    const db = makeDb(1)
-    db.completeBatch.mockRejectedValueOnce(new Error('DB connection lost'))
-    db.failBatch = vi.fn().mockResolvedValue(undefined)
-
-    await expect(store([makeArtist('mbid-a')], db)).rejects.toThrow('DB connection lost')
-
-    expect(db.failBatch).toHaveBeenCalledWith(1)
-  })
-
-  it('does not call failBatch when it is not provided', async () => {
-    const db = makeDb(1)
-    db.completeBatch.mockRejectedValueOnce(new Error('DB connection lost'))
-
-    await expect(store([makeArtist('mbid-a')], db)).rejects.toThrow('DB connection lost')
-  })
 })

--- a/tests/core/pipeline/store.test.ts
+++ b/tests/core/pipeline/store.test.ts
@@ -216,4 +216,21 @@ describe('store()', () => {
       streamingUrls: { spotify: 'https://spotify.com/foo' },
     })
   })
+
+  it('calls failBatch and rethrows when completeBatch throws', async () => {
+    const db = makeDb(1)
+    db.completeBatch.mockRejectedValueOnce(new Error('DB connection lost'))
+    db.failBatch = vi.fn().mockResolvedValue(undefined)
+
+    await expect(store([makeArtist('mbid-a')], db)).rejects.toThrow('DB connection lost')
+
+    expect(db.failBatch).toHaveBeenCalledWith(1)
+  })
+
+  it('does not call failBatch when it is not provided', async () => {
+    const db = makeDb(1)
+    db.completeBatch.mockRejectedValueOnce(new Error('DB connection lost'))
+
+    await expect(store([makeArtist('mbid-a')], db)).rejects.toThrow('DB connection lost')
+  })
 })

--- a/tests/core/slskd/orchestrator.test.ts
+++ b/tests/core/slskd/orchestrator.test.ts
@@ -455,4 +455,46 @@ describe('createSlskdOrchestrator', () => {
     expect(updateJobState).toHaveBeenCalledWith(4, 'completed', expect.any(Object))
     expect(updateJobState).not.toHaveBeenCalledWith(4, 'failed', expect.any(Object))
   })
+
+  it('isolates a throwing job so the rest of the queue still processes', async () => {
+    const updateJobState = vi.fn(async () => makeJob())
+    // Same targetId -> both jobs share one cached slskd client, so the single
+    // createSearch mock rejects for job 1 and resolves for job 2.
+    const slskdClient = {
+      createSearch: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('slskd unreachable'))
+        .mockResolvedValue({ id: 'search-2' }),
+      getSearchResults: vi.fn(async (): Promise<SlskdSearchResult[]> => []),
+      enqueueResult: vi.fn(async () => ({ id: 'queue-unused' })),
+      getDownloads: vi.fn(async () => []),
+    }
+
+    const orchestrator = createSlskdOrchestrator({
+      listPendingJobs: vi.fn(async () => [
+        makeJob({ id: 1, state: 'pending' }),
+        makeJob({ id: 2, state: 'pending' }),
+      ]),
+      processPendingJobs: vi.fn(async () => {}),
+      createSlskdClient: vi.fn(() => slskdClient),
+      updateJobState,
+    } as never)
+
+    // Must not reject: the first job's error is isolated, not propagated.
+    await expect(orchestrator.triggerSync()).resolves.toBeUndefined()
+
+    // Job 1 was marked failed with its error...
+    expect(updateJobState).toHaveBeenCalledWith(
+      1,
+      'failed',
+      expect.objectContaining({ lastError: expect.stringContaining('slskd unreachable') }),
+    )
+    // ...and job 2 was still processed despite job 1 throwing.
+    expect(updateJobState).toHaveBeenCalledWith(
+      2,
+      'searching',
+      expect.objectContaining({ slskdSearchId: 'search-2' }),
+    )
+    expect(slskdClient.createSearch).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
## Summary
Recovered from the parked `fix/worker-error-isolation` branch, rebased onto current main (rc.11). Wraps per-item work in background workers so a single failing item is recorded and skipped instead of aborting the whole run:

- `src/core/slskd/orchestrator.ts` -- per-job try/catch in the processing loop; a failing job is marked `failed` (with `lastError`) and the loop continues.
- `src/core/jobs/recorder.ts` -- hardened state transitions.
- `src/core/pipeline/enrich.ts` -- isolates per-artist enrichment failures.
- `src/core/clients/tag-radio-resolver.ts` -- tolerates a failed tag lookup.
- Tests for each: orchestrator job-isolation, recorder, enrich, tag-radio-resolver.

## Conflict resolution
The `store.ts` portion of this fix (per-item isolation + `failBatch`-on-error wrapper) already landed on main independently, with `failBatch` as a **required** `StoreDb` method. Took main's `store.ts` and `store.test.ts` as canonical and dropped the branch's now-redundant, optional-`failBatch` variant. The remaining 8 files are the genuinely novel worker isolation.

## Test plan
- typecheck: clean
- lint: clean (exit 0)
- new worker tests: 54 passed
- full suite with DATABASE_URL: 2275 passed; 1 pre-existing failure in `sync-flow.test.ts` (present on main, unrelated -- separate library-sync path, not slskd)