### PR TITLE
feat(slskd): queue album-kind approvals to slskd targets

### DIFF
--- a/src/core/slskd/runner.ts
+++ b/src/core/slskd/runner.ts
@@ -17,6 +17,19 @@ export type SlskdRunnerQueueInput = {
   }
 }
 
+export type SlskdRunnerQueueAlbumInput = {
+  sourceType: 'standalone_approval' | 'combined_approval'
+  userId: number
+  targetId: number
+  recommendationId?: number
+  lidarrArtistId?: number
+  artist: {
+    mbid: string
+    name: string
+  }
+  releaseGroupMbid: string
+}
+
 export type SlskdRunnerDeps = {
   resolveReleaseGroups: (artistMbid: string) => Promise<SlskdRunnerReleaseGroup[]>
   findActiveJob: (workKey: string) => Promise<{ id: number } | null>
@@ -85,7 +98,38 @@ export function createSlskdRunner(deps: SlskdRunnerDeps) {
     return { success: createdOrExisting > 0 }
   }
 
+  async function queueAlbum(input: SlskdRunnerQueueAlbumInput): Promise<{ success: boolean }> {
+    const releaseGroups = await deps.resolveReleaseGroups(input.artist.mbid)
+    const match = releaseGroups.find((rg) => rg.releaseGroupMbid === input.releaseGroupMbid)
+
+    if (!match) {
+      return { success: false }
+    }
+
+    const workKey = buildSlskdWorkKey(input.targetId, input.artist.mbid, match.releaseGroupMbid)
+    const existing = await deps.findActiveJob(workKey)
+    if (existing) {
+      return { success: true }
+    }
+
+    await deps.createJob({
+      userId: input.userId,
+      targetId: input.targetId,
+      recommendationId: input.recommendationId,
+      sourceType: input.sourceType,
+      workKey,
+      artistMbid: input.artist.mbid,
+      artistName: input.artist.name,
+      releaseGroupMbid: match.releaseGroupMbid,
+      releaseTitle: match.releaseTitle,
+      lidarrArtistId: input.lidarrArtistId,
+    })
+
+    return { success: true }
+  }
+
   return {
     queueArtist,
+    queueAlbum,
   }
 }

--- a/src/core/targets/slskd.ts
+++ b/src/core/targets/slskd.ts
@@ -17,6 +17,18 @@ export type SlskdTargetConfig = {
       name: string
     }
   }) => Promise<{ success: boolean }>
+  queueAlbum: (input: {
+    sourceType: 'standalone_approval' | 'combined_approval'
+    userId: number
+    targetId: number
+    recommendationId?: number
+    lidarrArtistId?: number
+    artist: {
+      mbid: string
+      name: string
+    }
+    releaseGroupMbid: string
+  }) => Promise<{ success: boolean }>
 }
 
 export function createSlskdTarget(targetId: number, config: SlskdTargetConfig): DestinationTarget {
@@ -24,7 +36,7 @@ export function createSlskdTarget(targetId: number, config: SlskdTargetConfig): 
     id: `slskd-${targetId}`,
     name: config.name,
     type: 'slskd',
-    capabilities: ['addArtist'],
+    capabilities: ['addArtist', 'addAlbum'],
     linkedLidarrTargetId: config.linkedLidarrTargetId,
 
     async addArtist(
@@ -48,6 +60,52 @@ export function createSlskdTarget(targetId: number, config: SlskdTargetConfig): 
           recommendationId: options.recommendationId,
           lidarrArtistId: options.lidarrArtistId,
           artist,
+        })
+
+        return queued.success
+          ? {
+              success: true,
+              targetType: 'slskd',
+              targetId,
+            }
+          : {
+              success: false,
+              targetType: 'slskd',
+              targetId,
+              error: 'No releases were queued for slskd',
+            }
+      } catch (err: unknown) {
+        return {
+          success: false,
+          targetType: 'slskd',
+          targetId,
+          error: errMsg(err),
+        }
+      }
+    },
+
+    async addAlbum(
+      album: { artistMbid: string; artistName: string; releaseGroupMbid: string },
+      options?: TargetAddOptions,
+    ): Promise<TargetResult> {
+      if (!options?.userId) {
+        return {
+          success: false,
+          targetType: 'slskd',
+          targetId,
+          error: 'slskd target requires user context',
+        }
+      }
+
+      try {
+        const queued = await config.queueAlbum({
+          sourceType: options.lidarrArtistId ? 'combined_approval' : 'standalone_approval',
+          userId: options.userId,
+          targetId,
+          recommendationId: options.recommendationId,
+          lidarrArtistId: options.lidarrArtistId,
+          artist: { mbid: album.artistMbid, name: album.artistName },
+          releaseGroupMbid: album.releaseGroupMbid,
         })
 
         return queued.success

--- a/src/index.ts
+++ b/src/index.ts
@@ -696,6 +696,7 @@ async function getEnabledTargetsForResolvedUser(
               : undefined,
           testConnection: () => client.testConnection(),
           queueArtist: (input) => runner.queueArtist(input),
+          queueAlbum: (input) => runner.queueAlbum(input),
         }),
       )
     }

--- a/tests/core/slskd/runner.test.ts
+++ b/tests/core/slskd/runner.test.ts
@@ -63,3 +63,109 @@ describe('createSlskdRunner', () => {
     expect(createJob.mock.calls[0]?.[0].workKey).not.toBe(createJob.mock.calls[1]?.[0].workKey)
   })
 })
+
+describe('createSlskdRunner().queueAlbum', () => {
+  it('queues exactly the matched release group', async () => {
+    const createJob = vi.fn().mockResolvedValue({ id: 9, state: 'pending' })
+    const runner = createSlskdRunner({
+      createJob,
+      findActiveJob: vi.fn().mockResolvedValue(null),
+      resolveReleaseGroups: vi.fn().mockResolvedValue([
+        { releaseGroupMbid: 'rg-1', releaseTitle: 'Untrue' },
+        { releaseGroupMbid: 'rg-2', releaseTitle: 'Rival Dealer' },
+      ]),
+    })
+
+    const result = await runner.queueAlbum({
+      sourceType: 'standalone_approval',
+      userId: 1,
+      targetId: 4,
+      artist: { mbid: '11111111-1111-1111-1111-111111111111', name: 'Burial' },
+      releaseGroupMbid: 'rg-2',
+    })
+
+    expect(result.success).toBe(true)
+    expect(createJob).toHaveBeenCalledTimes(1)
+    expect(createJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        releaseGroupMbid: 'rg-2',
+        releaseTitle: 'Rival Dealer',
+      }),
+    )
+  })
+
+  it('returns failure and skips createJob when the release group is unknown', async () => {
+    const createJob = vi.fn().mockResolvedValue({ id: 9, state: 'pending' })
+    const runner = createSlskdRunner({
+      createJob,
+      findActiveJob: vi.fn().mockResolvedValue(null),
+      resolveReleaseGroups: vi
+        .fn()
+        .mockResolvedValue([{ releaseGroupMbid: 'rg-1', releaseTitle: 'Untrue' }]),
+    })
+
+    const result = await runner.queueAlbum({
+      sourceType: 'standalone_approval',
+      userId: 1,
+      targetId: 4,
+      artist: { mbid: '11111111-1111-1111-1111-111111111111', name: 'Burial' },
+      releaseGroupMbid: 'rg-missing',
+    })
+
+    expect(result.success).toBe(false)
+    expect(createJob).not.toHaveBeenCalled()
+  })
+
+  it('treats an already-active job as success without creating a duplicate', async () => {
+    const createJob = vi.fn().mockResolvedValue({ id: 9, state: 'pending' })
+    const runner = createSlskdRunner({
+      createJob,
+      findActiveJob: vi.fn().mockResolvedValue({ id: 7 }),
+      resolveReleaseGroups: vi
+        .fn()
+        .mockResolvedValue([{ releaseGroupMbid: 'rg-1', releaseTitle: 'Untrue' }]),
+    })
+
+    const result = await runner.queueAlbum({
+      sourceType: 'standalone_approval',
+      userId: 1,
+      targetId: 4,
+      artist: { mbid: '11111111-1111-1111-1111-111111111111', name: 'Burial' },
+      releaseGroupMbid: 'rg-1',
+    })
+
+    expect(result.success).toBe(true)
+    expect(createJob).not.toHaveBeenCalled()
+  })
+
+  it('maps the source type from the presence of a linked Lidarr artist', async () => {
+    const createJob = vi.fn().mockResolvedValue({ id: 9, state: 'pending' })
+    const makeRunner = () =>
+      createSlskdRunner({
+        createJob,
+        findActiveJob: vi.fn().mockResolvedValue(null),
+        resolveReleaseGroups: vi
+          .fn()
+          .mockResolvedValue([{ releaseGroupMbid: 'rg-1', releaseTitle: 'Untrue' }]),
+      })
+
+    await makeRunner().queueAlbum({
+      sourceType: 'combined_approval',
+      userId: 1,
+      targetId: 4,
+      lidarrArtistId: 99,
+      artist: { mbid: '11111111-1111-1111-1111-111111111111', name: 'Burial' },
+      releaseGroupMbid: 'rg-1',
+    })
+    await makeRunner().queueAlbum({
+      sourceType: 'standalone_approval',
+      userId: 1,
+      targetId: 4,
+      artist: { mbid: '11111111-1111-1111-1111-111111111111', name: 'Burial' },
+      releaseGroupMbid: 'rg-1',
+    })
+
+    expect(createJob.mock.calls[0]?.[0].sourceType).toBe('combined_approval')
+    expect(createJob.mock.calls[1]?.[0].sourceType).toBe('standalone_approval')
+  })
+})

--- a/tests/core/targets/slskd.test.ts
+++ b/tests/core/targets/slskd.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest'
+import { createSlskdTarget, type SlskdTargetConfig } from '@/core/targets/slskd'
+
+function makeConfig(overrides?: { queueAlbum?: SlskdTargetConfig['queueAlbum'] }) {
+  const queueAlbum: SlskdTargetConfig['queueAlbum'] =
+    overrides?.queueAlbum ?? vi.fn(async () => ({ success: true }))
+  const config: SlskdTargetConfig = {
+    name: 'slskd',
+    testConnection: vi.fn(async () => ({ success: true, message: 'ok' })),
+    queueArtist: vi.fn(async () => ({ success: true })),
+    queueAlbum,
+  }
+  return { queueAlbum, config }
+}
+
+describe('createSlskdTarget().addAlbum', () => {
+  it('returns failure without calling queueAlbum when userId is missing', async () => {
+    const { config, queueAlbum } = makeConfig()
+    const target = createSlskdTarget(4, config)
+
+    const result = await target.addAlbum?.({
+      artistMbid: 'a1',
+      artistName: 'Burial',
+      releaseGroupMbid: 'rg-1',
+    })
+
+    expect(result).toEqual({
+      success: false,
+      targetType: 'slskd',
+      targetId: 4,
+      error: 'slskd target requires user context',
+    })
+    expect(queueAlbum).not.toHaveBeenCalled()
+  })
+
+  it('queues the album as a standalone approval when there is no linked Lidarr artist', async () => {
+    const { config, queueAlbum } = makeConfig()
+    const target = createSlskdTarget(4, config)
+
+    const result = await target.addAlbum?.(
+      { artistMbid: 'a1', artistName: 'Burial', releaseGroupMbid: 'rg-1' },
+      { userId: 1 },
+    )
+
+    expect(result).toEqual({ success: true, targetType: 'slskd', targetId: 4 })
+    expect(queueAlbum).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceType: 'standalone_approval',
+        userId: 1,
+        targetId: 4,
+        artist: { mbid: 'a1', name: 'Burial' },
+        releaseGroupMbid: 'rg-1',
+      }),
+    )
+  })
+
+  it('queues a combined approval when a linked Lidarr artist id is present', async () => {
+    const { config, queueAlbum } = makeConfig()
+    const target = createSlskdTarget(4, config)
+
+    await target.addAlbum?.(
+      { artistMbid: 'a1', artistName: 'Burial', releaseGroupMbid: 'rg-1' },
+      { userId: 1, lidarrArtistId: 99 },
+    )
+
+    expect(queueAlbum).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceType: 'combined_approval', lidarrArtistId: 99 }),
+    )
+  })
+
+  it('returns the "no releases queued" failure when queueAlbum reports no success', async () => {
+    const queueAlbum: SlskdTargetConfig['queueAlbum'] = vi.fn(async () => ({ success: false }))
+    const { config } = makeConfig({ queueAlbum })
+    const target = createSlskdTarget(4, config)
+
+    const result = await target.addAlbum?.(
+      { artistMbid: 'a1', artistName: 'Burial', releaseGroupMbid: 'rg-1' },
+      { userId: 1 },
+    )
+
+    expect(result).toEqual({
+      success: false,
+      targetType: 'slskd',
+      targetId: 4,
+      error: 'No releases were queued for slskd',
+    })
+  })
+
+  it('catches a rejected queueAlbum and reports the error message', async () => {
+    const queueAlbum: SlskdTargetConfig['queueAlbum'] = vi.fn(async () => {
+      throw new Error('boom')
+    })
+    const { config } = makeConfig({ queueAlbum })
+    const target = createSlskdTarget(4, config)
+
+    const result = await target.addAlbum?.(
+      { artistMbid: 'a1', artistName: 'Burial', releaseGroupMbid: 'rg-1' },
+      { userId: 1 },
+    )
+
+    expect(result).toEqual({
+      success: false,
+      targetType: 'slskd',
+      targetId: 4,
+      error: 'boom',
+    })
+  })
+
+  it('advertises both addArtist and addAlbum capabilities', () => {
+    const { config } = makeConfig()
+    const target = createSlskdTarget(4, config)
+
+    expect(target.capabilities).toContain('addArtist')
+    expect(target.capabilities).toContain('addAlbum')
+  })
+})


### PR DESCRIPTION
## What

Adds `addAlbum` capability parity to the slskd download target. Album-kind recommendations can now be queued to slskd, not just Lidarr.

Closes the one real acquisition gap surfaced by the plan-014 spike (which ruled NO-GO on any *new* acquisition backend, but recorded slskd album parity as the single genuine gap).

## How

- `src/core/slskd/runner.ts`: new `queueAlbum` — resolves the artist's release groups, finds the matching `releaseGroupMbid` (validates membership + recovers `releaseTitle`), and inserts one pending `slskd_jobs` row via the existing work-key dedupe. `queueArtist` untouched.
- `src/core/targets/slskd.ts`: `capabilities` now `['addArtist', 'addAlbum']`; new `addAlbum` method mirroring `addArtist` (userId guard, try/catch, identical return shape).
- `src/index.ts`: one factory wire line `queueAlbum: (input) => runner.queueAlbum(input)`.

Backend-only. No route, frontend, or i18n change required: the album dispatcher already maps a successful slskd album action to `queued` (`recommendations.ts:271`), and the UI already offers slskd as an approve-to-target for all recommendation kinds. Reuses the existing `slskd_jobs` table, work-key dedupe, and orchestrator — no schema/migration change.

## Design note

`addAlbum` recovers the release-group title by fetching the artist's full discography from MusicBrainz once per approval (same cost as the existing `queueArtist` path, respects the ~1 req/s MB limit). If album-approval volume ever makes that wasteful, the deferred optimization is a targeted `getReleaseGroup(releaseGroupMbid)` lookup.

## Tests

- `tests/core/slskd/runner.test.ts`: +4 `queueAlbum` cases (matched group, unknown group, already-active dedupe, source-type mapping).
- `tests/core/targets/slskd.test.ts`: new file, 6 cases (userId guard, standalone/combined source type, success, no-releases failure, rejected-callback error, capability declaration).
- Full unit suite: 2339 pass. typecheck 0, lint clean, i18n + api-docs gates pass.