### PR TITLE
refactor: extract loadOwnedRecommendation helper (#285)

### DIFF
--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import { selectPopularReleaseGroups } from '@/core/albums/popular'
 import { createMusicBrainzClient } from '@/core/clients/musicbrainz'
 import { createSpotifyClient } from '@/core/clients/spotify'
@@ -388,6 +388,32 @@ async function buildAddOptions(
 export function recommendationRoutes(deps: AppDependencies) {
   const router = new Hono<HonoEnv>()
 
+  // Missing and non-owned both 404 (don't leak ownership); on failure returns the Response to return as-is.
+  const loadOwnedRecommendation = async (
+    c: Context<HonoEnv>,
+    id: number,
+  ): Promise<
+    | {
+        rec: NonNullable<Awaited<ReturnType<AppDependencies['getRecommendation']>>>
+        userId?: number
+      }
+    | Response
+  > => {
+    const rec = await deps.getRecommendation(id)
+    const userId = c.get('userId')
+    if (!rec || !isOwned(rec, userId))
+      return problem(
+        c,
+        'recommendation-not-found',
+        'Recommendation not found',
+        404,
+        undefined,
+        undefined,
+        'errors.recommendation.notFound',
+      )
+    return { rec, userId }
+  }
+
   router.get('/api/v1/recommendations', zQuery(listRecommendationsQuerySchema), async (c) => {
     const userId = c.get('userId')
     const query = c.req.valid('query')
@@ -428,29 +454,9 @@ export function recommendationRoutes(deps: AppDependencies) {
 
   router.get('/api/v1/recommendations/:id', zParam(recommendationIdParamSchema), async (c) => {
     const { id } = c.req.valid('param')
-    const rec = await deps.getRecommendation(id)
-    if (!rec)
-      return problem(
-        c,
-        'recommendation-not-found',
-        'Recommendation not found',
-        404,
-        undefined,
-        undefined,
-        'errors.recommendation.notFound',
-      )
-    const userId = c.get('userId')
-    if (!isOwned(rec, userId))
-      return problem(
-        c,
-        'recommendation-not-found',
-        'Recommendation not found',
-        404,
-        undefined,
-        undefined,
-        'errors.recommendation.notFound',
-      )
-    return c.json(rec)
+    const loaded = await loadOwnedRecommendation(c, id)
+    if (loaded instanceof Response) return loaded
+    return c.json(loaded.rec)
   })
 
   router.patch(
@@ -475,28 +481,9 @@ export function recommendationRoutes(deps: AppDependencies) {
       const approvalMode: ApprovalMode = rawApprovalMode ?? 'single_target'
 
       if (status === 'approved') {
-        const rec = await deps.getRecommendation(id)
-        if (!rec)
-          return problem(
-            c,
-            'recommendation-not-found',
-            'Recommendation not found',
-            404,
-            undefined,
-            undefined,
-            'errors.recommendation.notFound',
-          )
-        const userId = c.get('userId')
-        if (!isOwned(rec, userId))
-          return problem(
-            c,
-            'recommendation-not-found',
-            'Recommendation not found',
-            404,
-            undefined,
-            undefined,
-            'errors.recommendation.notFound',
-          )
+        const loaded = await loadOwnedRecommendation(c, id)
+        if (loaded instanceof Response) return loaded
+        const { rec, userId } = loaded
 
         const targets = userId ? await deps.getEnabledTargetsForUser(userId) : []
         const effectiveTargets = targetId ? targets.filter((t) => t.id === targetId) : targets
@@ -630,28 +617,9 @@ export function recommendationRoutes(deps: AppDependencies) {
         })
       }
 
-      const rec = await deps.getRecommendation(id)
-      if (!rec)
-        return problem(
-          c,
-          'recommendation-not-found',
-          'Recommendation not found',
-          404,
-          undefined,
-          undefined,
-          'errors.recommendation.notFound',
-        )
-      const userId = c.get('userId')
-      if (!isOwned(rec, userId))
-        return problem(
-          c,
-          'recommendation-not-found',
-          'Recommendation not found',
-          404,
-          undefined,
-          undefined,
-          'errors.recommendation.notFound',
-        )
+      const loaded = await loadOwnedRecommendation(c, id)
+      if (loaded instanceof Response) return loaded
+      const { userId } = loaded
 
       if (status === 'rejected') {
         const validated = rejectStatusSchema.safeParse(body)


### PR DESCRIPTION
Item #8 from the code-quality notes in [#285](https://github.com/iuliandita/digarr/discussions/285).

The "fetch rec → 404 if missing → 404 if not owned" block was copy-pasted across three handlers: `GET /:id`, and both branches (approve + reject/skip) of `PATCH /:id`. Extracted a single closure helper `loadOwnedRecommendation(c, id)` that returns the owned rec (+ userId) or a 404 `Response` the caller returns as-is.

- Collapses the duplicated 404 problem responses **6 → 1**.
- Merges the missing-rec and non-owned checks into one 404 (identical responses; still doesn't leak ownership).
- The bulk-approve loop keeps its own per-id `not_found` handling — different control flow (pushes to a results array, doesn't return).

Net -32 lines, no behavior change.

### Verification
- `bun run typecheck` clean, `bun run lint` exit 0
- `bun run test` 2444 passed; recommendation route + api-route suites 68/68