### PR TITLE
chore(release): sync deploy digests to v1.8.0

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.12"
-  digest: "sha256:392088e42ff10b71f7979bdb9260f98fad325d8d957b8f657f96dd2357268c0f"
+  digest: "sha256:faa14b234ac41e208925ba6ca0b2b681790f4eeecb0f46e04377b38848cb9137"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:392088e42ff10b71f7979bdb9260f98fad325d8d957b8f657f96dd2357268c0f
+          image: ghcr.io/iuliandita/digarr@sha256:faa14b234ac41e208925ba6ca0b2b681790f4eeecb0f46e04377b38848cb9137
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:392088e42ff10b71f7979bdb9260f98fad325d8d957b8f657f96dd2357268c0f"
+          image: "ghcr.io/iuliandita/digarr@sha256:faa14b234ac41e208925ba6ca0b2b681790f4eeecb0f46e04377b38848cb9137"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:392088e42ff10b71f7979bdb9260f98fad325d8d957b8f657f96dd2357268c0f -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:faa14b234ac41e208925ba6ca0b2b681790f4eeecb0f46e04377b38848cb9137 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.9</Repository>
    <Tag>1.0.0-rc.9</Tag>
    <TagDescription>v1.0.0-rc.9 prerelease</TagDescription>


### PR DESCRIPTION
Repoints the pinned image digest to the published v1.8.0 image (`sha256:faa14b23...`) across `deploy/k8s/deployment.yaml`, `deploy/helm/digarr/values.yaml`, and `deploy/unraid/digarr.xml`. Generated by `scripts/sync-deploy-digests.ts v1.8.0`. Reproducibility follow-up to the v1.8.0 release.