### PR TITLE
fix(release): sync-deploy-digests repoints rendered.yaml too

### DIFF
--- a/scripts/sync-deploy-digests.ts
+++ b/scripts/sync-deploy-digests.ts
@@ -8,7 +8,15 @@
  * Fetches the multi-arch manifest digest from ghcr.io and rewrites:
  *   - deploy/k8s/deployment.yaml      (image ref with @sha256:...)
  *   - deploy/helm/digarr/values.yaml  (digest: "sha256:...")
+ *   - deploy/k8s/rendered.yaml        (image ref with @sha256:...)
  *   - deploy/unraid/digarr.xml        (digest comment)
+ *
+ * rendered.yaml is a `helm template` snapshot, but at the digest-sync step the
+ * only line that changes is the image digest, so a targeted string replace is
+ * byte-identical to a full regen -- and needs no helm, avoiding the
+ * local-helm-version-vs-CI drift that the helm-drift job would otherwise flag.
+ * (Chart-version changes still require regenerating via scripts/k8s-sync.sh in
+ * the release commit, where the chart version actually changes.)
  *
  * Auth: tries GH_TOKEN env first; falls back to anonymous token (public images).
  */
@@ -78,6 +86,11 @@ const targets: Target[] = [
     path: 'deploy/helm/digarr/values.yaml',
     pattern: /(^image:\n(?: {2}.*\n)*? {2}digest: ")sha256:[a-f0-9]+(")/m,
     replacement: (d, _match, prefix, suffix) => `${prefix}${d}${suffix}`,
+  },
+  {
+    path: 'deploy/k8s/rendered.yaml',
+    pattern: /ghcr\.io\/iuliandita\/digarr@sha256:[a-f0-9]+/g,
+    replacement: (d) => `ghcr.io/iuliandita/digarr@${d}`,
   },
   {
     path: 'deploy/unraid/digarr.xml',


### PR DESCRIPTION
## Problem

`scripts/sync-deploy-digests.ts` rewrote only 3 of the 4 pinned-digest files (deployment.yaml, values.yaml, digarr.xml), leaving `deploy/k8s/rendered.yaml` on the previous release's image digest. Because the `helm-drift` CI job regenerates rendered.yaml and fails on any diff, **every** digest-sync PR failed helm-drift until rendered.yaml was regenerated by hand — it bit v1.8.0 and v1.9.0.

## Fix

Add `deploy/k8s/rendered.yaml` as a 4th target, using the same `ghcr.io/iuliandita/digarr@sha256:` image-ref regex already proven on `deployment.yaml`.

At the digest-sync step the only line that changes in rendered.yaml is the image digest, so a targeted string replace is byte-identical to a full `helm template` regen — and needs no helm, sidestepping the local-helm-version-vs-CI-helm-3.16.4 drift that caused the repeat failures. Chart-version changes still regenerate via `scripts/k8s-sync.sh` in the release commit (where the chart version actually changes); this only touches the digest.

## Verification

- Ran the script at the current v1.9.0 digest: now emits 4 `updated` lines (incl. rendered.yaml); deploy files unchanged (already synced), only the script differs.
- `bun run typecheck` exit 0; lint clean (pre-existing warnings only).
- Regex is anchored to the image repo path, so config-checksum `sha256` annotations are untouched (rendered.yaml has exactly 1 matching line).