### PR TITLE
perf(resolve): race the post-audiodb image fallback tail

### DIFF
--- a/src/core/pipeline/resolve.ts
+++ b/src/core/pipeline/resolve.ts
@@ -397,37 +397,79 @@ export async function fetchArtistImage(
     }
   }
 
-  // Fallback chain: Lidarr -> fanart.tv -> musicinfo.pro
+  // Fallback chain: Lidarr -> fanart.tv -> musicinfo.pro.
+  // AudioDB stays the sequential primary above; the remaining fallbacks only
+  // fire when it misses, so we run them concurrently and pick the first hit by
+  // priority order (Lidarr > fanart > musicinfo) to match the old short-circuit
+  // winner while shaving the tail latency of the miss case.
+  type Hit = { url?: string; logoUrl?: string }
+  const tasks: Array<{ priority: number; run: () => Promise<Hit | null> }> = []
+
   if (lidarr) {
-    try {
-      const results = await lidarr.lookupArtist(`lidarr:${mbid}`)
-      const artist = results[0] as { images?: ImageEntry[] } | undefined
-      if (artist?.images?.length) {
-        const extracted = extractImages(artist.images)
-        if (extracted.url) return { ...extracted, failed: false }
-      }
-    } catch (err) {
-      console.warn(`[resolve] Lidarr image lookup failed for ${mbid}:`, err)
-    }
+    tasks.push({
+      priority: 0,
+      run: async () => {
+        try {
+          const results = await lidarr.lookupArtist(`lidarr:${mbid}`)
+          const artist = results[0] as { images?: ImageEntry[] } | undefined
+          if (artist?.images?.length) {
+            const extracted = extractImages(artist.images)
+            if (extracted.url) return extracted
+          }
+          return null
+        } catch (err) {
+          console.warn(`[resolve] Lidarr image lookup failed for ${mbid}:`, err)
+          return null
+        }
+      },
+    })
   }
 
   if (fanart) {
-    try {
-      const result = await fanart.getArtistImages(mbid)
-      if (result.url) return { ...result, failed: false }
-    } catch (err) {
-      console.warn(`[resolve] fanart.tv image lookup failed for ${mbid}:`, err)
-    }
+    tasks.push({
+      priority: 1,
+      run: async () => {
+        try {
+          const result = await fanart.getArtistImages(mbid)
+          if (result.url) return result
+          return null
+        } catch (err) {
+          console.warn(`[resolve] fanart.tv image lookup failed for ${mbid}:`, err)
+          return null
+        }
+      },
+    })
   }
 
   if (musicinfo) {
-    try {
-      const result = await musicinfo.lookupArtistImages(mbid)
-      if (result.url) return { ...result, failed: false }
-    } catch (err) {
-      console.warn(`[resolve] musicinfo image lookup failed for ${mbid}:`, err)
-    }
+    tasks.push({
+      priority: 2,
+      run: async () => {
+        try {
+          const result = await musicinfo.lookupArtistImages(mbid)
+          if (result.url) return result
+          return null
+        } catch (err) {
+          console.warn(`[resolve] musicinfo image lookup failed for ${mbid}:`, err)
+          return null
+        }
+      },
+    })
   }
+
+  const settled = await Promise.allSettled(tasks.map((task) => task.run()))
+  const hit = tasks
+    .map((task, i) => {
+      const result = settled[i]
+      return {
+        priority: task.priority,
+        value: result?.status === 'fulfilled' ? result.value : null,
+      }
+    })
+    .filter((candidate) => candidate.value?.url)
+    .sort((a, b) => a.priority - b.priority)[0]
+
+  if (hit?.value) return { ...hit.value, failed: false }
 
   return { failed: Boolean(lidarr ?? fanart ?? musicinfo) }
 }

--- a/tests/core/pipeline/resolve.test.ts
+++ b/tests/core/pipeline/resolve.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest'
 import type { MBArtist } from '@/core/clients/musicbrainz'
-import { resolve } from '@/core/pipeline/resolve'
+import { fetchArtistImage, resolve } from '@/core/pipeline/resolve'
 import type { DiscoveredArtist } from '@/core/types'
 
 function makeMbArtist(overrides: Partial<MBArtist> = {}): MBArtist {
@@ -710,5 +710,133 @@ describe('resolve()', () => {
       expect(result[0]?.beginYear).toBeUndefined()
       expect(result[0]?.endYear).toBeUndefined()
     })
+  })
+})
+
+describe('fetchArtistImage', () => {
+  const MBID = 'mbid-image'
+
+  function makeAudiodb(images: { url?: string; logoUrl?: string } = {}) {
+    return {
+      getArtistImages: vi.fn().mockResolvedValue(images),
+      searchArtistByName: vi.fn().mockResolvedValue({}),
+    }
+  }
+
+  function makeLidarr(images: Array<{ coverType: string; remoteUrl?: string }>) {
+    return {
+      lookupArtist: vi.fn().mockResolvedValue([{ images }]),
+    }
+  }
+
+  function makeFanart(images: { url?: string; logoUrl?: string }) {
+    return { getArtistImages: vi.fn().mockResolvedValue(images) }
+  }
+
+  function makeMusicinfo(images: { url?: string; logoUrl?: string }) {
+    return { lookupArtistImages: vi.fn().mockResolvedValue(images) }
+  }
+
+  it('short-circuits on AudioDB hit and never invokes fallbacks', async () => {
+    const audiodb = makeAudiodb({ url: 'https://audiodb/img.jpg' })
+    const lidarr = makeLidarr([{ coverType: 'poster', remoteUrl: 'https://lidarr/img.jpg' }])
+    const fanart = makeFanart({ url: 'https://fanart/img.jpg' })
+    const musicinfo = makeMusicinfo({ url: 'https://musicinfo/img.jpg' })
+
+    const result = await fetchArtistImage(
+      MBID,
+      'Test Artist',
+      audiodb as never,
+      lidarr as never,
+      fanart as never,
+      musicinfo as never,
+    )
+
+    expect(result).toEqual({ url: 'https://audiodb/img.jpg', failed: false })
+    expect(audiodb.getArtistImages).toHaveBeenCalledTimes(1)
+    expect(lidarr.lookupArtist).not.toHaveBeenCalled()
+    expect(fanart.getArtistImages).not.toHaveBeenCalled()
+    expect(musicinfo.lookupArtistImages).not.toHaveBeenCalled()
+  })
+
+  it('returns fanart image when AudioDB misses and only fanart is configured', async () => {
+    const audiodb = makeAudiodb({})
+    const fanart = makeFanart({ url: 'https://fanart/img.jpg', logoUrl: 'https://fanart/logo.png' })
+
+    const result = await fetchArtistImage(
+      MBID,
+      'Test Artist',
+      audiodb as never,
+      null,
+      fanart as never,
+      null,
+    )
+
+    expect(result).toEqual({
+      url: 'https://fanart/img.jpg',
+      logoUrl: 'https://fanart/logo.png',
+      failed: false,
+    })
+    expect(fanart.getArtistImages).toHaveBeenCalledWith(MBID)
+  })
+
+  it('prefers Lidarr over fanart when both return images (priority preserved despite concurrency)', async () => {
+    const audiodb = makeAudiodb({})
+    const lidarr = makeLidarr([{ coverType: 'poster', remoteUrl: 'https://lidarr/img.jpg' }])
+    const fanart = makeFanart({ url: 'https://fanart/img.jpg' })
+
+    const result = await fetchArtistImage(
+      MBID,
+      'Test Artist',
+      audiodb as never,
+      lidarr as never,
+      fanart as never,
+      null,
+    )
+
+    expect(result.url).toBe('https://lidarr/img.jpg')
+    expect(result.failed).toBe(false)
+  })
+
+  it('falls through to fanart without an unhandled rejection when Lidarr throws', async () => {
+    const audiodb = makeAudiodb({})
+    const lidarr = { lookupArtist: vi.fn().mockRejectedValue(new Error('lidarr down')) }
+    const fanart = makeFanart({ url: 'https://fanart/img.jpg' })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await fetchArtistImage(
+      MBID,
+      'Test Artist',
+      audiodb as never,
+      lidarr as never,
+      fanart as never,
+      null,
+    )
+
+    expect(result.url).toBe('https://fanart/img.jpg')
+    expect(result.failed).toBe(false)
+    expect(warn).toHaveBeenCalledWith(
+      `[resolve] Lidarr image lookup failed for ${MBID}:`,
+      expect.any(Error),
+    )
+    warn.mockRestore()
+  })
+
+  it('reports failed when AudioDB and all configured fallbacks miss', async () => {
+    const audiodb = makeAudiodb({})
+    const lidarr = makeLidarr([])
+    const fanart = makeFanart({})
+    const musicinfo = makeMusicinfo({})
+
+    const result = await fetchArtistImage(
+      MBID,
+      'Test Artist',
+      audiodb as never,
+      lidarr as never,
+      fanart as never,
+      musicinfo as never,
+    )
+
+    expect(result).toEqual({ failed: true })
   })
 })


### PR DESCRIPTION
## What

`fetchArtistImage` keeps AudioDB as the sequential, rate-limited primary (unchanged). When AudioDB misses, the remaining fallbacks (Lidarr, fanart.tv, musicinfo.pro) now run concurrently via `Promise.allSettled` instead of one-after-another, and the first hit **by priority** (Lidarr > fanart > musicinfo) is selected — matching the old short-circuit winner while shaving tail latency on the miss case.

## Scope honesty

This is NOT "race all four sources" — that would fire 3 usually-unnecessary requests against rate-limited APIs on every call. AudioDB stays first and short-circuits. The extra-request cost is bounded to the AudioDB-miss case only. Behaviour preserved: signature, return shape `{ url?, logoUrl?, failed }`, `RateLimitedError` name-search skip, and the exact `console.warn` strings are all unchanged.

## Verification

- `bun run typecheck` — pass
- `bun run lint` — clean
- `bun run test tests/core/pipeline/resolve.test.ts` — 33 pass (5 new)
- Priority-preservation test: Lidarr beats fanart when both return images, despite concurrency
- Short-circuit test: no fallback invoked on AudioDB hit
- No-unhandled-rejection test: Lidarr throws → falls to fanart, warn fired