### PR TITLE
chore(release): sync deploy digests to v1.5.0

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.12"
-  digest: "sha256:33055dca7ffee3b8cfb06e79c2831f6feaf96945594b5e5f9d0f024e1e572536"
+  digest: "sha256:898a379fe9d400199db2a1d6c4b88dcd8bcca21011f93d71bc188c8a64164113"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:33055dca7ffee3b8cfb06e79c2831f6feaf96945594b5e5f9d0f024e1e572536
+          image: ghcr.io/iuliandita/digarr@sha256:898a379fe9d400199db2a1d6c4b88dcd8bcca21011f93d71bc188c8a64164113
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:33055dca7ffee3b8cfb06e79c2831f6feaf96945594b5e5f9d0f024e1e572536"
+          image: "ghcr.io/iuliandita/digarr@sha256:898a379fe9d400199db2a1d6c4b88dcd8bcca21011f93d71bc188c8a64164113"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:33055dca7ffee3b8cfb06e79c2831f6feaf96945594b5e5f9d0f024e1e572536 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:898a379fe9d400199db2a1d6c4b88dcd8bcca21011f93d71bc188c8a64164113 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.9</Repository>
    <Tag>1.0.0-rc.9</Tag>
    <TagDescription>v1.0.0-rc.9 prerelease</TagDescription>


### PR DESCRIPTION
Repoints the pinned image digest to the published v1.5.0 image `ghcr.io/iuliandita/digarr@sha256:898a379fe9d400199db2a1d6c4b88dcd8bcca21011f93d71bc188c8a64164113` across `deploy/helm/digarr/values.yaml`, `deploy/k8s/deployment.yaml`, `deploy/k8s/rendered.yaml`, and `deploy/unraid/digarr.xml`. Reproducibility follow-up to the v1.5.0 release (#257).