### PR TITLE
chore(release): sync deploy digests to v1.0.0-rc.12

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.12"
-  digest: "sha256:bc149e850a447d0aac7983d9e93ff7ef333c10e1747026d950b0579fdc8e7b46"
+  digest: "sha256:a5f55f6620250681dad5c9d39568a9ffa7cd479fdd378f9fbfaf8bfbcfcc60d3"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:bc149e850a447d0aac7983d9e93ff7ef333c10e1747026d950b0579fdc8e7b46
+          image: ghcr.io/iuliandita/digarr@sha256:a5f55f6620250681dad5c9d39568a9ffa7cd479fdd378f9fbfaf8bfbcfcc60d3
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:bc149e850a447d0aac7983d9e93ff7ef333c10e1747026d950b0579fdc8e7b46"
+          image: "ghcr.io/iuliandita/digarr@sha256:a5f55f6620250681dad5c9d39568a9ffa7cd479fdd378f9fbfaf8bfbcfcc60d3"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:bc149e850a447d0aac7983d9e93ff7ef333c10e1747026d950b0579fdc8e7b46 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:a5f55f6620250681dad5c9d39568a9ffa7cd479fdd378f9fbfaf8bfbcfcc60d3 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.9</Repository>
    <Tag>1.0.0-rc.9</Tag>
    <TagDescription>v1.0.0-rc.9 prerelease</TagDescription>


### PR DESCRIPTION
Repoint the four deploy manifests (helm values, k8s deployment, k8s rendered, unraid) to the published v1.0.0-rc.12 image digest `sha256:a5f55f66`. Generated by `scripts/sync-deploy-digests.ts` + `k8s-sync.sh` (helm 3.16.4).