### PR TITLE
chore(release): sync deploy digests to v1.2.0

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.12"
-  digest: "sha256:48ac0eaf1739a45992201dbad9c89dfa367a455a2afe8c048f23c005ff333148"
+  digest: "sha256:9bacbf36cea896a79bea381d5f5e0f9c347abd3da9add7974bc9c557270942df"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:48ac0eaf1739a45992201dbad9c89dfa367a455a2afe8c048f23c005ff333148
+          image: ghcr.io/iuliandita/digarr@sha256:9bacbf36cea896a79bea381d5f5e0f9c347abd3da9add7974bc9c557270942df
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:48ac0eaf1739a45992201dbad9c89dfa367a455a2afe8c048f23c005ff333148"
+          image: "ghcr.io/iuliandita/digarr@sha256:9bacbf36cea896a79bea381d5f5e0f9c347abd3da9add7974bc9c557270942df"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:48ac0eaf1739a45992201dbad9c89dfa367a455a2afe8c048f23c005ff333148 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:9bacbf36cea896a79bea381d5f5e0f9c347abd3da9add7974bc9c557270942df -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.9</Repository>
    <Tag>1.0.0-rc.9</Tag>
    <TagDescription>v1.0.0-rc.9 prerelease</TagDescription>


### PR DESCRIPTION
Repoints the four deploy surfaces (Helm `values.yaml`, `deployment.yaml`, `rendered.yaml`, unraid `digarr.xml`) to the published v1.2.0 image digest `sha256:9bacbf36cea896a79bea381d5f5e0f9c347abd3da9add7974bc9c557270942df`. rendered.yaml regenerated with helm v3.16.4 (matches CI). Reproducibility follow-up, not a gate.