### PR TITLE
feat(pipeline): queue concurrent scan runs instead of rejecting (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Releases that have been promoted to the `:stable` Docker channel carry a `(stabl
 
 ### Changed
 
+- **A scan started while another is running is now queued, not rejected.** Digarr runs one discovery pipeline at a time (shared external-API and memory budgets). Previously a "Run Scan" while a run was already in progress was refused outright; on a multi-user instance one person's scan blocked everyone. Now the request is queued behind the active run and starts automatically when it finishes -- the toast reports your position in the queue. Clicking twice does not stack duplicate runs. Pipeline status now also reports queue length and your position. Translated across all 15 shipped locales.
 - **Spotify connect form now shows the Redirect URI to register.** Connecting Spotify requires adding an exact callback URL to your Spotify app, but Digarr previously computed that URL silently and never displayed it -- so it was easy to misconfigure the Spotify app and have the connection fail. The Settings -> Connections -> Spotify form now shows the exact Redirect URI for your instance with a copy button, and the README documents the full create-app -> register-redirect-URI -> paste-credentials flow. Translated across all 15 shipped locales.
 
 ## v1.10.0 - 2026-06-24

--- a/docs/API.md
+++ b/docs/API.md
@@ -138,17 +138,20 @@ Setup validation rules:
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| POST | `/api/v1/pipeline/run` | Yes | Start a full discovery scan. Returns 202. |
-| GET | `/api/v1/pipeline/status` | Yes | Current pipeline status (running, stage, last run) |
+| POST | `/api/v1/pipeline/run` | Yes | Start a full discovery scan, or queue it behind an in-flight run. Returns 202 with `{ queued, position }`. |
+| GET | `/api/v1/pipeline/status` | Yes | Current pipeline status (running, stage, last run, `queueLength`, caller `queuePosition`) |
 | GET | `/api/v1/pipeline/events` | Yes | SSE stream of pipeline progress events |
 | POST | `/api/v1/pipeline/quick-discover` | Yes | Fire-and-forget: discover artists similar to a given name. Rate limited: 5/min |
 | POST | `/api/v1/pipeline/rescan` | Yes | Re-fetch images/metadata for existing recommendations |
 
 `POST /api/v1/pipeline/run` and `/api/v1/pipeline/rescan` are intentionally
 available to any authenticated user (not admin-only): "Run Scan" is a core
-regular-user action on the dashboard and discover screens. Concurrency is
-bounded by a single-flight orchestrator, so a second run while one is active
-returns `409` rather than starting a parallel run.
+regular-user action on the dashboard and discover screens. The orchestrator is
+single-flight (one run at a time, shared API/RAM budgets), but a run requested
+while one is active is **queued FIFO**, not rejected: the response is still 202
+with `queued: true` and the caller's 1-based `position`. A given user is deduped
+(a double-click does not stack two runs). The queue drains automatically when
+the active run finishes. The queue is in-memory and per-process.
 
 **POST /api/v1/pipeline/quick-discover** body:
 ```json

--- a/src/core/i18n/messages/de.ts
+++ b/src/core/i18n/messages/de.ts
@@ -307,6 +307,8 @@ export const de = {
   'discover.retryFailed': 'Wiederholungsversuch fehlgeschlagen',
   'discover.scanAlreadyRunning': 'Scan läuft bereits',
   'discover.scanStarted': 'Scan gestartet - Fortschritt im Dashboard prüfen',
+  'discover.scanQueued':
+    'Scan in Warteschlange (Position {0}) - startet, sobald der aktuelle Lauf endet',
   'discover.scanStartFailed': 'Scan konnte nicht gestartet werden',
   'discover.select': 'Auswählen',
   'discover.shortcutsLabel': 'Kurzbefehle:',

--- a/src/core/i18n/messages/en.ts
+++ b/src/core/i18n/messages/en.ts
@@ -319,6 +319,7 @@ export const en = {
   'discover.retryFailed': 'Retry failed',
   'discover.scanAlreadyRunning': 'Scan already running',
   'discover.scanStarted': 'Scan started - check Dashboard for progress',
+  'discover.scanQueued': 'Scan queued (position {0}) - it will start when the current run finishes',
   'discover.scanStartFailed': 'Failed to start scan',
   'discover.select': 'Select',
   'discover.shortcutsLabel': 'Shortcuts:',

--- a/src/core/i18n/messages/es.ts
+++ b/src/core/i18n/messages/es.ts
@@ -307,6 +307,8 @@ export const es = {
   'discover.retryFailed': 'Reintentar falló',
   'discover.scanAlreadyRunning': 'El escaneo ya está en curso',
   'discover.scanStarted': 'Escaneo iniciado - revisa el Panel para ver el progreso',
+  'discover.scanQueued':
+    'Escaneo en cola (posicion {0}) - comenzara cuando termine la ejecucion actual',
   'discover.scanStartFailed': 'No se pudo iniciar el escaneo',
   'discover.select': 'Seleccionar',
   'discover.shortcutsLabel': 'Atajos:',

--- a/src/core/i18n/messages/fr.ts
+++ b/src/core/i18n/messages/fr.ts
@@ -307,6 +307,7 @@ export const fr = {
   'discover.retryFailed': 'La nouvelle tentative a échoué',
   'discover.scanAlreadyRunning': 'Le scan est déjà en cours',
   'discover.scanStarted': 'Scan lance - vérifiez le tableau de bord pour la progression',
+  'discover.scanQueued': 'Scan en attente (position {0}) - demarrera a la fin du scan en cours',
   'discover.scanStartFailed': "Échec du démarrage de l'analyse",
   'discover.select': 'Sélectionner',
   'discover.shortcutsLabel': 'Raccourcis :',

--- a/src/core/i18n/messages/it.ts
+++ b/src/core/i18n/messages/it.ts
@@ -307,6 +307,8 @@ export const it = {
   'discover.retryFailed': 'Nuovo tentativo fallito',
   'discover.scanAlreadyRunning': 'Scansione già in corso',
   'discover.scanStarted': 'Scansione avviata - controlla la Dashboard per i progressi',
+  'discover.scanQueued':
+    'Scansione in coda (posizione {0}) - partira al termine della scansione corrente',
   'discover.scanStartFailed': 'Impossibile avviare la scansione',
   'discover.select': 'Seleziona',
   'discover.shortcutsLabel': 'Scorciatoie:',

--- a/src/core/i18n/messages/ja.ts
+++ b/src/core/i18n/messages/ja.ts
@@ -306,6 +306,8 @@ export const ja = {
   'discover.retryFailed': '再試行に失敗しました',
   'discover.scanAlreadyRunning': 'スキャンはすでに実行中です',
   'discover.scanStarted': 'スキャンを開始しました - 進行状況はダッシュボードで確認してください',
+  'discover.scanQueued':
+    'スキャンを順番待ちに追加しました (順番 {0}) - 現在の実行が終わると開始します',
   'discover.scanStartFailed': 'スキャンの開始に失敗しました',
   'discover.select': '選択',
   'discover.shortcutsLabel': 'ショートカット:',

--- a/src/core/i18n/messages/ko.ts
+++ b/src/core/i18n/messages/ko.ts
@@ -303,6 +303,8 @@ export const ko = {
   'discover.retryFailed': '재시도 실패',
   'discover.scanAlreadyRunning': '스캔이 이미 실행 중입니다',
   'discover.scanStarted': '스캔을 시작했습니다 - 진행 상황은 대시보드에서 확인하세요',
+  'discover.scanQueued':
+    '스캔이 대기열에 추가되었습니다 (순번 {0}) - 현재 실행이 끝나면 시작됩니다',
   'discover.scanStartFailed': '스캔을 시작하지 못했습니다.',
   'discover.select': '선택',
   'discover.shortcutsLabel': '단축키:',

--- a/src/core/i18n/messages/nl.ts
+++ b/src/core/i18n/messages/nl.ts
@@ -307,6 +307,7 @@ export const nl = {
   'discover.retryFailed': 'Opnieuw proberen mislukt',
   'discover.scanAlreadyRunning': 'Scan wordt al uitgevoerd',
   'discover.scanStarted': 'Scan gestart - bekijk het Dashboard voor de voortgang',
+  'discover.scanQueued': 'Scan in wachtrij (positie {0}) - start zodra de huidige run klaar is',
   'discover.scanStartFailed': 'Kan het scannen niet starten',
   'discover.select': 'Selecteer',
   'discover.shortcutsLabel': 'Sneltoetsen:',

--- a/src/core/i18n/messages/pl.ts
+++ b/src/core/i18n/messages/pl.ts
@@ -307,6 +307,8 @@ export const pl = {
   'discover.retryFailed': 'Ponowna próba nie powiodła się',
   'discover.scanAlreadyRunning': 'Skanowanie już trwa',
   'discover.scanStarted': 'Skanowanie uruchomione - sprawdź Panel, aby zobaczyć postęp',
+  'discover.scanQueued':
+    'Skanowanie w kolejce (pozycja {0}) - rozpocznie sie po zakonczeniu biezacego',
   'discover.scanStartFailed': 'Nie udało się rozpocząć skanowania',
   'discover.select': 'Wybierz',
   'discover.shortcutsLabel': 'Skróty:',

--- a/src/core/i18n/messages/pt-BR.ts
+++ b/src/core/i18n/messages/pt-BR.ts
@@ -307,6 +307,8 @@ export const ptBR = {
   'discover.retryFailed': 'Falha na nova tentativa',
   'discover.scanAlreadyRunning': 'A varredura já está em andamento',
   'discover.scanStarted': 'Varredura iniciada - veja o Painel para acompanhar o progresso',
+  'discover.scanQueued':
+    'Varredura na fila (posicao {0}) - comecara quando a execucao atual terminar',
   'discover.scanStartFailed': 'Falha ao iniciar a verificação',
   'discover.select': 'Selecione',
   'discover.shortcutsLabel': 'Atalhos:',

--- a/src/core/i18n/messages/ro.ts
+++ b/src/core/i18n/messages/ro.ts
@@ -307,6 +307,8 @@ export const ro = {
   'discover.retryFailed': 'Reîncercarea a eșuat',
   'discover.scanAlreadyRunning': 'Scanarea rulează deja',
   'discover.scanStarted': 'Scanarea a început - verificați Panoul pentru progres',
+  'discover.scanQueued':
+    'Scanare in coada (pozitia {0}) - va incepe dupa ce se termina rularea curenta',
   'discover.scanStartFailed': 'Nu s-a pornit scanarea',
   'discover.select': 'Selectați',
   'discover.shortcutsLabel': 'Scurtături:',

--- a/src/core/i18n/messages/ru.ts
+++ b/src/core/i18n/messages/ru.ts
@@ -307,6 +307,8 @@ export const ru = {
   'discover.retryFailed': 'Повторная попытка не удалась',
   'discover.scanAlreadyRunning': 'Сканирование уже выполняется',
   'discover.scanStarted': 'Сканирование запущено - проверьте Панель для прогресса',
+  'discover.scanQueued':
+    'Сканирование в очереди (позиция {0}) - начнётся после завершения текущего',
   'discover.scanStartFailed': 'Не удалось запустить сканирование',
   'discover.select': 'Выбрать',
   'discover.shortcutsLabel': 'Горячие клавиши:',

--- a/src/core/i18n/messages/tr.ts
+++ b/src/core/i18n/messages/tr.ts
@@ -305,6 +305,7 @@ export const tr = {
   'discover.retryFailed': 'Yeniden deneme başarısız oldu',
   'discover.scanAlreadyRunning': 'Tarama zaten çalışıyor',
   'discover.scanStarted': 'Tarama başlatıldı - ilerleme için Panoyu kontrol edin',
+  'discover.scanQueued': 'Tarama siraya alindi (sira {0}) - mevcut calisma bitince baslayacak',
   'discover.scanStartFailed': 'Tarama başlatılamadı',
   'discover.select': 'Seç',
   'discover.shortcutsLabel': 'Kısayollar:',

--- a/src/core/i18n/messages/uk.ts
+++ b/src/core/i18n/messages/uk.ts
@@ -307,6 +307,7 @@ export const uk = {
   'discover.retryFailed': 'Повторна спроба не вдалася',
   'discover.scanAlreadyRunning': 'Сканування вже виконується',
   'discover.scanStarted': 'Сканування запущено - перевірте Панель для прогресу',
+  'discover.scanQueued': 'Сканування в черзі (позиція {0}) - почнеться після завершення поточного',
   'discover.scanStartFailed': 'Не вдалося почати сканування',
   'discover.select': 'Виберіть',
   'discover.shortcutsLabel': 'Гарячі клавіші:',

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -290,6 +290,7 @@ export const zhCN = {
   'discover.retryFailed': '重试失败',
   'discover.scanAlreadyRunning': '扫描已在运行',
   'discover.scanStarted': '扫描已开始 - 请到仪表盘查看进度',
+  'discover.scanQueued': '扫描已加入队列（位置 {0}）- 当前运行结束后将开始',
   'discover.scanStartFailed': '无法开始扫描',
   'discover.select': '选择',
   'discover.shortcutsLabel': '快捷键：',

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -103,11 +103,23 @@ export function shouldDropAlbumCandidate(
   )
 }
 
+interface QueuedRun {
+  userId: number | undefined
+  deps: PipelineDeps
+  enqueuedAt: Date
+}
+
+export type EnqueueResult = {
+  status: 'started' | 'queued' | 'duplicate'
+  position: number
+}
+
 export class PipelineOrchestrator extends EventEmitter {
   private running = false
   private currentStage: string | null = null
   private currentMessage: string | null = null
   private _currentUserId: number | undefined = undefined
+  private queue: QueuedRun[] = []
 
   override emit(eventName: string | symbol, ...args: unknown[]): boolean {
     if (eventName === 'progress') {
@@ -560,11 +572,51 @@ export class PipelineOrchestrator extends EventEmitter {
       this.running = false
       // Drop the userId so subsequent non-pipeline emits don't inherit a stale owner
       this._currentUserId = undefined
+      this.drainQueue()
     }
+  }
+
+  /**
+   * Start a run now, or queue it FIFO behind the in-flight one. Single-flight is
+   * preserved (one pipeline at a time, shared API/RAM budgets); a busy caller is
+   * parked instead of rejected. Deduped per userId so a double-click doesn't
+   * stack two runs.
+   */
+  enqueue(deps: PipelineDeps): EnqueueResult {
+    if (!this.running) {
+      this.startRun(deps)
+      return { status: 'started', position: 0 }
+    }
+    if (this._currentUserId === deps.userId) return { status: 'duplicate', position: 0 }
+    const existing = this.queue.findIndex((q) => q.userId === deps.userId)
+    if (existing >= 0) return { status: 'duplicate', position: existing + 1 }
+    this.queue.push({ userId: deps.userId, deps, enqueuedAt: new Date() })
+    return { status: 'queued', position: this.queue.length }
+  }
+
+  private startRun(deps: PipelineDeps): void {
+    this.run(deps).catch((err: unknown) => {
+      console.error('[orchestrator] queued run failed:', err)
+    })
+  }
+
+  private drainQueue(): void {
+    const next = this.queue.shift()
+    if (next) this.startRun(next.deps)
   }
 
   get isRunning(): boolean {
     return this.running
+  }
+
+  get queueLength(): number {
+    return this.queue.length
+  }
+
+  /** 1-based position of userId in the queue; 0 if running or not queued. */
+  queuePositionFor(userId: number | undefined): number {
+    const i = this.queue.findIndex((q) => q.userId === userId)
+    return i >= 0 ? i + 1 : 0
   }
 
   get stage(): string | null {

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -40,22 +40,10 @@ export function pipelineRoutes(deps: AppDependencies) {
 
   // Intentionally NOT admin-gated: "Run Scan" is a core regular-user action,
   // reachable from the dashboard (TodaysPick) and discover surfaces. Any
-  // authenticated user may start a run; concurrency is bounded by the
-  // orchestrator.isRunning singleton (a second run returns 409), so the blast
-  // radius is one in-flight pipeline regardless of caller. See plan 008 Part C.
+  // authenticated user may start a run; single-flight is preserved by the
+  // orchestrator, so the blast radius is one in-flight pipeline regardless of
+  // caller. A run requested while one is in progress is queued, not rejected.
   router.post('/api/v1/pipeline/run', async (c) => {
-    if (deps.orchestrator.isRunning) {
-      return problem(
-        c,
-        'pipeline-already-running',
-        'A pipeline run is already in progress',
-        409,
-        undefined,
-        undefined,
-        'errors.pipeline.alreadyRunning',
-      )
-    }
-
     const settings = await deps.getSettings()
     if (!settings) {
       return c.json({ error: 'Settings not found' }, 400)
@@ -110,26 +98,30 @@ export function pipelineRoutes(deps: AppDependencies) {
         : undefined,
     }
 
-    // Fire-and-forget
-    deps.orchestrator
-      .run({
-        db: deps.storeDb,
-        settings: { ...settings, preferences: userPreferences, spotifyAccessToken },
-        userId,
-        providerRegistry: deps.providerRegistry,
-        userConnections,
-        autoApproveDeps,
-        librarySync: deps.librarySync,
-        jobRecorder: deps.jobRecorder,
-        trigger: 'manual',
-        responseLocale,
-        promptLocale: null,
-      } as unknown as PipelineDeps)
-      .catch((err: unknown) => {
-        console.error('Pipeline run failed:', err)
-      })
+    // Start now, or queue behind the in-flight run (single-flight preserved).
+    const enqueued = deps.orchestrator.enqueue({
+      db: deps.storeDb,
+      settings: { ...settings, preferences: userPreferences, spotifyAccessToken },
+      userId,
+      providerRegistry: deps.providerRegistry,
+      userConnections,
+      autoApproveDeps,
+      librarySync: deps.librarySync,
+      jobRecorder: deps.jobRecorder,
+      trigger: 'manual',
+      responseLocale,
+      promptLocale: null,
+    } as unknown as PipelineDeps)
 
-    return c.json({ message: 'Pipeline started' }, 202)
+    const queued = enqueued.status !== 'started'
+    return c.json(
+      {
+        message: queued ? 'Pipeline queued' : 'Pipeline started',
+        queued,
+        position: enqueued.position,
+      },
+      202,
+    )
   })
 
   router.post('/api/v1/discovery-modes/run', zJson(discoveryModeRunSchema), async (c) => {
@@ -187,10 +179,13 @@ export function pipelineRoutes(deps: AppDependencies) {
 
   router.get('/api/v1/pipeline/status', async (c) => {
     const lastBatch = await deps.getLastBatch()
+    const userId = c.get('userId')
     return c.json({
       running: deps.orchestrator.isRunning,
       stage: deps.orchestrator.stage,
       message: deps.orchestrator.stageMessage,
+      queueLength: deps.orchestrator.queueLength,
+      queuePosition: userId ? deps.orchestrator.queuePositionFor(userId) : 0,
       lastRun: lastBatch
         ? {
             batchId: lastBatch.id,

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -571,7 +571,13 @@ function AppShell({ children }: { children: React.ReactNode }) {
                 disabled={!!pipelineRunning}
                 onClick={() =>
                   triggerPipeline()
-                    .then(() => toast.success(t('discover.scanStarted')))
+                    .then((res) =>
+                      toast.success(
+                        res.queued
+                          ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
+                          : t('discover.scanStarted'),
+                      ),
+                    )
                     .catch((err) => {
                       const msg = errMsg(err)
                       toast.error(msg.includes('409') ? t('discover.scanAlreadyRunning') : msg)

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -208,11 +208,19 @@ export const testService = (service: string, config: Record<string, unknown>) =>
 export const testWebhook = () => fetchApi<void>('/settings/test-webhook', { method: 'POST' })
 
 // Pipeline
-export const triggerPipeline = () => fetchApi('/pipeline/run', { method: 'POST' })
+export const triggerPipeline = () =>
+  fetchApi<{ message: string; queued?: boolean; position?: number }>('/pipeline/run', {
+    method: 'POST',
+  })
 export const getPipelineStatus = () =>
-  fetchApi<{ running: boolean; stage?: string; message?: string; lastRun?: unknown }>(
-    '/pipeline/status',
-  )
+  fetchApi<{
+    running: boolean
+    stage?: string
+    message?: string
+    queueLength?: number
+    queuePosition?: number
+    lastRun?: unknown
+  }>('/pipeline/status')
 export const rescanArtists = () =>
   fetchApi<{ updated: number; total: number }>('/pipeline/rescan', { method: 'POST' })
 

--- a/src/web/pages/dashboard.tsx
+++ b/src/web/pages/dashboard.tsx
@@ -647,7 +647,13 @@ export function Dashboard() {
           onSkip={handleSkip}
           onRunScan={() => {
             triggerPipeline()
-              .then(() => toast.success(t('discover.scanStarted')))
+              .then((res) =>
+                toast.success(
+                  res.queued
+                    ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
+                    : t('discover.scanStarted'),
+                ),
+              )
               .catch(() => toast.error(t('discover.scanStartFailed')))
           }}
           targets={approveTargets}

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -124,7 +124,13 @@ function EmptyState({ filter }: { filter: FilterTab }) {
             type="button"
             onClick={() =>
               triggerPipeline()
-                .then(() => toast.success(t('discover.scanStarted')))
+                .then((res) =>
+                  toast.success(
+                    res.queued
+                      ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
+                      : t('discover.scanStarted'),
+                  ),
+                )
                 .catch((err) => {
                   const msg =
                     typeof err === 'object' && err !== null && 'message' in err
@@ -1461,7 +1467,13 @@ export function DiscoverPage() {
           type="button"
           onClick={() =>
             triggerPipeline()
-              .then(() => toast.success(t('discover.scanStarted')))
+              .then((res) =>
+                toast.success(
+                  res.queued
+                    ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
+                    : t('discover.scanStarted'),
+                ),
+              )
               .catch((err) => {
                 const msg = errMsg(err)
                 toast.error(msg.includes('409') ? t('discover.scanAlreadyRunning') : msg)

--- a/tests/api-routes/pipeline.test.ts
+++ b/tests/api-routes/pipeline.test.ts
@@ -51,7 +51,7 @@ describe('API routes: pipeline', () => {
     expect(body.message).toBeDefined()
   })
 
-  it('returns 409 when pipeline is already running', async () => {
+  it('queues the run (202) when a pipeline is already running', async () => {
     const { app, deps } = createTestApp()
     // Simulate running state
     ;(deps.orchestrator as unknown as Record<string, unknown>).isRunning = true
@@ -60,7 +60,10 @@ describe('API routes: pipeline', () => {
       method: 'POST',
       headers: { Authorization: 'Bearer tok' },
     })
-    expect(runRes.status).toBe(409)
+    expect(runRes.status).toBe(202)
+    const body = await runRes.json()
+    expect(body.queued).toBe(true)
+    expect(body.position).toBe(1)
   })
 
   it('returns pipeline status', async () => {

--- a/tests/core/pipeline/orchestrator.test.ts
+++ b/tests/core/pipeline/orchestrator.test.ts
@@ -479,6 +479,68 @@ describe('PipelineOrchestrator', () => {
     expect(orchestrator.isRunning).toBe(false)
   })
 
+  it('enqueue starts immediately when idle', async () => {
+    const db = makeDb()
+    const result = orchestrator.enqueue({
+      db,
+      settings: defaultSettings,
+      providerRegistry,
+      librarySync: { syncForUser },
+      userId: 1,
+    })
+    expect(result).toEqual({ status: 'started', position: 0 })
+    await vi.waitFor(() => expect(orchestrator.isRunning).toBe(false))
+  })
+
+  it('queues a second run behind an in-flight one and drains on completion', async () => {
+    const db = makeDb()
+
+    // Hang the first run so it stays in flight while we enqueue more.
+    let resolveAnalyze!: () => void
+    mockAnalyze.mockReturnValue(
+      new Promise<typeof tasteProfile>((res) => {
+        resolveAnalyze = () => res(tasteProfile)
+      }),
+    )
+
+    const first = orchestrator.enqueue({
+      db,
+      settings: defaultSettings,
+      providerRegistry,
+      librarySync: { syncForUser },
+      userId: 1,
+    })
+    expect(first.status).toBe('started')
+    expect(orchestrator.isRunning).toBe(true)
+
+    const second = orchestrator.enqueue({
+      db,
+      settings: defaultSettings,
+      providerRegistry,
+      librarySync: { syncForUser },
+      userId: 2,
+    })
+    expect(second).toEqual({ status: 'queued', position: 1 })
+    expect(orchestrator.queueLength).toBe(1)
+    expect(orchestrator.queuePositionFor(2)).toBe(1)
+
+    // Same user again while busy is deduped, not stacked.
+    const dupe = orchestrator.enqueue({
+      db,
+      settings: defaultSettings,
+      providerRegistry,
+      librarySync: { syncForUser },
+      userId: 2,
+    })
+    expect(dupe.status).toBe('duplicate')
+    expect(orchestrator.queueLength).toBe(1)
+
+    // Finishing the first run drains the queue and starts the second.
+    resolveAnalyze()
+    await vi.waitFor(() => expect(orchestrator.queueLength).toBe(0))
+    await vi.waitFor(() => expect(orchestrator.isRunning).toBe(false))
+  })
+
   it('skips LB source when listenbrainzUsername is null', async () => {
     const { createListenBrainzSource } = await import('@/core/plugins/listenbrainz')
     const db = makeDb()

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -19,6 +19,13 @@ export function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependenc
     orchestrator: Object.assign(new EventEmitter(), {
       isRunning: false,
       run: vi.fn(async () => ({ batchId: 1 })),
+      enqueue: vi.fn(function (this: { isRunning: boolean }) {
+        return this.isRunning
+          ? { status: 'queued', position: 1 }
+          : { status: 'started', position: 0 }
+      }),
+      queueLength: 0,
+      queuePositionFor: vi.fn(() => 0),
       stage: null,
       stageMessage: null,
       currentUserId: undefined,

--- a/tests/server/routes/pipeline.test.ts
+++ b/tests/server/routes/pipeline.test.ts
@@ -44,6 +44,11 @@ function makeMockOrchestrator(isRunning = false) {
   return Object.assign(emitter, {
     isRunning,
     run: vi.fn(async () => ({ batchId: 1 })),
+    enqueue: vi.fn(() =>
+      isRunning ? { status: 'queued', position: 1 } : { status: 'started', position: 0 },
+    ),
+    queueLength: isRunning ? 1 : 0,
+    queuePositionFor: vi.fn(() => 0),
   })
 }
 
@@ -200,14 +205,14 @@ describe('POST /api/v1/pipeline/run', () => {
     expect(body.message).toBe('Pipeline started')
   })
 
-  it('returns 409 when pipeline is already running', async () => {
+  it('queues the run (202) when a pipeline is already running', async () => {
     const orchestrator = makeMockOrchestrator(true) as unknown as AppDependencies['orchestrator']
     const app = createApp(makeDeps({ orchestrator }))
     const res = await authedRequest(app, '/api/v1/pipeline/run', { method: 'POST' })
-    expect(res.status).toBe(409)
+    expect(res.status).toBe(202)
     const body = await res.json()
-    expect(body.title).toMatch(/already/i)
-    expect(body.code).toBe('errors.pipeline.alreadyRunning')
+    expect(body.queued).toBe(true)
+    expect(body.position).toBe(1)
   })
 
   it('returns 400 when settings are missing', async () => {
@@ -271,7 +276,7 @@ describe('POST /api/v1/pipeline/run', () => {
     })
 
     expect(res.status).toBe(202)
-    expect(orchestrator.run).toHaveBeenCalledWith(
+    expect(orchestrator.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
         responseLocale: 'fr',
         promptLocale: null,
@@ -285,7 +290,7 @@ describe('POST /api/v1/pipeline/run', () => {
     const app = createApp(makeDeps({ orchestrator, librarySync }))
     const res = await authedRequest(app, '/api/v1/pipeline/run', { method: 'POST' })
     expect(res.status).toBe(202)
-    expect(orchestrator.run).toHaveBeenCalledWith(expect.objectContaining({ librarySync }))
+    expect(orchestrator.enqueue).toHaveBeenCalledWith(expect.objectContaining({ librarySync }))
   })
 })
 


### PR DESCRIPTION
Addresses item #4 from the code-quality discussion (#285): the process-wide pipeline singleton blocked all users — a scan requested while one was running got a blunt 409.

## Decision
Keep single-flight (one pipeline at a time — shared external-API rate budgets + small-box RAM), but **queue** a concurrent request instead of rejecting it, and drain on completion.

## Changes
- **Orchestrator** (`src/core/pipeline/orchestrator.ts`): `enqueue()` + in-memory FIFO queue; `drainQueue()` runs in `run()`'s `finally` (drains on success *or* error); `queueLength` / `queuePositionFor()` getters. `run()`'s throw-on-concurrent contract is **unchanged** — internal callers (subscription runner, scheduled startup) and existing tests rely on it; the queue is a policy layer on top. Per-user dedupe: a double-click doesn't stack two runs.
- **`POST /pipeline/run`**: enqueue instead of 409. Still 202, body now `{ message, queued, position }`.
- **`GET /pipeline/status`**: adds `queueLength` + caller `queuePosition`.
- **Web**: "Run Scan" toast reports queue position when queued. New `discover.scanQueued` key across **all 15 locales**.
- **Docs**: `docs/API.md` + `CHANGELOG.md`.

## Scope note
Only `POST /pipeline/run` (the dashboard/discover "Run Scan" button) queues. `quick-discover` and `discovery-modes/run` keep their immediate 409 — they're distinct "I want this now" actions and don't share the same deps-build path. The queue is in-memory and per-process (consistent with the prior single-flight state; lost on restart).

## Checks
- typecheck clean, lint exit 0 (one pre-existing unrelated warning untouched)
- 2446 tests pass / 25 skipped (+2 new orchestrator queue tests; updated route tests that asserted the old 409)