### PR TITLE
feat(discovery): derive genre signal from listening data for non-library installs

### DIFF
--- a/src/core/pipeline/analyze.ts
+++ b/src/core/pipeline/analyze.ts
@@ -42,10 +42,25 @@ export async function analyze(sources: DiscoverySource[]): Promise<TasteProfile>
 
   const topArtists = Array.from(byName.values()).sort((a, b) => b.playCount - a.playCount)
 
-  // Genre extraction from listening data is not yet implemented.
-  // Library genre overlap (the main genre scoring path) works via the
-  // orchestrator passing libraryGenres from Lidarr to score().
-  const topGenres: Array<{ name: string; weight: number }> = []
+  // Aggregate genres from listening sources that carry them (e.g. Spotify).
+  // Weight each genre by the sum of playCount of artists that carry it, then
+  // normalize so the highest-weight genre is 1.0. Artists with no genres are
+  // skipped. Genres are lowercased to match score()'s libraryGenreSet.
+  const genreWeights = new Map<string, number>()
+  for (const artist of topArtists) {
+    if (!artist.genres || artist.genres.length === 0) continue
+    for (const genre of artist.genres) {
+      const key = genre.toLowerCase()
+      genreWeights.set(key, (genreWeights.get(key) ?? 0) + artist.playCount)
+    }
+  }
+  const maxWeight = genreWeights.size > 0 ? Math.max(...genreWeights.values()) : 0
+  const topGenres: Array<{ name: string; weight: number }> =
+    maxWeight > 0
+      ? [...genreWeights.entries()]
+          .map(([name, weight]) => ({ name, weight: weight / maxWeight }))
+          .sort((a, b) => b.weight - a.weight)
+      : []
 
   // Determine recentTrend from listening activity
   const recentTrend = computeRecentTrend(activityData)

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -413,9 +413,11 @@ export class PipelineOrchestrator extends EventEmitter {
         message: t('pipeline.message.scoring', String(resolved.length)),
       })
       const popularityMap = (await db.getPopularityMap?.()) ?? new Map<string, number>()
+      const referenceGenres =
+        libraryGenres.length > 0 ? libraryGenres : tasteProfile.topGenres.map((g) => g.name)
       const scored = score(
         resolved,
-        libraryGenres,
+        referenceGenres,
         prefs.scoringWeights,
         feedbackHistory,
         popularityMap,

--- a/src/core/plugins/spotify.ts
+++ b/src/core/plugins/spotify.ts
@@ -15,6 +15,7 @@ export function createSpotifySource(accessToken: string): DiscoverySource {
         name: a.name,
         playCount: a.popularity,
         source: 'spotify',
+        genres: a.genres ?? [],
       }))
     },
 

--- a/src/core/plugins/types.ts
+++ b/src/core/plugins/types.ts
@@ -5,6 +5,7 @@ export type TopArtistEntry = {
   mbid?: string
   playCount: number
   source: string
+  genres?: string[]
 }
 
 export type SimilarArtistEntry = {

--- a/tests/core/pipeline/analyze.test.ts
+++ b/tests/core/pipeline/analyze.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest'
 import { analyze } from '@/core/pipeline/analyze'
-import type { DiscoverySource } from '@/core/plugins/types'
+import type { DiscoverySource, TopArtistEntry } from '@/core/plugins/types'
 
 const lbArtists = [
   { name: 'Radiohead', mbid: 'mbid-rh', playCount: 500, source: 'listenbrainz' },
@@ -146,5 +146,85 @@ describe('analyze()', () => {
   it('returns empty topArtists when no sources provided', async () => {
     const profile = await analyze([])
     expect(profile.topArtists).toEqual([])
+  })
+})
+
+describe('analyze() genre aggregation', () => {
+  function makeSpotifyLike(artists: TopArtistEntry[]): DiscoverySource {
+    return {
+      id: 'spotify',
+      name: 'Spotify',
+      capabilities: ['topArtists'],
+      getTopArtists: vi.fn().mockResolvedValue(artists),
+      getSimilarArtists: vi.fn().mockResolvedValue([]),
+      testConnection: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+    }
+  }
+
+  it('aggregates topGenres weighted by playCount, normalized, lowercased', async () => {
+    const source = makeSpotifyLike([
+      { name: 'Artist A', playCount: 100, source: 'spotify', genres: ['Rock', 'Electronic'] },
+      { name: 'Artist B', playCount: 200, source: 'spotify', genres: ['Electronic', 'Ambient'] },
+    ])
+    const profile = await analyze([source])
+
+    // Electronic: 100+200=300, Rock: 100, Ambient: 200 -> max=300
+    // normalized: Electronic=1.0, Ambient=0.666..., Rock=0.333...
+    const byName = Object.fromEntries(profile.topGenres.map((g) => [g.name, g.weight]))
+    expect(byName.electronic).toBeCloseTo(1.0)
+    expect(byName.ambient).toBeCloseTo(200 / 300)
+    expect(byName.rock).toBeCloseTo(100 / 300)
+    expect(byName.Electronic).toBeUndefined() // must be lowercased
+  })
+
+  it('sorts topGenres descending by weight', async () => {
+    const source = makeSpotifyLike([
+      { name: 'Artist A', playCount: 50, source: 'spotify', genres: ['jazz'] },
+      { name: 'Artist B', playCount: 200, source: 'spotify', genres: ['rock', 'jazz'] },
+    ])
+    const profile = await analyze([source])
+
+    for (let i = 1; i < profile.topGenres.length; i++) {
+      expect(profile.topGenres[i - 1]?.weight ?? 0).toBeGreaterThanOrEqual(
+        profile.topGenres[i]?.weight ?? 0,
+      )
+    }
+  })
+
+  it('returns empty topGenres when no artists carry genres', async () => {
+    const source = makeSpotifyLike([
+      { name: 'Artist A', playCount: 100, source: 'spotify' },
+      { name: 'Artist B', playCount: 200, source: 'spotify', genres: [] },
+    ])
+    const profile = await analyze([source])
+    expect(profile.topGenres).toEqual([])
+  })
+
+  it('returns empty topGenres when no sources provided', async () => {
+    const profile = await analyze([])
+    expect(profile.topGenres).toEqual([])
+  })
+
+  it('artists without genres contribute nothing to topGenres', async () => {
+    const source = makeSpotifyLike([
+      { name: 'Artist A', playCount: 999, source: 'spotify' }, // no genres field
+      { name: 'Artist B', playCount: 10, source: 'spotify', genres: ['indie'] },
+    ])
+    const profile = await analyze([source])
+
+    expect(profile.topGenres).toHaveLength(1)
+    expect(profile.topGenres[0]?.name).toBe('indie')
+    expect(profile.topGenres[0]?.weight).toBeCloseTo(1.0)
+  })
+
+  it('normalizes so the max-weight genre is exactly 1.0', async () => {
+    const source = makeSpotifyLike([
+      { name: 'X', playCount: 500, source: 'spotify', genres: ['metal'] },
+      { name: 'Y', playCount: 100, source: 'spotify', genres: ['metal', 'punk'] },
+    ])
+    const profile = await analyze([source])
+
+    const max = Math.max(...profile.topGenres.map((g) => g.weight))
+    expect(max).toBeCloseTo(1.0)
   })
 })

--- a/tests/core/pipeline/orchestrator.test.ts
+++ b/tests/core/pipeline/orchestrator.test.ts
@@ -803,4 +803,95 @@ describe('PipelineOrchestrator', () => {
     const call = mockResolve.mock.calls.at(-1)
     expect(call?.[8]).toBe(true)
   })
+
+  it('uses libraryGenres as the reference set when library artists are present (library-install parity)', async () => {
+    const db = {
+      ...makeDb(),
+      getLibraryArtistsForUser: vi.fn().mockResolvedValue([
+        {
+          mbid: 'mbid-1',
+          name: 'Library Artist',
+          source: 'lidarr',
+          sourceArtistId: '1',
+          genres: ['rock', 'metal'],
+          matchMethod: 'mbid',
+          matchConfidence: 1.0,
+        },
+      ]),
+    }
+    // Taste profile with genres from listening sources
+    mockAnalyze.mockResolvedValue({
+      ...tasteProfile,
+      topGenres: [
+        { name: 'electronic', weight: 1.0 },
+        { name: 'ambient', weight: 0.5 },
+      ],
+    })
+
+    await orchestrator.run({
+      db,
+      settings: defaultSettings,
+      providerRegistry,
+      librarySync: { syncForUser },
+      userId: 1,
+    })
+
+    const scoreCall = mockScore.mock.calls[0]
+    const referenceGenres = scoreCall?.[1] as string[]
+    // Library present: must use libraryGenres, NOT listening-derived genres
+    expect(referenceGenres.sort()).toEqual(['metal', 'rock'])
+    expect(referenceGenres).not.toContain('electronic')
+  })
+
+  it('uses listening-derived topGenres as the reference set when library is empty (discovery-only mode)', async () => {
+    const db = {
+      ...makeDb(),
+      getLibraryArtistsForUser: vi.fn().mockResolvedValue([]),
+    }
+    // Taste profile carries genres from Spotify
+    mockAnalyze.mockResolvedValue({
+      ...tasteProfile,
+      topGenres: [
+        { name: 'electronic', weight: 1.0 },
+        { name: 'ambient', weight: 0.5 },
+      ],
+    })
+
+    await orchestrator.run({
+      db,
+      settings: defaultSettings,
+      providerRegistry,
+      librarySync: { syncForUser },
+      userId: 1,
+    })
+
+    const scoreCall = mockScore.mock.calls[0]
+    const referenceGenres = scoreCall?.[1] as string[]
+    // No library: must fall back to listening-derived genre names
+    expect(referenceGenres.sort()).toEqual(['ambient', 'electronic'])
+  })
+
+  it('passes empty reference genres when both library and listening genres are absent', async () => {
+    const db = {
+      ...makeDb(),
+      getLibraryArtistsForUser: vi.fn().mockResolvedValue([]),
+    }
+    // Taste profile with no genres (no Spotify or sources without genre data)
+    mockAnalyze.mockResolvedValue({
+      ...tasteProfile,
+      topGenres: [],
+    })
+
+    await orchestrator.run({
+      db,
+      settings: defaultSettings,
+      providerRegistry,
+      librarySync: { syncForUser },
+      userId: 1,
+    })
+
+    const scoreCall = mockScore.mock.calls[0]
+    const referenceGenres = scoreCall?.[1] as string[]
+    expect(referenceGenres).toEqual([])
+  })
 })

--- a/tests/core/pipeline/score.test.ts
+++ b/tests/core/pipeline/score.test.ts
@@ -300,4 +300,30 @@ describe('score()', () => {
     const [scored] = score([artist], [], defaultWeights, new Map())
     expect(scored?.sourceScores.recency).toBeUndefined()
   })
+
+  it('produces identical scores when libraryGenres is passed vs listening-derived genres with same content', () => {
+    // Parity regression guard: score() is pure; what matters is the set content,
+    // not whether it came from libraryGenres or topGenres. Same genre set -> same scores.
+    const artist = makeArtist({
+      genres: ['rock', 'electronic'],
+      discoveries: [{ name: 'X', similarityScore: 0.7, source: 'listenbrainz' }],
+    })
+
+    const referenceGenres = ['rock', 'electronic']
+    const listeningDerivedGenres = ['electronic', 'rock'] // same content, different order
+
+    const fromLibrary = score([artist], referenceGenres, defaultWeights, new Map())
+    const fromListening = score([artist], listeningDerivedGenres, defaultWeights, new Map())
+
+    expect(fromLibrary[0]?.score).toBeCloseTo(fromListening[0]?.score ?? -1)
+    expect(fromLibrary[0]?.sourceScores.genreOverlap).toBeCloseTo(
+      fromListening[0]?.sourceScores.genreOverlap ?? -1,
+    )
+  })
+
+  it('genreOverlap is 0 with empty reference set and remains 0 regardless of artist genres', () => {
+    const artist = makeArtist({ genres: ['rock', 'metal'] })
+    const [result] = score([artist], [], defaultWeights, new Map())
+    expect(result?.sourceScores.genreOverlap).toBe(0)
+  })
 })

--- a/tests/core/plugins/spotify.test.ts
+++ b/tests/core/plugins/spotify.test.ts
@@ -67,11 +67,13 @@ describe('createSpotifySource()', () => {
       name: 'Radiohead',
       playCount: 82,
       source: 'spotify',
+      genres: ['art rock', 'alternative'],
     })
     expect(artists[1]).toEqual({
       name: 'Bjork',
       playCount: 71,
       source: 'spotify',
+      genres: ['art pop', 'electronic'],
     })
   })
 


### PR DESCRIPTION
## What

Plumbs listening-derived genre signal through to scoring so **discovery-only installs (no Lidarr library)** score on genre overlap instead of forfeiting the `genreOverlap` weight (default 0.2).

Today `score()` computes `genreOverlap` against `libraryGenres`, which is empty with no Lidarr library, zeroing that component for every candidate — for exactly the users the discovery-only differentiator targets. The genre signal is already pulled every run (Spotify returns genres on top artists) but was dropped at the plugin layer and never aggregated.

## How

- `TopArtistEntry` gains optional `genres?: string[]`.
- Spotify source passes through the genres the client already returns (no new HTTP calls).
- `analyze()` aggregates `topGenres`: weight each genre by the summed `playCount` of artists carrying it, normalize so the top genre is 1.0, lowercase, sort desc.
- Orchestrator picks the reference set: `libraryGenres.length > 0 ? libraryGenres : topGenres`. **Library installs are byte-identical** — `score()` is unmodified.

Plex/Jellyfin/Emby/Last.fm/ListenBrainz deferred: their top-artist fetches don't carry genres without an extra per-artist call.

## Tests

- 6 `analyze()` aggregation cases (weighting, normalization, lowercasing, sort, empty parity).
- 3 orchestrator reference-set cases incl. a **library-install parity regression guard** (asserts `score()` receives `libraryGenres`, not listening genres, when a library is present).
- 2 `score()` parity/edge cases.
- typecheck 0, full suite 2350 pass, lint clean (pre-existing warnings only).