### PR TITLE
chore(release): sync deploy digests to v1.7.0

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.12"
-  digest: "sha256:df6aa71c68901eb058a8152dc83bb7fbb38aae630b99afaf18c36af5b47c8eba"
+  digest: "sha256:392088e42ff10b71f7979bdb9260f98fad325d8d957b8f657f96dd2357268c0f"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:df6aa71c68901eb058a8152dc83bb7fbb38aae630b99afaf18c36af5b47c8eba
+          image: ghcr.io/iuliandita/digarr@sha256:392088e42ff10b71f7979bdb9260f98fad325d8d957b8f657f96dd2357268c0f
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:df6aa71c68901eb058a8152dc83bb7fbb38aae630b99afaf18c36af5b47c8eba"
+          image: "ghcr.io/iuliandita/digarr@sha256:392088e42ff10b71f7979bdb9260f98fad325d8d957b8f657f96dd2357268c0f"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:df6aa71c68901eb058a8152dc83bb7fbb38aae630b99afaf18c36af5b47c8eba -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:392088e42ff10b71f7979bdb9260f98fad325d8d957b8f657f96dd2357268c0f -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.9</Repository>
    <Tag>1.0.0-rc.9</Tag>
    <TagDescription>v1.0.0-rc.9 prerelease</TagDescription>


### PR DESCRIPTION
Repoint the pinned image digest to the published v1.7.0 image (`sha256:392088e4…`) across the four deploy files: `deploy/helm/digarr/values.yaml`, `deploy/k8s/deployment.yaml`, `deploy/k8s/rendered.yaml` (regenerated with helm v3.16.4), and `deploy/unraid/digarr.xml`. Reproducibility follow-up to the v1.7.0 release (#263).