### PR TITLE
perf(library): request album-only release groups in coverage

### DIFF
--- a/src/core/clients/musicbrainz.ts
+++ b/src/core/clients/musicbrainz.ts
@@ -201,10 +201,13 @@ export function createMusicBrainzClient() {
     return request<MBSearchResult>(`/artist/?${params}`)
   }
 
-  async function getReleaseGroups(artistMbid: string): Promise<MBReleaseGroup[]> {
+  async function getReleaseGroups(
+    artistMbid: string,
+    types: readonly string[] = ['album', 'ep', 'single'],
+  ): Promise<MBReleaseGroup[]> {
     const params = new URLSearchParams({
       artist: artistMbid,
-      type: 'album|ep|single',
+      type: types.join('|'),
       fmt: 'json',
       limit: '100',
     })

--- a/src/core/library/album-coverage.ts
+++ b/src/core/library/album-coverage.ts
@@ -35,7 +35,7 @@ export function createAlbumCoverageService(deps: {
     async getCoverageForArtist(userId: number, artistMbid: string): Promise<AlbumCoverage> {
       const [ownedAlbums, releaseGroups] = await Promise.all([
         deps.store.listOwnedAlbumsForArtist(userId, artistMbid),
-        deps.mbClient.getReleaseGroups(artistMbid),
+        deps.mbClient.getReleaseGroups(artistMbid, ['album']),
       ])
 
       const ownedByMbid = new Map(ownedAlbums.map((album) => [album.albumMbid, album]))

--- a/tests/core/clients/musicbrainz.test.ts
+++ b/tests/core/clients/musicbrainz.test.ts
@@ -449,6 +449,26 @@ describe('createMusicBrainzClient', () => {
       expect(url).toContain('type=')
     })
 
+    it('defaults the type filter to album|ep|single', async () => {
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ 'release-groups': [] }))
+      const client = createMusicBrainzClient()
+      await client.getReleaseGroups(MOCK_ARTIST_MBID)
+
+      const [url] = mockFetch.mock.calls[0] as [string]
+      expect(decodeURIComponent(new URL(url).searchParams.get('type') ?? '')).toBe(
+        'album|ep|single',
+      )
+    })
+
+    it('narrows the type filter to album when requested', async () => {
+      mockFetch.mockResolvedValueOnce(makeJsonResponse({ 'release-groups': [] }))
+      const client = createMusicBrainzClient()
+      await client.getReleaseGroups(MOCK_ARTIST_MBID, ['album'])
+
+      const [url] = mockFetch.mock.calls[0] as [string]
+      expect(new URL(url).searchParams.get('type')).toBe('album')
+    })
+
     it('returns correctly shaped MBReleaseGroup array', async () => {
       mockFetch.mockResolvedValueOnce(makeJsonResponse(MOCK_RG_RESPONSE))
       const client = createMusicBrainzClient()


### PR DESCRIPTION
## What

`album-coverage` only wants studio albums but called `getReleaseGroups(artistMbid)`, which requests `type=album|ep|single` and then discards the EP/single rows in JS. This adds an optional `types` parameter to `getReleaseGroups` (default `['album','ep','single']` — byte-identical to the old hardcoded string) and has coverage pass `['album']`, trimming EP/single rows out of that one request.

## Honest scope

This is a marginal payload trim, not a fix for an N+1 — the request was already a single capped call (`limit: 100`). `getReleaseGroups` is shared by ~8 callers, several of which legitimately need EP/single, so the narrowing is strictly opt-in: every other caller keeps the default and is unaffected.

## Verification

- `bun run typecheck` — pass
- `bun run lint` — clean
- `bun run test tests/core/clients tests/core/library` — 410 pass
- Default `['album','ep','single'].join('|') === 'album|ep|single'` (verified); narrowed call sends `type=album`
- All 7 other `getReleaseGroups(` callers remain single-arg