### PR TITLE
feat: develop nightly channel + build traceability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,58 @@
+name: Nightly
+
+on:
+  push:
+    branches:
+      - develop
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  nightly:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Short SHA
+        id: sha
+        run: echo "short=$(echo "${GITHUB_SHA}" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push :nightly
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${{ steps.sha.outputs.short }}
+          build-args: |
+            DIGARR_GIT_SHA=${{ github.sha }}
+            DIGARR_CHANNEL=nightly
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
 
+# A newer push to develop cancels an in-flight build: the moving :nightly always
+# converges on the latest commit, but a superseded commit's :nightly-<sha> tag
+# may never publish. Acceptable for a dev channel (latest-develop is the intent).
 concurrency:
   group: nightly
   cancel-in-progress: true
@@ -20,6 +23,7 @@ env:
 jobs:
   nightly:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             RUNTIME_IMAGE=${{ matrix.runtime-image }}
+            DIGARR_GIT_SHA=${{ github.sha }}
+            DIGARR_CHANNEL=${{ steps.tag.outputs.prerelease == 'true' && 'rc' || 'stable' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -15,6 +15,10 @@ FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf100
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+ARG DIGARR_GIT_SHA=dev
+ARG DIGARR_CHANNEL=local
+ENV DIGARR_GIT_SHA=${DIGARR_GIT_SHA}
+ENV DIGARR_CHANNEL=${DIGARR_CHANNEL}
 ENV NODE_ENV=production
 RUN bun run build
 

--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import { isShuttingDown } from '@/core/lifecycle'
 import { errMsg } from '@/core/validation'
 import type { Database } from '@/db'
+import { CHANNEL, GIT_SHA, VERSION } from '@/version'
 
 type HealthDeps = {
   db: Database
@@ -17,7 +18,7 @@ export function healthRoutes(deps: HealthDeps) {
     }
     try {
       await deps.db.execute(sql`SELECT 1`)
-      return c.json({ status: 'ok' })
+      return c.json({ status: 'ok', version: VERSION, gitSha: GIT_SHA, channel: CHANNEL })
     } catch (err: unknown) {
       console.error('[health] DB check failed:', errMsg(err))
       return c.json({ status: 'error', db: 'unavailable' }, 503)

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,8 @@
 import pkg from '../package.json'
 
 export const VERSION = pkg.version
+
+// Stamped at build time via Docker build-args -> ENV (Bun inlines process.env.*).
+// On the web side, Vite `define` replaces these same identifiers (see vite.config.ts).
+export const GIT_SHA = process.env.DIGARR_GIT_SHA ?? 'dev'
+export const CHANNEL = process.env.DIGARR_CHANNEL ?? 'local'

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -31,7 +31,7 @@ import {
 import { Toaster, toast } from 'sonner'
 import { normalizeLocale, type SupportedLocale } from '@/core/i18n/locales'
 import { errMsg } from '@/core/validation'
-import { VERSION } from '@/version'
+import { CHANNEL, GIT_SHA, VERSION } from '@/version'
 import { AuthGate } from './components/auth-gate'
 import { BottomNav } from './components/bottom-nav'
 import { ErrorBoundary } from './components/error-boundary'
@@ -753,6 +753,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
         />
         <footer className="hidden md:block fixed bottom-2 right-3 text-micro text-muted select-none pointer-events-none z-10">
           v{VERSION}
+          {CHANNEL === 'nightly' ? ` (${GIT_SHA})` : ''}
         </footer>
       </div>
     </PreviewContext.Provider>

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -753,7 +753,7 @@ function AppShell({ children }: { children: React.ReactNode }) {
         />
         <footer className="hidden md:block fixed bottom-2 right-3 text-micro text-muted select-none pointer-events-none z-10">
           v{VERSION}
-          {CHANNEL === 'nightly' ? ` (${GIT_SHA})` : ''}
+          {CHANNEL === 'nightly' ? ` (${GIT_SHA.slice(0, 7)})` : ''}
         </footer>
       </div>
     </PreviewContext.Provider>

--- a/tests/server/routes/health.test.ts
+++ b/tests/server/routes/health.test.ts
@@ -135,6 +135,16 @@ describe('GET /health', () => {
     expect(body.status).toBe('ok')
   })
 
+  it('includes version, gitSha and channel in the ok body', async () => {
+    const app = createApp(makeDeps())
+    const res = await app.request('/health')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.version).toMatch(/^\d+\.\d+\.\d+/)
+    expect(body.gitSha).toBe('dev')
+    expect(body.channel).toBe('local')
+  })
+
   it('returns 503 with status draining when shutting down', async () => {
     const app = createApp(makeDeps())
     markShuttingDown()

--- a/tests/server/version.test.ts
+++ b/tests/server/version.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { CHANNEL, GIT_SHA, VERSION } from '@/version'
+
+describe('version module', () => {
+  it('exposes a non-empty VERSION from package.json', () => {
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  it('falls back to dev/local when build env is unset', () => {
+    expect(GIT_SHA).toBe('dev')
+    expect(CHANNEL).toBe('local')
+  })
+})

--- a/tests/server/version.test.ts
+++ b/tests/server/version.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { CHANNEL, GIT_SHA, VERSION } from '@/version'
 
 describe('version module', () => {
@@ -9,5 +9,21 @@ describe('version module', () => {
   it('falls back to dev/local when build env is unset', () => {
     expect(GIT_SHA).toBe('dev')
     expect(CHANNEL).toBe('local')
+  })
+})
+
+describe('version module env injection', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('reads GIT_SHA and CHANNEL from build env when set', async () => {
+    vi.stubEnv('DIGARR_GIT_SHA', 'abc1234')
+    vi.stubEnv('DIGARR_CHANNEL', 'nightly')
+    vi.resetModules()
+    const mod = await import('@/version')
+    expect(mod.GIT_SHA).toBe('abc1234')
+    expect(mod.CHANNEL).toBe('nightly')
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    'process.env.DIGARR_GIT_SHA': JSON.stringify(process.env.DIGARR_GIT_SHA ?? 'dev'),
+    'process.env.DIGARR_CHANNEL': JSON.stringify(process.env.DIGARR_CHANNEL ?? 'local'),
+  },
   resolve: {
     alias: { '@': path.resolve(__dirname, './src') },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  // Fallbacks ('dev'/'local') must stay in sync with src/version.ts.
   define: {
     'process.env.DIGARR_GIT_SHA': JSON.stringify(process.env.DIGARR_GIT_SHA ?? 'dev'),
     'process.env.DIGARR_CHANNEL': JSON.stringify(process.env.DIGARR_CHANNEL ?? 'local'),


### PR DESCRIPTION
Establishes the `develop` integration branch's first payload: build-traceability plumbing plus the nightly image channel.

## What
- `src/version.ts` exports `GIT_SHA` + `CHANNEL` (from `DIGARR_GIT_SHA`/`DIGARR_CHANNEL`, fallbacks `dev`/`local`).
- `vite.config.ts` `define` inlines both for the browser bundle; Bun inlines them server-side.
- `GET /health` now returns `{ status, version, gitSha, channel }`.
- Footer shows the short sha on the `nightly` channel only.
- `deploy/docker/Dockerfile` accepts `DIGARR_GIT_SHA`/`DIGARR_CHANNEL` build-args and bakes them before `bun run build`.
- `release.yml` stamps the sha + `stable`/`rc` channel into release images.
- New `nightly.yml`: on push to `develop`, builds a GHCR-only multi-arch image tagged `:nightly` + `:nightly-<shortsha>`.

## Why
Closes the bisect loop raised in community feedback (271 releases, no nightly channel, hard to map a bug report to a build). Nightly testers now run `:nightly` and report the exact sha shown in the footer / `/health`.

## Tests
`bun run lint && bun run typecheck && bun run test` green (2401 passed). New tests: version env-injection + `/health` fields.