### PR TITLE
refactor(discovery): share parseSeeds via runtime

### DIFF
--- a/src/core/discovery-modes/modes/artist-relationships.ts
+++ b/src/core/discovery-modes/modes/artist-relationships.ts
@@ -1,8 +1,6 @@
 import { createMusicBrainzClient } from '@/core/clients/musicbrainz'
 import type { DiscoveryModeDefinition, RawDiscoveryCandidate } from '../types'
-import { getNormalizedLimit, normalizeDiscoveryName } from './runtime'
-
-type SeedArtist = { name: string; mbid?: string }
+import { getNormalizedLimit, normalizeDiscoveryName, parseSeeds } from './runtime'
 
 // Artist-artist relation types MusicBrainz exposes that are useful for
 // discovery. Used to populate the picker and bound which edges we follow.
@@ -15,25 +13,6 @@ const SUPPORTED_RELATIONSHIP_TYPES = [
   'married',
   'involved with',
 ] as const
-
-function parseSeeds(raw: unknown): SeedArtist[] {
-  const items = Array.isArray(raw)
-    ? raw
-    : typeof raw === 'string'
-      ? raw.split(',').map((s) => s.trim())
-      : []
-  const seeds: SeedArtist[] = []
-  for (const item of items) {
-    if (typeof item === 'string') {
-      if (item.trim()) seeds.push({ name: item.trim() })
-    } else if (item && typeof item === 'object' && 'name' in item) {
-      const rec = item as Record<string, unknown>
-      const name = String(rec.name ?? '').trim()
-      if (name) seeds.push({ name, mbid: typeof rec.mbid === 'string' ? rec.mbid : undefined })
-    }
-  }
-  return seeds
-}
 
 function parseRelationshipTypes(raw: unknown): Set<string> {
   const items = Array.isArray(raw)

--- a/src/core/discovery-modes/modes/labels.ts
+++ b/src/core/discovery-modes/modes/labels.ts
@@ -1,32 +1,16 @@
 import { createDiscogsClient } from '@/core/clients/discogs'
 import type { DiscoveryModeDefinition, RawDiscoveryCandidate } from '../types'
-import { getDiscoveryModeConnections, getNormalizedLimit, normalizeDiscoveryName } from './runtime'
-
-type SeedArtist = { name: string; mbid?: string }
+import {
+  getDiscoveryModeConnections,
+  getNormalizedLimit,
+  normalizeDiscoveryName,
+  parseSeeds,
+} from './runtime'
 
 // Bounded traversal so a label fan-out stays cheap on the Discogs 60/min limit:
 // at most 3 seeds, one label per seed => ~2 search calls per seed (~6 total).
 const MAX_SEEDS = 3
 const LABELS_PER_SEED = 1
-
-function parseSeeds(raw: unknown): SeedArtist[] {
-  const items = Array.isArray(raw)
-    ? raw
-    : typeof raw === 'string'
-      ? raw.split(',').map((s) => s.trim())
-      : []
-  const seeds: SeedArtist[] = []
-  for (const item of items) {
-    if (typeof item === 'string') {
-      if (item.trim()) seeds.push({ name: item.trim() })
-    } else if (item && typeof item === 'object' && 'name' in item) {
-      const rec = item as Record<string, unknown>
-      const name = String(rec.name ?? '').trim()
-      if (name) seeds.push({ name, mbid: typeof rec.mbid === 'string' ? rec.mbid : undefined })
-    }
-  }
-  return seeds
-}
 
 export function createLabelsMode(): DiscoveryModeDefinition {
   return {

--- a/src/core/discovery-modes/modes/runtime.ts
+++ b/src/core/discovery-modes/modes/runtime.ts
@@ -40,3 +40,24 @@ export function getProviderPath(request: DiscoveryModeRequest): string[] {
 export function normalizeDiscoveryName(name: string): string {
   return name.trim().toLowerCase()
 }
+
+export type SeedArtist = { name: string; mbid?: string }
+
+export function parseSeeds(raw: unknown): SeedArtist[] {
+  const items = Array.isArray(raw)
+    ? raw
+    : typeof raw === 'string'
+      ? raw.split(',').map((s) => s.trim())
+      : []
+  const seeds: SeedArtist[] = []
+  for (const item of items) {
+    if (typeof item === 'string') {
+      if (item.trim()) seeds.push({ name: item.trim() })
+    } else if (item && typeof item === 'object' && 'name' in item) {
+      const rec = item as Record<string, unknown>
+      const name = String(rec.name ?? '').trim()
+      if (name) seeds.push({ name, mbid: typeof rec.mbid === 'string' ? rec.mbid : undefined })
+    }
+  }
+  return seeds
+}


### PR DESCRIPTION
## What

`parseSeeds` and its `SeedArtist` type were duplicated byte-for-byte across two discovery-mode files (`labels.ts`, `artist-relationships.ts`). If one copy gained a new accepted seed shape or a validation fix, the other would silently drift.

Moves both into the existing shared module `src/core/discovery-modes/modes/runtime.ts` (the established home for cross-mode utilities, already imported by both files) and replaces the local copies with an import.

## Notes

- Moved body is byte-identical to the originals — no behavior change.
- Only `parseSeeds` is imported (not `type SeedArtist`); neither mode references the type name locally, so importing it would be unused and fail lint. The return type carries it implicitly.

## Verification

- `bun run typecheck` — pass
- `bun run lint` — clean (no new warnings)
- `bun run test tests/core/discovery-modes` — 51/51 pass
- `grep -rn "function parseSeeds" src/core/discovery-modes/modes/` — exactly one match (runtime.ts)