### PR TITLE
fix: wizard 400 for null AI fields (#290) + redact webhook credentials in logs

### DIFF
--- a/src/core/clients/http.ts
+++ b/src/core/clients/http.ts
@@ -215,6 +215,7 @@ export function redactUrlForLog(url: string): string {
 
     if (parsed.username) parsed.username = REDACTED_QUERY_VALUE
     if (parsed.password) parsed.password = REDACTED_QUERY_VALUE
+    if (parsed.hash) parsed.hash = REDACTED_QUERY_VALUE
 
     const redactedParams = new URLSearchParams()
 

--- a/src/core/clients/http.ts
+++ b/src/core/clients/http.ts
@@ -4,7 +4,19 @@ import { isPrivateIp, isPrivateUrl } from '@/core/notifications'
 import { formatUrlHostname, getLookupHostname, normalizeIp } from '@/core/validation'
 
 const REDACTED_QUERY_VALUE = '[REDACTED]'
-const SENSITIVE_QUERY_KEYS = new Set(['api_key', 'apikey', 'key', 'token', 'secret', 'password'])
+const SENSITIVE_QUERY_KEYS = new Set([
+  'api_key',
+  'apikey',
+  'key',
+  'token',
+  'secret',
+  'password',
+  'auth',
+  'access_token',
+  'auth_token',
+  'signature',
+  'sig',
+])
 
 type HttpClientConfig = {
   baseUrl: string
@@ -200,6 +212,10 @@ export function redactUrlForLog(url: string): string {
   try {
     const absolute = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url)
     const parsed = absolute ? new URL(url) : new URL(url, 'http://redact.invalid')
+
+    if (parsed.username) parsed.username = REDACTED_QUERY_VALUE
+    if (parsed.password) parsed.password = REDACTED_QUERY_VALUE
+
     const redactedParams = new URLSearchParams()
 
     for (const [key, value] of parsed.searchParams.entries()) {

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -1,5 +1,6 @@
 import { lookup } from 'node:dns/promises'
 import { isIP } from 'node:net'
+import { redactUrlForLog } from './clients/http'
 import {
   formatUrlHostname,
   getLookupHostname,
@@ -34,6 +35,27 @@ export type WebhookPayload =
       message: string
       timestamp: string
     }
+
+function redactWebhookUrl(url: string): string {
+  const redacted = redactUrlForLog(url)
+  try {
+    const parsed = new URL(redacted)
+    const host = parsed.hostname
+    const isDiscordHost = host.endsWith('discord.com') || host.endsWith('discordapp.com')
+    const isSlackHost = host.endsWith('slack.com')
+    if (!isDiscordHost && !isSlackHost) return redacted
+    const segments = parsed.pathname.split('/')
+    for (let i = segments.length - 1; i >= 0; i--) {
+      if (segments[i] !== '') {
+        segments[i] = '[REDACTED]'
+        break
+      }
+    }
+    return parsed.origin + segments.join('/') + parsed.search + parsed.hash
+  } catch {
+    return redacted
+  }
+}
 
 function isDiscordWebhook(url: string): boolean {
   try {
@@ -114,7 +136,7 @@ export async function sendWebhook(url: string, payload: WebhookPayload): Promise
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 10_000)
 
-  const safeUrl = url.replace(/:\/\/[^@]*@/, '://***@')
+  const safeUrl = redactWebhookUrl(url)
   const body = isDiscordWebhook(url) ? formatDiscordPayload(payload) : payload
   const fetchHeaders: Record<string, string> = { 'Content-Type': 'application/json' }
   const fetchUrl = new URL(url)

--- a/src/server/routes/setup.ts
+++ b/src/server/routes/setup.ts
@@ -32,7 +32,7 @@ export function setupRoutes(deps: AppDependencies) {
 
     const body = c.req.valid('json') as Record<string, unknown>
     const sanitized = Object.fromEntries(
-      Object.entries(body).filter(([key]) => GLOBAL_SETUP_FIELDS.has(key)),
+      Object.entries(body).filter(([key, value]) => GLOBAL_SETUP_FIELDS.has(key) && value != null),
     )
 
     const missing: string[] = []

--- a/src/server/schemas/setup.ts
+++ b/src/server/schemas/setup.ts
@@ -11,9 +11,9 @@ export const setupCompleteSchema = z
     lidarrApiKey: z.string().max(200).optional(),
     skipTlsVerify: z.boolean().optional(),
     aiProvider: z.string().max(64).optional(),
-    aiApiKey: z.string().max(500).optional(),
+    aiApiKey: z.string().max(500).nullish(),
     aiModel: z.string().max(200).optional(),
-    aiBaseUrl: z.string().max(2048).optional(),
+    aiBaseUrl: z.string().max(2048).nullish(),
     preferences: z.record(z.string(), z.unknown()).optional(),
     // Emby credentials (persisted separately on users row)
     embyUrl: z.string().max(2048).optional(),

--- a/tests/api-routes/setup.test.ts
+++ b/tests/api-routes/setup.test.ts
@@ -66,6 +66,33 @@ describe('API routes: setup', () => {
     expect(body.fields).toBeDefined()
   })
 
+  it('accepts null aiBaseUrl and aiApiKey (issue #290 - Gemini/OpenAI wizard)', async () => {
+    const completeSetup = vi.fn(async () => ({ success: true }))
+    const { app } = createTestApp({
+      isSetupComplete: vi.fn(async () => false),
+      getUserCount: vi.fn(async () => 0),
+      completeSetup,
+    })
+
+    const res = await app.request('/api/v1/setup/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        aiProvider: 'gemini',
+        aiModel: 'gemini-pro',
+        aiBaseUrl: null,
+        aiApiKey: null,
+      }),
+    })
+    expect(res.status).toBe(204)
+    expect(completeSetup).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        aiBaseUrl: expect.anything(),
+        aiApiKey: expect.anything(),
+      }),
+    )
+  })
+
   it('ignores legacy listening-source fields during setup completion', async () => {
     const completeSetup = vi.fn(async () => ({ success: true }))
     const { app } = createTestApp({

--- a/tests/core/notifications.test.ts
+++ b/tests/core/notifications.test.ts
@@ -184,6 +184,28 @@ describe('sendWebhook', () => {
     expect(loggedMessage).not.toContain('SECRET123')
   })
 
+  it('does not log Slack path token in failure messages', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 })
+
+    await sendWebhook('https://hooks.slack.com/services/T123/B456/SLACKSECRET', makePayload())
+
+    expect(consoleSpy).toHaveBeenCalledOnce()
+    const loggedMessage = consoleSpy.mock.calls[0]?.[0] as string
+    expect(loggedMessage).not.toContain('SLACKSECRET')
+    expect(loggedMessage).toContain('[REDACTED]')
+  })
+
+  it('does not log discordapp.com path token in failure messages', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 })
+
+    await sendWebhook('https://discordapp.com/api/webhooks/789/APPSECRET', makePayload())
+
+    expect(consoleSpy).toHaveBeenCalledOnce()
+    const loggedMessage = consoleSpy.mock.calls[0]?.[0] as string
+    expect(loggedMessage).not.toContain('APPSECRET')
+    expect(loggedMessage).toContain('[REDACTED]')
+  })
+
   it('aborts after timeout', async () => {
     // Simulate a fetch that never resolves until abort
     fetchMock.mockImplementation((_url: string, init: RequestInit) => {

--- a/tests/core/notifications.test.ts
+++ b/tests/core/notifications.test.ts
@@ -163,6 +163,27 @@ describe('sendWebhook', () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('private/internal'))
   })
 
+  it('does not log Discord path token in failure messages', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 })
+
+    await sendWebhook('https://discord.com/api/webhooks/123456/SUPERSECRETTOKEN', makePayload())
+
+    expect(consoleSpy).toHaveBeenCalledOnce()
+    const loggedMessage = consoleSpy.mock.calls[0]?.[0] as string
+    expect(loggedMessage).not.toContain('SUPERSECRETTOKEN')
+    expect(loggedMessage).toContain('[REDACTED]')
+  })
+
+  it('does not log token query param values in failure messages', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 })
+
+    await sendWebhook('https://example.com/hook?token=SECRET123', makePayload())
+
+    expect(consoleSpy).toHaveBeenCalledOnce()
+    const loggedMessage = consoleSpy.mock.calls[0]?.[0] as string
+    expect(loggedMessage).not.toContain('SECRET123')
+  })
+
   it('aborts after timeout', async () => {
     // Simulate a fetch that never resolves until abort
     fetchMock.mockImplementation((_url: string, init: RequestInit) => {

--- a/tests/core/redact-url.test.ts
+++ b/tests/core/redact-url.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+import { redactUrlForLog } from '@/core/clients/http'
+
+describe('redactUrlForLog', () => {
+  it('redacts ?token= values', () => {
+    const result = redactUrlForLog('https://example.com/hook?token=SECRETVAL')
+    expect(result).not.toContain('SECRETVAL')
+    expect(result).toContain('REDACTED')
+  })
+
+  it('redacts ?auth= values (new key)', () => {
+    const result = redactUrlForLog('https://example.com/hook?auth=AUTHSECRET')
+    expect(result).not.toContain('AUTHSECRET')
+    expect(result).toContain('REDACTED')
+  })
+
+  it('is case-insensitive on key matching (?Token=)', () => {
+    const result = redactUrlForLog('https://example.com/hook?Token=MYTOKEN')
+    expect(result).not.toContain('MYTOKEN')
+    expect(result).toContain('REDACTED')
+  })
+
+  it('masks userinfo username and password', () => {
+    const result = redactUrlForLog('https://user:pass@host.example.com/path')
+    expect(result).not.toContain('user')
+    expect(result).not.toContain('pass')
+    expect(result).toContain('REDACTED')
+  })
+
+  it('leaves non-sensitive query params intact (?user=test)', () => {
+    const result = redactUrlForLog('https://example.com/hook?user=test&foo=bar')
+    expect(result).toContain('user=test')
+    expect(result).toContain('foo=bar')
+  })
+
+  it('returns a plain url with no secrets unchanged', () => {
+    const url = 'https://example.com/api/webhook'
+    expect(redactUrlForLog(url)).toBe(url)
+  })
+})

--- a/tests/core/redact-url.test.ts
+++ b/tests/core/redact-url.test.ts
@@ -28,6 +28,19 @@ describe('redactUrlForLog', () => {
     expect(result).toContain('REDACTED')
   })
 
+  it('redacts a non-empty url fragment', () => {
+    const result = redactUrlForLog('https://example.com/hook?ok=1#token=SECRET')
+    expect(result).not.toContain('SECRET')
+    expect(result).toContain('[REDACTED]')
+  })
+
+  it('redacts two sensitive params in one url', () => {
+    const result = redactUrlForLog('https://example.com/hook?token=AAA&secret=BBB')
+    expect(result).not.toContain('AAA')
+    expect(result).not.toContain('BBB')
+    expect(result).toContain('REDACTED')
+  })
+
   it('leaves non-sensitive query params intact (?user=test)', () => {
     const result = redactUrlForLog('https://example.com/hook?user=test&foo=bar')
     expect(result).toContain('user=test')


### PR DESCRIPTION
Two small, independent fixes landing on develop (ride :nightly, batch into next release).

## 1. Setup wizard 400 (#290)
The wizard sends `aiBaseUrl: null` / `aiApiKey: null` for AI providers that don't use them (Gemini, OpenAI, Anthropic, Ollama). The Zod schema declared these `.optional()`, which rejects `null` (accepts only `undefined`), so `POST /api/v1/setup/complete` 400'd before the handler ran.

- `src/server/schemas/setup.ts`: `aiApiKey` / `aiBaseUrl` -> `.nullish()`.
- `src/server/routes/setup.ts`: strip null/undefined values before persisting so literal nulls don't reach settings and the `SetupConfig` cast stays sound. Required-field 400 path unchanged.
- Regression test for the Gemini-style null payload.

Fixes #290.

## 2. Redact webhook credentials in failure logs
`sendWebhook()` logged the webhook URL on failure with a regex that only masked userinfo, leaking secrets in `?token=` / `?auth=` query params and the secret path token in Discord/Slack webhook URLs.

- `src/core/clients/http.ts`: extend `SENSITIVE_QUERY_KEYS` (`auth`, `access_token`, `auth_token`, `signature`, `sig`); mask userinfo and URL fragment in `redactUrlForLog` (generic, benefits the http client too).
- `src/core/notifications.ts`: `redactWebhookUrl()` wraps `redactUrlForLog` and masks the final path segment for discord.com / discordapp.com / slack.com hosts; never throws, never echoes the raw url.
- New `tests/core/redact-url.test.ts` + webhook failure-log cases (Discord/Slack/discordapp/generic ?token=, fragment, multi-param).

## Verification
- `bun run test`: 2414 passed / 25 skipped.
- `bun run lint`: clean (7 pre-existing warnings, unrelated).
- `bun run typecheck`: clean.