### PR TITLE
fix: resolve first available Lidarr root folder instead of hardcoded id 1 (#288)

### DIFF
--- a/src/core/clients/lidarr.ts
+++ b/src/core/clients/lidarr.ts
@@ -119,11 +119,14 @@ export function createLidarrClient(url: string, apiKey: string, skipTlsVerify = 
     artistName: string,
     qualityProfileId: number,
     metadataProfileId: number,
-    rootFolderId: number,
+    rootFolderId?: number | null,
     options?: AddArtistOptions,
   ): Promise<LidarrArtist> {
     const folders = await getRootFolders()
-    const folder = folders.find((f) => f.id === rootFolderId)
+    if (folders.length === 0) {
+      throw new Error('No root folders configured in Lidarr')
+    }
+    const folder = rootFolderId == null ? folders[0] : folders.find((f) => f.id === rootFolderId)
     if (!folder) {
       throw new Error(`Root folder with id ${rootFolderId} not found`)
     }

--- a/src/core/pipeline/auto-approve.ts
+++ b/src/core/pipeline/auto-approve.ts
@@ -27,7 +27,7 @@ type AutoApproveConfig = {
   monitorOption: 'all' | 'new' | 'none'
   qualityProfileId: number
   metadataProfileId: number
-  rootFolderId: number
+  rootFolderId?: number
 }
 
 export async function autoApprove(

--- a/src/core/targets/lidarr.ts
+++ b/src/core/targets/lidarr.ts
@@ -18,7 +18,7 @@ export function createLidarrTarget(
   const client = createLidarrClient(config.url, config.apiKey, config.skipTlsVerify)
   const qualityProfileId = config.qualityProfileId ?? 1
   const metadataProfileId = config.metadataProfileId ?? 1
-  const rootFolderId = config.rootFolderId ?? 1
+  const rootFolderId = config.rootFolderId
 
   return {
     id: `lidarr-${targetId}`,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -476,7 +476,7 @@ export type PlaylistStrategy = 'weekly_digest' | 'genre_focus' | 'mood_mix' | 'r
 export type Preferences = {
   qualityProfileId: number
   metadataProfileId: number
-  rootFolderId: number
+  rootFolderId?: number
   scheduleCron: string
   scoreThreshold: number
   scoringWeights: {
@@ -511,7 +511,6 @@ export type ScoringWeights = Preferences['scoringWeights']
 export const DEFAULT_PREFERENCES: Preferences = {
   qualityProfileId: 1,
   metadataProfileId: 1,
-  rootFolderId: 1,
   scheduleCron: '0 0 * * 0',
   scoreThreshold: 0.5,
   scoringWeights: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -665,7 +665,7 @@ async function getEnabledTargetsForResolvedUser(
           skipTlsVerify: (row.config.skipTlsVerify as boolean) ?? false,
           qualityProfileId: Number(prefs.qualityProfileId ?? 1),
           metadataProfileId: Number(prefs.metadataProfileId ?? 1),
-          rootFolderId: Number(prefs.rootFolderId ?? 1),
+          rootFolderId: prefs.rootFolderId != null ? Number(prefs.rootFolderId) : undefined,
         }),
       )
     }

--- a/src/server/routes/lidarr.ts
+++ b/src/server/routes/lidarr.ts
@@ -81,7 +81,7 @@ export function lidarrRoutes(deps: AppDependencies) {
         artistName,
         qualityProfileId ?? 1,
         metadataProfileId ?? 1,
-        rootFolderId ?? 1,
+        rootFolderId,
       )
       return c.json(artist)
     },

--- a/src/web/components/approve-dialog.tsx
+++ b/src/web/components/approve-dialog.tsx
@@ -30,12 +30,20 @@ export function ApproveDialog({ defaults, monitorOption, onConfirm, onCancel }: 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: snap runs once against the initial default
   useEffect(() => {
     getLidarrApproveOptions()
       .then((opts) => {
         setProfiles(opts.qualityProfiles)
         setMetadataProfiles(opts.metadataProfiles)
         setRootFolders(opts.rootFolders)
+        // If the pre-filled default isn't an actual Lidarr root folder
+        // (e.g. stale id 1 after a folder was deleted/recreated), snap to
+        // the first available folder so we never send a non-existent id.
+        const firstFolder = opts.rootFolders[0]
+        if (firstFolder && !opts.rootFolders.some((f) => String(f.id) === rf)) {
+          setRf(String(firstFolder.id))
+        }
       })
       .catch(() => setError(true))
       .finally(() => setLoading(false))

--- a/src/web/pages/dashboard.tsx
+++ b/src/web/pages/dashboard.tsx
@@ -715,7 +715,7 @@ export function Dashboard() {
           defaults={{
             qualityProfileId: Number(prefs.qualityProfileId ?? 1),
             metadataProfileId: Number(prefs.metadataProfileId ?? 1),
-            rootFolderId: Number(prefs.rootFolderId ?? 1),
+            rootFolderId: Number(prefs.rootFolderId ?? 0),
           }}
           monitorOption={approveDialogState.monitorOption}
           onCancel={() => setApproveDialogState(null)}

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -1492,7 +1492,7 @@ export function DiscoverPage() {
           defaults={{
             qualityProfileId: Number(prefs.qualityProfileId ?? 1),
             metadataProfileId: Number(prefs.metadataProfileId ?? 1),
-            rootFolderId: Number(prefs.rootFolderId ?? 1),
+            rootFolderId: Number(prefs.rootFolderId ?? 0),
           }}
           monitorOption={approveDialogState.monitorOption}
           onCancel={() => setApproveDialogState(null)}

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -1520,7 +1520,7 @@ function LidarrPreferencesSection() {
 
   const [qualityProfileId, setQualityProfileId] = useState('1')
   const [metadataProfileId, setMetadataProfileId] = useState('1')
-  const [rootFolderId, setRootFolderId] = useState('1')
+  const [rootFolderId, setRootFolderId] = useState('')
   const [saving, setSaving] = useState(false)
 
   // Sync local state from user prefs when they load
@@ -1529,8 +1529,18 @@ function LidarrPreferencesSection() {
     const p = userPrefs as Record<string, unknown>
     setQualityProfileId(String(p.qualityProfileId ?? 1))
     setMetadataProfileId(String(p.metadataProfileId ?? 1))
-    setRootFolderId(String(p.rootFolderId ?? 1))
+    setRootFolderId(p.rootFolderId != null ? String(p.rootFolderId) : '')
   }, [userPrefs])
+
+  // Snap root folder selector to the first real folder when none is set
+  // or the stored id no longer exists among the loaded folders.
+  useEffect(() => {
+    if (!rootFolders || rootFolders.length === 0) return
+    const first = rootFolders[0]
+    if (first && !rootFolders.some((f) => String(f.id) === rootFolderId)) {
+      setRootFolderId(String(first.id))
+    }
+  }, [rootFolders, rootFolderId])
 
   async function handleSave() {
     setSaving(true)
@@ -1538,7 +1548,7 @@ function LidarrPreferencesSection() {
       await updateUserPreferences({
         qualityProfileId: parseInt(qualityProfileId, 10) || 1,
         metadataProfileId: parseInt(metadataProfileId, 10) || 1,
-        rootFolderId: parseInt(rootFolderId, 10) || 1,
+        rootFolderId: rootFolderId ? parseInt(rootFolderId, 10) : undefined,
       })
       queryClient.invalidateQueries({ queryKey: ['user-preferences'] })
       toast.success(t('settings.lidarrPreferencesSaved'))

--- a/tests/core/clients/lidarr.test.ts
+++ b/tests/core/clients/lidarr.test.ts
@@ -235,6 +235,69 @@ describe('createLidarrClient', () => {
         }),
       )
     })
+
+    it('uses first available folder when rootFolderId is undefined (id not 1)', async () => {
+      const altFolders: RootFolder[] = [
+        { id: 5, path: '/music5', freeSpace: 10_000_000_000 },
+        { id: 7, path: '/music7', freeSpace: 5_000_000_000 },
+      ]
+      mockGet.mockResolvedValueOnce(altFolders)
+      mockPost.mockResolvedValueOnce({ ...mockArtists[0], id: 20 })
+
+      const client = createLidarrClient(TEST_URL, TEST_KEY)
+      await client.addArtist('a74b1b7f-71a5-4011-9441-d0b5e4122711', 'Radiohead', 1, 1)
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/v1/artist',
+        expect.objectContaining({ rootFolderPath: '/music5' }),
+      )
+    })
+
+    it('uses first available folder when rootFolderId is null', async () => {
+      const altFolders: RootFolder[] = [
+        { id: 5, path: '/music5', freeSpace: 10_000_000_000 },
+        { id: 7, path: '/music7', freeSpace: 5_000_000_000 },
+      ]
+      mockGet.mockResolvedValueOnce(altFolders)
+      mockPost.mockResolvedValueOnce({ ...mockArtists[0], id: 21 })
+
+      const client = createLidarrClient(TEST_URL, TEST_KEY)
+      await client.addArtist('a74b1b7f-71a5-4011-9441-d0b5e4122711', 'Radiohead', 1, 1, null)
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/v1/artist',
+        expect.objectContaining({ rootFolderPath: '/music5' }),
+      )
+    })
+
+    it('uses the explicit folder path when a valid rootFolderId is provided', async () => {
+      mockGet.mockResolvedValueOnce(mockFolders)
+      mockPost.mockResolvedValueOnce({ ...mockArtists[0], id: 22 })
+
+      const client = createLidarrClient(TEST_URL, TEST_KEY)
+      await client.addArtist('a74b1b7f-71a5-4011-9441-d0b5e4122711', 'Radiohead', 1, 1, 2)
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/v1/artist',
+        expect.objectContaining({ rootFolderPath: '/music2' }),
+      )
+    })
+
+    it('throws with id in message when rootFolderId does not match any folder', async () => {
+      mockGet.mockResolvedValueOnce(mockFolders)
+      const client = createLidarrClient(TEST_URL, TEST_KEY)
+      await expect(
+        client.addArtist('a74b1b7f-71a5-4011-9441-d0b5e4122711', 'Radiohead', 1, 1, 42),
+      ).rejects.toThrow('Root folder with id 42 not found')
+    })
+
+    it('throws when no root folders are configured in Lidarr', async () => {
+      mockGet.mockResolvedValueOnce([])
+      const client = createLidarrClient(TEST_URL, TEST_KEY)
+      await expect(
+        client.addArtist('a74b1b7f-71a5-4011-9441-d0b5e4122711', 'Radiohead', 1, 1),
+      ).rejects.toThrow('No root folders configured in Lidarr')
+    })
   })
 
   describe('getAlbums()', () => {

--- a/tests/core/targets/lidarr.test.ts
+++ b/tests/core/targets/lidarr.test.ts
@@ -85,7 +85,7 @@ describe('createLidarrTarget()', () => {
       { monitorOption: 'selected', selectedAlbumIds: ['album-1'] },
     )
 
-    expect(client.addArtist).toHaveBeenCalledWith('mbid-rh', 'Radiohead', 1, 1, 1, {
+    expect(client.addArtist).toHaveBeenCalledWith('mbid-rh', 'Radiohead', 1, 1, undefined, {
       monitorOption: 'none',
     })
     expect(client.updateAlbum).toHaveBeenCalledWith(10, { monitored: true })

--- a/tests/web/components/approve-dialog.test.tsx
+++ b/tests/web/components/approve-dialog.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { I18nProvider } from '@/web/lib/i18n'
+
+vi.mock('@/web/lib/locale-storage', () => ({
+  detectBrowserLocale: vi.fn(() => 'en'),
+  getStoredLocale: vi.fn(() => 'en'),
+  setStoredLocale: vi.fn(),
+}))
+
+vi.mock('@/web/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/web/lib/api')>()
+  return {
+    ...actual,
+    getLidarrApproveOptions: vi.fn(),
+  }
+})
+
+import { ApproveDialog } from '@/web/components/approve-dialog'
+import { getLidarrApproveOptions } from '@/web/lib/api'
+
+function renderWithProviders(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <MemoryRouter>
+      <I18nProvider>
+        <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+      </I18nProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('ApproveDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('snaps to first available folder when default id is not in the loaded list', async () => {
+    vi.mocked(getLidarrApproveOptions).mockResolvedValue({
+      qualityProfiles: [{ id: 2, name: 'Standard' }],
+      metadataProfiles: [{ id: 3, name: 'Standard' }],
+      rootFolders: [
+        { id: 5, path: '/music5' },
+        { id: 7, path: '/music7' },
+      ],
+    })
+
+    const onConfirm = vi.fn()
+    renderWithProviders(
+      <ApproveDialog
+        defaults={{ qualityProfileId: 1, metadataProfileId: 1, rootFolderId: 1 }}
+        monitorOption="all"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    // Wait for options to load — button becomes enabled once all selects populate
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /add to lidarr/i })).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /add to lidarr/i }))
+
+    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ rootFolderId: 5 }))
+  })
+
+  it('keeps default id when it exists among loaded folders', async () => {
+    vi.mocked(getLidarrApproveOptions).mockResolvedValue({
+      qualityProfiles: [{ id: 2, name: 'Standard' }],
+      metadataProfiles: [{ id: 3, name: 'Standard' }],
+      rootFolders: [
+        { id: 1, path: '/music' },
+        { id: 5, path: '/music5' },
+      ],
+    })
+
+    const onConfirm = vi.fn()
+    renderWithProviders(
+      <ApproveDialog
+        defaults={{ qualityProfileId: 1, metadataProfileId: 1, rootFolderId: 1 }}
+        monitorOption="all"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /add to lidarr/i })).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /add to lidarr/i }))
+
+    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ rootFolderId: 1 }))
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #288. Digarr defaulted the Lidarr `rootFolderId` to a hardcoded `1` in several places. This breaks when a root folder was deleted and recreated in Lidarr (the new folder gets an id > 1) and the user never set a root-folder preference: the add fails with "Root folder with id 1 not found".

Root cause was structural, not just stray literals: `mergePreferences()` injected `DEFAULT_PREFERENCES.rootFolderId = 1`, so `prefs.rootFolderId` was *never* undefined and the backend could not tell "user picked 1" from "never set". The frontend additionally sent the stale `1` as an explicit override, which would defeat any backend resolution.

## Changes

**Backend** (`fix(lidarr): resolve first available root folder when none configured`)
- `client.addArtist` (the single chokepoint for every add path): a nullish `rootFolderId` now resolves to the first available root folder; an explicit-but-missing id still throws; an empty folder list throws a clear error.
- Removed the hardcoded `?? 1` fallbacks in `targets/lidarr.ts`, `routes/lidarr.ts`, and `index.ts`.
- Removed `rootFolderId: 1` from `DEFAULT_PREFERENCES` and made the field optional, so "not set" is genuinely `undefined` and reaches the resolver.

**Frontend** (`fix(web): snap Lidarr root folder to first available, drop hardcoded 1`)
- `ApproveDialog` snaps its root-folder selection to the first real folder when the pre-filled default isn't among the loaded folders (covers the discover + dashboard approve flows).
- Settings root-folder selector defaults to the first available folder when unset and saves `undefined` rather than `1` when none is chosen.
- Replaced the `?? 1` defaults in discover/dashboard with a `?? 0` unset sentinel the dialog reliably overrides.

## Tests
- 5 new `lidarr.test.ts` cases (no id -> first folder, asserted against a first folder whose id is not 1; explicit valid id; explicit missing id throws; empty list throws).
- New `approve-dialog.test.tsx`: snaps to first folder when default absent; keeps the default when present.

## Verification
- `bun run test`: 2421 passed, 25 skipped, 0 failed
- `bun run typecheck`: clean
- `bun run lint`: clean (0 errors)
- `bun run i18n:check`: clean (no new strings)

Each task went through spec-compliance + code-quality review before landing.