### PR TITLE
chore(release): sync deploy digests to v1.4.0

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.12"
-  digest: "sha256:43d4b49e2896246b83569e3befdd7f4b07f75abb6fa9f53fef3475de87ba2d91"
+  digest: "sha256:33055dca7ffee3b8cfb06e79c2831f6feaf96945594b5e5f9d0f024e1e572536"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:43d4b49e2896246b83569e3befdd7f4b07f75abb6fa9f53fef3475de87ba2d91
+          image: ghcr.io/iuliandita/digarr@sha256:33055dca7ffee3b8cfb06e79c2831f6feaf96945594b5e5f9d0f024e1e572536
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:43d4b49e2896246b83569e3befdd7f4b07f75abb6fa9f53fef3475de87ba2d91"
+          image: "ghcr.io/iuliandita/digarr@sha256:33055dca7ffee3b8cfb06e79c2831f6feaf96945594b5e5f9d0f024e1e572536"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:43d4b49e2896246b83569e3befdd7f4b07f75abb6fa9f53fef3475de87ba2d91 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:33055dca7ffee3b8cfb06e79c2831f6feaf96945594b5e5f9d0f024e1e572536 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.9</Repository>
    <Tag>1.0.0-rc.9</Tag>
    <TagDescription>v1.0.0-rc.9 prerelease</TagDescription>


### PR DESCRIPTION
Repoints the deploy manifests to the published v1.4.0 image digest `sha256:33055dca7ffee3b8cfb06e79c2831f6feaf96945594b5e5f9d0f024e1e572536` (via `scripts/sync-deploy-digests.ts v1.4.0` + `scripts/k8s-sync.sh` for the rendered snapshot). Reproducibility follow-up to the v1.4.0 release; all four deploy files now agree.