### PR TITLE
chore(release): sync deploy digests to v1.1.0

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.12"
-  digest: "sha256:859e9bb13e437c7d8471a34962207a903363de9b6d951cbc5cb4120ca375d805"
+  digest: "sha256:48ac0eaf1739a45992201dbad9c89dfa367a455a2afe8c048f23c005ff333148"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:859e9bb13e437c7d8471a34962207a903363de9b6d951cbc5cb4120ca375d805
+          image: ghcr.io/iuliandita/digarr@sha256:48ac0eaf1739a45992201dbad9c89dfa367a455a2afe8c048f23c005ff333148
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:859e9bb13e437c7d8471a34962207a903363de9b6d951cbc5cb4120ca375d805"
+          image: "ghcr.io/iuliandita/digarr@sha256:48ac0eaf1739a45992201dbad9c89dfa367a455a2afe8c048f23c005ff333148"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:859e9bb13e437c7d8471a34962207a903363de9b6d951cbc5cb4120ca375d805 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:48ac0eaf1739a45992201dbad9c89dfa367a455a2afe8c048f23c005ff333148 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.9</Repository>
    <Tag>1.0.0-rc.9</Tag>
    <TagDescription>v1.0.0-rc.9 prerelease</TagDescription>


### PR DESCRIPTION
Repoints the v1.1.0 image digest (`sha256:48ac0ea...`) across deploy/helm/digarr/values.yaml, deploy/k8s/deployment.yaml, deploy/k8s/rendered.yaml, and deploy/unraid/digarr.xml after the release image published. Reproducibility follow-up to #241.