### PR TITLE
chore(unraid): sync built-in template with upstream CA tweaks

### DIFF
--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -2,9 +2,12 @@
 <Container version="2">
   <Name>Digarr</Name>
   <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989 -->
-   <Repository>docker.io/iuliandita/digarr:1.10.0</Repository>
-   <Tag>1.10.0</Tag>
-   <TagDescription>v1.10.0 release</TagDescription>
+  <Repository>docker.io/iuliandita/digarr:1.10.0</Repository>
+  <Registry>https://hub.docker.com/r/iuliandita/digarr</Registry>
+  <Branch>
+    <Tag>1.10.0</Tag>
+    <TagDescription>v1.10.0 release</TagDescription>
+  </Branch>
   <Network>bridge</Network>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
@@ -19,22 +22,21 @@
     REQUIRES a PostgreSQL database. Point DATABASE_URL at your existing
     postgres instance, or install a postgres container first.
   </Overview>
+  <Requires>
+    Requires a separate PostgreSQL database.
+  </Requires>
   <Category>MediaApp:Music</Category>
   <WebUI>http://[IP]:[PORT:3000]</WebUI>
   <Icon>https://raw.githubusercontent.com/iuliandita/digarr/main/docs/logo.png</Icon>
-  <ExtraParams/>
-  <DonateText/>
-  <DonateLink/>
-  <DonateImg/>
 
   <!-- Required -->
   <Config Name="Web UI Port" Target="3000" Default="3000" Mode="tcp"
-    Description="Port for the web interface" Type="Port" Display="always"
-    Required="true" Mask="false"/>
+    Description="Port for the web interface" Type="Port" Display="always-hide"
+    Required="true" Mask="false">3000</Config>
 
   <Config Name="Database URL" Target="DATABASE_URL" Default=""
     Description="PostgreSQL connection string, e.g. postgresql://user:pass@host:5432/digarr"
-    Type="Variable" Display="always" Required="true" Mask="false"/>
+    Type="Variable" Display="always-hide" Required="true" Mask="false"/>
 
   <!-- Auth (recommended) -->
   <Config Name="Initial Username" Target="DIGARR_INITIAL_USERNAME" Default=""
@@ -97,13 +99,13 @@
     Description="32+ char key for encrypting stored API tokens (auto-generated if blank)"
     Type="Variable" Display="advanced" Required="false" Mask="true"/>
 
-  <Config Name="Disable Registration" Target="DIGARR_DISABLE_REGISTRATION" Default="true"
+  <Config Name="Disable Registration" Target="DIGARR_DISABLE_REGISTRATION" Default="true|false"
     Description="Set to false to allow new user registration"
-    Type="Variable" Display="advanced" Required="false" Mask="false"/>
+    Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
 
-  <Config Name="Skip TLS Verify" Target="SKIP_TLS_VERIFY" Default="false"
+  <Config Name="Skip TLS Verify" Target="SKIP_TLS_VERIFY" Default="false|true"
     Description="Skip TLS certificate verification for Lidarr/Jellyfin connections"
-    Type="Variable" Display="advanced" Required="false" Mask="false"/>
+    Type="Variable" Display="advanced-hide" Required="true" Mask="false"/>
 
   <Config Name="Webhook URL" Target="WEBHOOK_URL" Default=""
     Description="Discord, Slack, ntfy, or any HTTP endpoint for notifications"


### PR DESCRIPTION
Bring our built-in `deploy/unraid/digarr.xml` in line with the changes nwithan8 merged into [selfhosters/unRAID-CA-templates#658](https://github.com/selfhosters/unRAID-CA-templates/pull/658):

- add `<Registry>`, `<Branch>` wrapper, and `<Requires>` (Postgres) fields
- port + DATABASE_URL set to `always-hide` (hidden once configured); port gets an inner value
- registration / TLS-verify knobs use unraid boolean toggle syntax (`true|false`) + `advanced-hide` + `Required=true`
- drop empty `ExtraParams`/`Donate*` stubs

Digest pin + `:1.10.0` tag retained — built-in stays the reproducible deploy copy; `sync-deploy-digests.ts` anchors (`<Repository>`/`<Tag>`/`<TagDescription>`) still match. The fallback mirror (`iuliandita/unraid-templates`) is already updated to the `:latest` CA version.