### PR TITLE
fix(docker): collapse DB credentials to a single password secret

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -30,7 +30,6 @@ jobs:
         run: |
           cp deploy/docker/.env.example deploy/docker/.env
           printf '%s\n' 'testpass123' > deploy/docker/secrets/postgres_password
-          printf '%s\n' 'postgres://digarr:testpass123@postgres:5432/digarr' > deploy/docker/secrets/database_url
 
       - name: Start services
         working-directory: deploy/docker
@@ -85,7 +84,6 @@ jobs:
         run: |
           cp deploy/docker/.env.example deploy/docker/.env
           printf '%s\n' 'testpass123' > deploy/docker/secrets/postgres_password
-          printf '%s\n' 'postgres://digarr:testpass123@postgres:5432/digarr' > deploy/docker/secrets/database_url
 
       - name: Start services
         if: steps.docker.outputs.ready == 'true'

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ mkdir digarr && cd digarr
 curl -LO https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/docker-compose.yml
 curl -LO https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/.env.example
 mkdir -p secrets
+# Set ONE database password -- both Postgres and the app read this single file.
 printf '%s\n' 'change-this-password' > secrets/postgres_password
-printf '%s\n' 'postgres://digarr:change-this-password@postgres:5432/digarr' > secrets/database_url
 cp .env.example .env
-# Edit both secrets files and optionally .env
+# Edit secrets/postgres_password and optionally .env
 docker compose up -d
 ```
 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -7,9 +7,8 @@ production or local development.
 
 ```
 cd deploy/docker
-cp secrets/postgres_password.example secrets/postgres_password
-cp secrets/database_url.example      secrets/database_url
-# edit both files with real values
+# Set ONE database password -- both Postgres and the app read this single file.
+printf '%s\n' 'change-this-password' > secrets/postgres_password
 cp .env.example .env
 docker compose up -d
 ```
@@ -34,11 +33,15 @@ defined there (build context, postgres port publish). Everything else
 
 ## Secrets
 
-The base compose file uses the `_FILE` env convention. The app reads
-`DATABASE_URL_FILE`; Postgres reads `POSTGRES_PASSWORD_FILE`. Create
-`secrets/postgres_password` and `secrets/database_url` before starting the
-stack; see `secrets/*.example` for the expected format.
+The base compose file uses the `_FILE` env convention with a single secret.
+Postgres reads its password from `POSTGRES_PASSWORD_FILE`, and the app reads the
+same file via `DB_PASS_FILE`, then assembles `DATABASE_URL` from `DB_HOST`,
+`DB_USER`, `DB_NAME`, and that password. The password therefore lives in exactly
+one place -- `secrets/postgres_password` -- so the app and Postgres can never
+disagree. Create that file before starting the stack; see
+`secrets/postgres_password.example` for the format (one line, the password
+only).
 
 If you need env-var-only deployment (e.g. platforms without Compose secrets),
-use a small compose override that sets `DATABASE_URL` for the app,
+use a small compose override that sets `DATABASE_URL` for the app and
 `POSTGRES_PASSWORD` for Postgres, and removes the `_FILE` variables.

--- a/deploy/docker/docker-compose.dev.yml
+++ b/deploy/docker/docker-compose.dev.yml
@@ -7,7 +7,6 @@
 #
 # Prerequisites (one-time):
 #   cp deploy/docker/secrets/postgres_password.example deploy/docker/secrets/postgres_password
-#   cp deploy/docker/secrets/database_url.example      deploy/docker/secrets/database_url
 
 services:
   app:

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -6,8 +6,6 @@
 secrets:
   postgres_password:
     file: ./secrets/postgres_password
-  database_url:
-    file: ./secrets/database_url
 
 networks:
   frontend:
@@ -33,9 +31,14 @@ services:
         required: false
     environment:
       - PORT=3000
-      - DATABASE_URL_FILE=/run/secrets/database_url
+      # The app assembles DATABASE_URL from these parts and the password file,
+      # so the DB password lives in exactly one place: secrets/postgres_password.
+      - DB_HOST=postgres
+      - DB_USER=${DB_USER:-digarr}
+      - DB_NAME=${DB_NAME:-digarr}
+      - DB_PASS_FILE=/run/secrets/postgres_password
     secrets:
-      - database_url
+      - postgres_password
     ports:
       - "${PORT:-3000}:3000"
     depends_on:

--- a/deploy/docker/secrets/database_url.example
+++ b/deploy/docker/secrets/database_url.example
@@ -1,1 +1,0 @@
-postgres://digarr:changeme@postgres:5432/digarr

--- a/docs/guides/docker-desktop.md
+++ b/docs/guides/docker-desktop.md
@@ -17,12 +17,12 @@ mkdir digarr && cd digarr
 curl -LO https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/docker-compose.yml
 curl -LO https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/.env.example
 mkdir -p secrets
+# One database password -- both Postgres and the app read this single file.
 printf '%s\n' 'change-this-password' > secrets/postgres_password
-printf '%s\n' 'postgres://digarr:change-this-password@postgres:5432/digarr' > secrets/database_url
 cp .env.example .env
 ```
 
-Edit both files in `secrets/` with the same real password, and optionally edit
+Edit `secrets/postgres_password` with a real password, and optionally edit
 `.env`, then:
 
 ```sh
@@ -36,11 +36,12 @@ mkdir digarr; cd digarr
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/docker-compose.yml" -OutFile "docker-compose.yml"
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/.env.example" -OutFile ".env"
 New-Item -ItemType Directory -Force -Path "secrets"
-Set-Content -Path "secrets/postgres_password" -Value "change-this-password"
-Set-Content -Path "secrets/database_url" -Value "postgres://digarr:change-this-password@postgres:5432/digarr"
+# WriteAllText avoids the UTF-8 BOM that Set-Content adds, which would corrupt
+# the password. Both Postgres and the app read this single file.
+[System.IO.File]::WriteAllText("secrets/postgres_password", "change-this-password")
 ```
 
-Edit both files in `secrets/` with the same real password, and optionally edit
+Edit `secrets/postgres_password` with a real password, and optionally edit
 `.env`, then:
 
 ```powershell
@@ -68,5 +69,7 @@ docker compose up -d
 
 - **Port conflict:** If port 3000 is in use, change `PORT` in `.env`.
 - **Slow startup:** First pull downloads ~200 MB. Subsequent starts are fast.
-- **Database errors:** Ensure `secrets/postgres_password` and
-  `secrets/database_url` exist, use the same password, and contain no quotes.
+- **Database errors:** Ensure `secrets/postgres_password` exists, contains only
+  the password on a single line, and has no quotes or UTF-8 BOM. If you changed
+  the password after the first start, Postgres keeps the old one baked into its
+  data volume -- run `docker compose down -v` to reset (this wipes the database).

--- a/docs/guides/synology.md
+++ b/docs/guides/synology.md
@@ -18,9 +18,10 @@ Container Manager supports compose projects natively. Use it if you want a no-SS
 2. Set the project name to `digarr`
 3. Set the path to a shared folder (e.g., `/volume1/docker/digarr`)
 4. Paste the contents of the [docker-compose.yml](https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/docker-compose.yml)
-5. Create two files in the project folder before starting:
-   - `secrets/postgres_password` containing only the database password
-   - `secrets/database_url` containing `postgres://digarr:YOUR_PASSWORD@postgres:5432/digarr`
+5. Create one file in the project folder before starting:
+   - `secrets/postgres_password` containing only the database password (both
+     the app and PostgreSQL read this single file, so there is nothing to keep
+     in sync)
 6. Click **Done**
 
 Both the app and PostgreSQL containers start together automatically.
@@ -33,10 +34,8 @@ curl -LO https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/
 curl -LO https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/.env.example
 mkdir -p secrets
 printf '%s\n' 'change-this-password' > secrets/postgres_password
-printf '%s\n' 'postgres://digarr:change-this-password@postgres:5432/digarr' > secrets/database_url
 cp .env.example .env
 vi secrets/postgres_password
-vi secrets/database_url
 sudo docker compose up -d
 ```
 
@@ -75,15 +74,13 @@ sudo curl -LO https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/do
 sudo curl -LO https://raw.githubusercontent.com/iuliandita/digarr/main/deploy/docker/.env.example
 sudo mkdir -p secrets
 printf '%s\n' 'change-this-password' | sudo tee secrets/postgres_password > /dev/null
-printf '%s\n' 'postgres://digarr:change-this-password@postgres:5432/digarr' | sudo tee secrets/database_url > /dev/null
 sudo cp .env.example .env
 ```
 
-Edit both secret files with the same real password:
+Edit the secret file with a real password:
 
 ```sh
 sudo vi secrets/postgres_password
-sudo vi secrets/database_url
 ```
 
 Start both containers:


### PR DESCRIPTION
Fixes #306.

## Problem
The docker compose stack shipped **two** secret files that both had to carry the same password:
- `secrets/postgres_password` (Postgres init password)
- `secrets/database_url` (full DSN with the password embedded)

Set one but not the other -- or hit the Windows `Set-Content` UTF-8 BOM in only one file -- and the app gets `password authentication failed for user "digarr"`. Because the `pgdata` volume bakes in the first-boot password, fixing the file afterwards doesn't help without `down -v`. This is the "Postgres errors during docker install" users reported. The existing docker-desktop guide even listed "use the same password" as a manual troubleshooting step -- a footgun.

## Fix
The app already assembles `DATABASE_URL` from `DB_HOST`/`DB_USER`/`DB_NAME` + `DB_PASS_FILE` (`buildDatabaseUrl()` + `envOrFile()`). So point **both** Postgres (`POSTGRES_PASSWORD_FILE`) and the app (`DB_PASS_FILE`) at the one `secrets/postgres_password` file. The password now lives in exactly one place and cannot drift. No app code changes.

- `docker-compose.yml`: drop the `database_url` secret + `DATABASE_URL_FILE`; app gets `DB_HOST/DB_USER/DB_NAME/DB_PASS_FILE`
- delete `secrets/database_url.example`
- `compatibility.yml`: stop writing the redundant secret
- docs (root README, docker README, synology, docker-desktop): one-secret setup; Windows switched to BOM-free `WriteAllText`; note `down -v` to reset a stale first-boot password

## Verification
- `docker compose config` renders correctly for base + dev + compat overlays
- Booted the base stack against the released `:stable` image: Postgres healthy, app connected with only `postgres_password`, `GET /health` -> `{"status":"ok"}`, migrations ran, 0 errors
- No remaining `database_url` references outside git history
- The `Compatibility` workflow exercises this end-to-end on the PR