### PR TITLE
test(targets): cover addAlbum album-not-found path

### DIFF
--- a/tests/core/targets/lidarr-add-album.test.ts
+++ b/tests/core/targets/lidarr-add-album.test.ts
@@ -104,4 +104,29 @@ describe('createLidarrTarget().addAlbum', () => {
     expect(client.updateAlbum).not.toHaveBeenCalled()
     expect(client.triggerCommand).not.toHaveBeenCalled()
   })
+
+  it('returns success:false with "album not found in Lidarr" when the release group is absent after add', async () => {
+    const client = mockLidarrClient()
+    client.getArtists.mockResolvedValue([])
+    client.addArtist.mockResolvedValue({ id: 42 })
+    // Lidarr has the artist but not this release group yet
+    client.getAlbums.mockResolvedValue([
+      { id: 7, foreignAlbumId: 'some-other-rg', monitored: false, title: 'Other' },
+    ])
+
+    const target = createLidarrTarget(1, {
+      url: 'http://lidarr:8686',
+      apiKey: 'abc',
+    })
+
+    const result = await target.addAlbum?.(
+      { artistMbid: 'a1', artistName: 'Artist', releaseGroupMbid: 'rg-missing' },
+      { qualityProfileId: 1, metadataProfileId: 1, rootFolderId: 1 },
+    )
+
+    expect(result?.success).toBe(false)
+    expect(result?.error).toBe('album not found in Lidarr')
+    expect(client.updateAlbum).not.toHaveBeenCalled()
+    expect(client.triggerCommand).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## What

Adds a regression test for the Lidarr `addAlbum` "album not found in Lidarr" failure branch (`src/core/targets/lidarr.ts`): after the artist is ensured present, the code re-reads the artist's albums and returns `{ success: false, error: 'album not found in Lidarr' }` when no album matches the requested release group.

## Why it's not a duplicate

An existing test already touched this branch loosely — via the *existing-artist* path, an *empty* album list, asserting only that `error` is truthy. The new case is distinct and stricter:

- exercises the **add-artist** path (artist absent, then added)
- album list is **non-empty but non-matching** (drives `.find()` to undefined, not just an empty array)
- asserts the **exact** error string `'album not found in Lidarr'` (the contract the UI depends on), not just truthiness
- asserts the **no-side-effects** property — `updateAlbum` and `triggerCommand` are not invoked on the failure path

Test-only; no source changed.

## Verification

- `bun run test tests/core/targets/lidarr-add-album.test.ts` — 5/5 pass
- `bun run typecheck` — pass
- `bun run lint` — clean (no new warnings)