### PR TITLE
fix: surface swallowed discovery source failures + dead-code cleanup (#285)

### DIFF
--- a/src/core/ops/hygiene.ts
+++ b/src/core/ops/hygiene.ts
@@ -251,8 +251,7 @@ export async function aiReasoningAudit(
   }
   auditState = { flaggedIds: [], fixedIds: [], inProgress: true }
 
-  // biome-ignore lint/suspicious/noExplicitAny: drizzle dynamic query
-  const recs = await (db as any)
+  const recs = await db
     .select({
       recId: recommendations.id,
       aiReasoning: recommendations.aiReasoning,
@@ -297,8 +296,7 @@ export async function aiReasoningAudit(
             rec.artistName as string,
             allGenres as string[],
           )
-          // biome-ignore lint/suspicious/noExplicitAny: drizzle dynamic query
-          await (db as any)
+          await db
             .update(recommendations)
             .set({ aiReasoning: newReasoning })
             .where(eq(recommendations.id, id))

--- a/src/core/pipeline/discover.ts
+++ b/src/core/pipeline/discover.ts
@@ -147,6 +147,8 @@ export async function discover(
   const listeningSources = sources.listeningSources ?? []
 
   // For each seed artist, query each configured listening source for similar artists
+  // Aggregate per-source failures so a dead source is logged once, not per seed.
+  const sourceFailures = new Map<string, { count: number; lastError: string }>()
   await Promise.all(
     seedArtists.map(async (artist) => {
       for (const source of listeningSources) {
@@ -160,12 +162,21 @@ export async function discover(
               source: source.id,
             })
           }
-        } catch {
-          // Isolate source failure
+        } catch (err) {
+          const prev = sourceFailures.get(source.id)
+          sourceFailures.set(source.id, {
+            count: (prev?.count ?? 0) + 1,
+            lastError: err instanceof Error ? err.message : String(err),
+          })
         }
       }
     }),
   )
+  for (const [sourceId, { count, lastError }] of sourceFailures) {
+    console.warn(
+      `[discover] source ${sourceId} failed for ${count} seed artist(s); last error: ${lastError}`,
+    )
+  }
 
   // One AI call with the full profile
   if (sources.ai != null) {
@@ -188,8 +199,10 @@ export async function discover(
           source: 'ai',
         })
       }
-    } catch {
-      // Isolate source failure
+    } catch (err) {
+      console.warn(
+        `[discover] AI source failed: ${err instanceof Error ? err.message : String(err)}`,
+      )
     }
   }
 

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -213,7 +213,6 @@ async function approveAlbumToTargets(
 
   const targetActions: Record<string, unknown> = {}
   let anySuccess = false
-  let externalId: number | string | undefined
   let lidarrError: string | undefined
 
   for (const target of actionableTargets) {
@@ -274,18 +273,14 @@ async function approveAlbumToTargets(
     }
     if (result.success) {
       anySuccess = true
-      if (target.type === 'lidarr' && externalId == null) externalId = result.externalId
     } else if (target.type === 'lidarr') {
       lidarrError = result.error
     }
   }
 
   const status = anySuccess ? 'added_to_lidarr' : 'add_failed'
-  // Do NOT persist the album external id as lidarrArtistId: for album approvals
-  // `externalId` is the Lidarr ALBUM id, which has wrong semantics for the
-  // recommendations.lidarr_artist_id column. The album id is already retained
-  // in targetActions[target.id], and album status is driven by `anySuccess`.
-  void externalId
+  // lidarrArtistId stays undefined: the album path returns the Lidarr ALBUM id,
+  // wrong semantics for lidarr_artist_id (it's kept in targetActions instead).
   return { status, targetActions, lidarrArtistId: undefined, lidarrError }
 }
 

--- a/tests/core/pipeline/discover.test.ts
+++ b/tests/core/pipeline/discover.test.ts
@@ -115,6 +115,7 @@ describe('discover()', () => {
     }
     const lfm = makeLfm()
     const ai = makeAi()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const results = await discover(profile, { listeningSources: [lb, lfm], ai }, 10)
 
@@ -123,16 +124,24 @@ describe('discover()', () => {
     expect(results.filter((r) => r.source === 'ai').length).toBeGreaterThan(0)
     // But no LB results
     expect(results.filter((r) => r.source === 'listenbrainz').length).toBe(0)
+    // The swallowed failure must be observable, not silent
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('[discover] source listenbrainz failed'),
+    )
+    warn.mockRestore()
   })
 
   it('isolates AI source failure - other sources still return results', async () => {
     const lb = makeLb()
     const ai = { getRecommendations: vi.fn().mockRejectedValue(new Error('AI down')) }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const results = await discover(profile, { listeningSources: [lb], ai }, 10)
 
     expect(results.filter((r) => r.source === 'listenbrainz').length).toBeGreaterThan(0)
     expect(results.filter((r) => r.source === 'ai').length).toBe(0)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('[discover] AI source failed'))
+    warn.mockRestore()
   })
 
   it('respects topArtistsLimit - skips artists beyond the limit', async () => {


### PR DESCRIPTION
First low-hanging-fruit batch from the code-quality notes in [#285](https://github.com/iuliandita/digarr/discussions/285) (thanks @tinkermesomething / angelsomething).

### Changes
- **Observability — silent source failures** (`src/core/pipeline/discover.ts`): the per-source and AI `catch` blocks swallowed errors with no logging, so a fully-down source (e.g. ListenBrainz) returned "Discovered 0 artists" with no indication why. Now per-source failures aggregate into a counter and emit **one warn per source** (`[discover] source <id> failed for N seed artist(s); last error: ...`) plus a warn on AI failure. Aggregation avoids one-line-per-seed spam. Existing isolation tests extended to assert the warn fires.
- **Dead code** (`src/server/routes/recommendations.ts`): removed the redundant `externalId` local in the album-approval path — it was only assigned to be `void`-ed. The album id is already retained in `targetActions[target.id]`; `lidarrArtistId` stays `undefined` (kept the explanatory comment).
- **Type cleanup** (`src/core/ops/hygiene.ts`): dropped two `(db as any)` casts + their `biome-ignore` lines on fully static queries. `OpsDb` is the full `Database` type and sibling queries in the same file already call `.select`/`.update` uncast.

### Verification
- `bun run typecheck` clean
- `bun run lint` exit 0 (7 pre-existing warnings unchanged, none in touched files)
- `bun run test` 2444 passed; discover suite 17/17 incl. new assertions

Remaining #285 items (separate PRs): PATCH dup-fetch helper (#8), `overrides.ts` flatten (#1, i18n-sensitive), plus the noted-but-maybe-intentional pipeline singleton (#4) and multi-target atomicity (#5).