### PR TITLE
chore(release): sync deploy digests to v1.10.0

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -8,7 +8,7 @@ image:
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
   tag: "1.0.0-rc.12"
-  digest: "sha256:519869675a6806fb479b71aaf573e2ec65afada7c4509f53df4e4cf0ce4acff6"
+  digest: "sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:519869675a6806fb479b71aaf573e2ec65afada7c4509f53df4e4cf0ce4acff6
+          image: ghcr.io/iuliandita/digarr@sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:519869675a6806fb479b71aaf573e2ec65afada7c4509f53df4e4cf0ce4acff6"
+          image: "ghcr.io/iuliandita/digarr@sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:519869675a6806fb479b71aaf573e2ec65afada7c4509f53df4e4cf0ce4acff6 -->
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989 -->
    <Repository>docker.io/iuliandita/digarr:1.0.0-rc.9</Repository>
    <Tag>1.0.0-rc.9</Tag>
    <TagDescription>v1.0.0-rc.9 prerelease</TagDescription>


### PR DESCRIPTION
Repoints the pinned image digest to the published v1.10.0 image (`sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989`) across all four deploy files: deployment.yaml, values.yaml, digarr.xml, and rendered.yaml. First release where rendered.yaml was updated automatically by the script (the #276 fix) — no manual helm regen needed.