### PR TITLE
feat(popular-albums): Last.fm fallback + connection-aware gating

### DIFF
--- a/src/core/clients/lastfm.ts
+++ b/src/core/clients/lastfm.ts
@@ -72,6 +72,18 @@ export type LastFmChartArtist = {
   mbid?: string
 }
 
+export type LastFmTopAlbum = {
+  title: string
+  popularity: number
+  mbid?: string
+}
+
+type LfmArtistTopAlbumsResponse = {
+  topalbums?: {
+    album?: Array<{ name: string; playcount?: string | number; mbid?: string }>
+  }
+}
+
 export function createLastFmClient(username: string, apiKey: string) {
   const http = createHttpClient({ baseUrl: BASE_URL })
 
@@ -186,6 +198,26 @@ export function createLastFmClient(username: string, apiKey: string) {
     }))
   }
 
+  async function getTopAlbumsForArtist(
+    artist: string,
+    mbid?: string,
+    limit = 50,
+  ): Promise<LastFmTopAlbum[]> {
+    const params: Record<string, string> = {
+      method: 'artist.getTopAlbums',
+      artist,
+      limit: String(limit),
+    }
+    if (mbid) params.mbid = mbid
+    const res = await get<LfmArtistTopAlbumsResponse>(params)
+    const albums = res?.topalbums?.album ?? []
+    return albums.map((a) => ({
+      title: a.name,
+      popularity: Number(a.playcount) || 0,
+      mbid: a.mbid || undefined,
+    }))
+  }
+
   async function testConnection(): Promise<ServiceTestResult> {
     try {
       const artists = await getTopArtists('7day')
@@ -204,6 +236,7 @@ export function createLastFmClient(username: string, apiKey: string) {
     getTopArtists,
     getTopArtistsPaged,
     getTopArtistsByTag,
+    getTopAlbumsForArtist,
     getRecentTracks,
     getChartTopArtists,
     testConnection,

--- a/src/core/i18n/messages/de.ts
+++ b/src/core/i18n/messages/de.ts
@@ -282,6 +282,10 @@ export const de = {
   'discover.monitorSelectedDescription': 'Wähle, welche Alben überwacht werden sollen',
   'discover.monitorPopular': 'Beliebte Alben',
   'discover.monitorPopularDescription': 'Die 3 beliebtesten Album-Veröffentlichungen überwachen',
+  'discover.monitorPopularUnavailable':
+    'Verbinde Spotify oder Last.fm, um beliebte Alben zu überwachen',
+  'discover.popularAlbumsFailed':
+    'Die beliebten Alben für diesen Künstler konnten nicht ermittelt werden. Versuche eine andere Überwachungsoption.',
   'discover.monitorNoneDescription': 'Ohne Überwachung hinzufügen (nur verfolgen)',
   'discover.discoveryRunStarted': 'Erkennungslauf gestartet.',
   'discover.exportFailed': 'Der Export ist fehlgeschlagen',

--- a/src/core/i18n/messages/en.ts
+++ b/src/core/i18n/messages/en.ts
@@ -295,6 +295,9 @@ export const en = {
   'discover.monitorSelectedDescription': 'Choose which albums to monitor',
   'discover.monitorPopular': 'Popular albums',
   'discover.monitorPopularDescription': 'Monitor the top 3 album releases',
+  'discover.monitorPopularUnavailable': 'Connect Spotify or Last.fm to monitor popular albums',
+  'discover.popularAlbumsFailed':
+    'Could not determine popular albums for this artist. Try another monitor option.',
   'discover.monitorNoneDescription': 'Add unmonitored (tracking only)',
   'discover.discoveryRunStarted': 'Discovery run started.',
   'discover.exportFailed': 'Export failed',

--- a/src/core/i18n/messages/es.ts
+++ b/src/core/i18n/messages/es.ts
@@ -282,6 +282,10 @@ export const es = {
   'discover.monitorSelectedDescription': 'Elige qué álbumes supervisar',
   'discover.monitorPopular': 'Álbumes populares',
   'discover.monitorPopularDescription': 'Supervisar los 3 lanzamientos de álbum más populares',
+  'discover.monitorPopularUnavailable':
+    'Conecta Spotify o Last.fm para supervisar los álbumes populares',
+  'discover.popularAlbumsFailed':
+    'No se pudieron determinar los álbumes populares de este artista. Prueba otra opción de supervisión.',
   'discover.monitorNoneDescription': 'Añadir sin supervisión (solo seguimiento)',
   'discover.discoveryRunStarted': 'Se inició la ejecución de descubrimiento.',
   'discover.exportFailed': 'Exportación fallida',

--- a/src/core/i18n/messages/fr.ts
+++ b/src/core/i18n/messages/fr.ts
@@ -282,6 +282,10 @@ export const fr = {
   'discover.monitorSelectedDescription': 'Choisir les albums à surveiller',
   'discover.monitorPopular': 'Albums populaires',
   'discover.monitorPopularDescription': "Surveiller les 3 sorties d'album les plus populaires",
+  'discover.monitorPopularUnavailable':
+    'Connectez Spotify ou Last.fm pour surveiller les albums populaires',
+  'discover.popularAlbumsFailed':
+    'Impossible de déterminer les albums populaires pour cet artiste. Essayez une autre option de surveillance.',
   'discover.monitorNoneDescription': 'Ajouter sans surveillance (suivi uniquement)',
   'discover.discoveryRunStarted': "L'exécution de la découverte a démarré.",
   'discover.exportFailed': "Échec de l'exportation",

--- a/src/core/i18n/messages/it.ts
+++ b/src/core/i18n/messages/it.ts
@@ -282,6 +282,10 @@ export const it = {
   'discover.monitorSelectedDescription': 'Scegli quali album monitorare',
   'discover.monitorPopular': 'Album popolari',
   'discover.monitorPopularDescription': 'Monitora le 3 uscite album più popolari',
+  'discover.monitorPopularUnavailable':
+    'Collega Spotify o Last.fm per monitorare gli album popolari',
+  'discover.popularAlbumsFailed':
+    "Impossibile determinare gli album popolari per questo artista. Prova un'altra opzione di monitoraggio.",
   'discover.monitorNoneDescription': 'Aggiungi senza monitoraggio (solo tracciamento)',
   'discover.discoveryRunStarted': "L'esecuzione del rilevamento è iniziata.",
   'discover.exportFailed': 'Esportazione non riuscita',

--- a/src/core/i18n/messages/ja.ts
+++ b/src/core/i18n/messages/ja.ts
@@ -281,6 +281,10 @@ export const ja = {
   'discover.monitorSelectedDescription': '監視するアルバムを選択',
   'discover.monitorPopular': '人気アルバム',
   'discover.monitorPopularDescription': '人気上位3件のアルバムリリースを監視',
+  'discover.monitorPopularUnavailable':
+    '人気アルバムを監視するには Spotify または Last.fm を接続してください',
+  'discover.popularAlbumsFailed':
+    'このアーティストの人気アルバムを特定できませんでした。別の監視オプションをお試しください。',
   'discover.monitorNoneDescription': '監視せずに追加（追跡のみ）',
   'discover.discoveryRunStarted': '検出の実行が開始されました。',
   'discover.exportFailed': 'エクスポートに失敗しました',

--- a/src/core/i18n/messages/ko.ts
+++ b/src/core/i18n/messages/ko.ts
@@ -278,6 +278,10 @@ export const ko = {
   'discover.monitorSelectedDescription': '모니터링할 앨범 선택',
   'discover.monitorPopular': '인기 앨범',
   'discover.monitorPopularDescription': '가장 인기 있는 앨범 릴리스 3개 모니터링',
+  'discover.monitorPopularUnavailable':
+    '인기 앨범을 모니터링하려면 Spotify 또는 Last.fm을 연결하세요',
+  'discover.popularAlbumsFailed':
+    '이 아티스트의 인기 앨범을 확인할 수 없습니다. 다른 모니터링 옵션을 시도해 보세요.',
   'discover.monitorNoneDescription': '모니터링 없이 추가(추적만)',
   'discover.discoveryRunStarted': '검색 실행이 시작되었습니다.',
   'discover.exportFailed': '내보내기 실패',

--- a/src/core/i18n/messages/nl.ts
+++ b/src/core/i18n/messages/nl.ts
@@ -282,6 +282,9 @@ export const nl = {
   'discover.monitorSelectedDescription': 'Kies welke albums je wilt volgen',
   'discover.monitorPopular': 'Populaire albums',
   'discover.monitorPopularDescription': 'Volg de 3 populairste albumreleases',
+  'discover.monitorPopularUnavailable': 'Verbind Spotify of Last.fm om populaire albums te volgen',
+  'discover.popularAlbumsFailed':
+    'Kon de populaire albums voor deze artiest niet bepalen. Probeer een andere monitoroptie.',
   'discover.monitorNoneDescription': 'Toevoegen zonder monitoring (alleen volgen)',
   'discover.discoveryRunStarted': 'Discovery-run gestart.',
   'discover.exportFailed': 'Exporteren is mislukt',

--- a/src/core/i18n/messages/pl.ts
+++ b/src/core/i18n/messages/pl.ts
@@ -282,6 +282,10 @@ export const pl = {
   'discover.monitorSelectedDescription': 'Wybierz, które albumy monitorować',
   'discover.monitorPopular': 'Popularne albumy',
   'discover.monitorPopularDescription': 'Monitoruj 3 najpopularniejsze wydania albumów',
+  'discover.monitorPopularUnavailable':
+    'Połącz Spotify lub Last.fm, aby monitorować popularne albumy',
+  'discover.popularAlbumsFailed':
+    'Nie udało się ustalić popularnych albumów tego wykonawcy. Wypróbuj inną opcję monitorowania.',
   'discover.monitorNoneDescription': 'Dodaj bez monitorowania (tylko śledzenie)',
   'discover.discoveryRunStarted': 'Rozpoczęto wykrywanie.',
   'discover.exportFailed': 'Eksport nie powiódł się',

--- a/src/core/i18n/messages/pt-BR.ts
+++ b/src/core/i18n/messages/pt-BR.ts
@@ -282,6 +282,10 @@ export const ptBR = {
   'discover.monitorSelectedDescription': 'Escolha quais álbuns monitorar',
   'discover.monitorPopular': 'Álbuns populares',
   'discover.monitorPopularDescription': 'Monitorar os 3 lançamentos de álbum mais populares',
+  'discover.monitorPopularUnavailable':
+    'Conecte o Spotify ou o Last.fm para monitorar álbuns populares',
+  'discover.popularAlbumsFailed':
+    'Não foi possível determinar os álbuns populares deste artista. Tente outra opção de monitoramento.',
   'discover.monitorNoneDescription': 'Adicionar sem monitoramento (apenas rastreamento)',
   'discover.discoveryRunStarted': 'Execução de descoberta iniciada.',
   'discover.exportFailed': 'Falha na exportação',

--- a/src/core/i18n/messages/ro.ts
+++ b/src/core/i18n/messages/ro.ts
@@ -282,6 +282,10 @@ export const ro = {
   'discover.monitorSelectedDescription': 'Alege ce albume să monitorizezi',
   'discover.monitorPopular': 'Albume populare',
   'discover.monitorPopularDescription': 'Monitorizează cele mai populare 3 lansări de albume',
+  'discover.monitorPopularUnavailable':
+    'Conectează Spotify sau Last.fm pentru a monitoriza albumele populare',
+  'discover.popularAlbumsFailed':
+    'Nu s-au putut determina albumele populare pentru acest artist. Încearcă altă opțiune de monitorizare.',
   'discover.monitorNoneDescription': 'Adaugă fără monitorizare (doar urmărire)',
   'discover.discoveryRunStarted': 'Executarea descoperirii a început.',
   'discover.exportFailed': 'Exportul nu a reușit',

--- a/src/core/i18n/messages/ru.ts
+++ b/src/core/i18n/messages/ru.ts
@@ -282,6 +282,10 @@ export const ru = {
   'discover.monitorSelectedDescription': 'Выберите, какие альбомы отслеживать',
   'discover.monitorPopular': 'Популярные альбомы',
   'discover.monitorPopularDescription': 'Отслеживать 3 самых популярных альбомных релиза',
+  'discover.monitorPopularUnavailable':
+    'Подключите Spotify или Last.fm, чтобы отслеживать популярные альбомы',
+  'discover.popularAlbumsFailed':
+    'Не удалось определить популярные альбомы для этого исполнителя. Попробуйте другой вариант отслеживания.',
   'discover.monitorNoneDescription': 'Добавить без мониторинга (только отслеживание)',
   'discover.discoveryRunStarted': 'Запуск исследования начался.',
   'discover.exportFailed': 'Экспорт не удался',

--- a/src/core/i18n/messages/tr.ts
+++ b/src/core/i18n/messages/tr.ts
@@ -281,6 +281,10 @@ export const tr = {
   'discover.monitorSelectedDescription': 'Hangi albümlerin izleneceğini seç',
   'discover.monitorPopular': 'Popüler albümler',
   'discover.monitorPopularDescription': 'En popüler 3 albüm yayınını izle',
+  'discover.monitorPopularUnavailable':
+    'Popüler albümleri izlemek için Spotify veya Last.fm bağlayın',
+  'discover.popularAlbumsFailed':
+    'Bu sanatçı için popüler albümler belirlenemedi. Başka bir izleme seçeneği deneyin.',
   'discover.monitorNoneDescription': 'İzleme olmadan ekle (yalnızca takip)',
   'discover.discoveryRunStarted': 'Keşif çalıştırması başladı.',
   'discover.exportFailed': 'Dışa aktarma başarısız oldu',

--- a/src/core/i18n/messages/uk.ts
+++ b/src/core/i18n/messages/uk.ts
@@ -282,6 +282,10 @@ export const uk = {
   'discover.monitorSelectedDescription': 'Виберіть, які альбоми відстежувати',
   'discover.monitorPopular': 'Популярні альбоми',
   'discover.monitorPopularDescription': 'Відстежувати 3 найпопулярніші релізи альбомів',
+  'discover.monitorPopularUnavailable':
+    'Підключіть Spotify або Last.fm, щоб відстежувати популярні альбоми',
+  'discover.popularAlbumsFailed':
+    'Не вдалося визначити популярні альбоми для цього виконавця. Спробуйте інший варіант відстеження.',
   'discover.monitorNoneDescription': 'Додати без моніторингу (лише відстеження)',
   'discover.discoveryRunStarted': 'Запуск виявлення розпочато.',
   'discover.exportFailed': 'Помилка експорту',

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -268,6 +268,8 @@ export const zhCN = {
   'discover.monitorSelectedDescription': '选择要监控的专辑',
   'discover.monitorPopular': '热门专辑',
   'discover.monitorPopularDescription': '监控最热门的 3 张专辑发行',
+  'discover.monitorPopularUnavailable': '连接 Spotify 或 Last.fm 以监控热门专辑',
+  'discover.popularAlbumsFailed': '无法确定此艺人的热门专辑。请尝试其他监控选项。',
   'discover.monitorNoneDescription': '以不监控方式添加（仅跟踪）',
   'discover.discoveryRunStarted': '发现运行已开始。',
   'discover.exportFailed': '导出失败',

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -1,9 +1,11 @@
 import { type Context, Hono } from 'hono'
-import { selectPopularReleaseGroups } from '@/core/albums/popular'
+import { type PopularAlbumCandidate, selectPopularReleaseGroups } from '@/core/albums/popular'
+import { createLastFmClient } from '@/core/clients/lastfm'
 import { createMusicBrainzClient } from '@/core/clients/musicbrainz'
 import { createSpotifyClient } from '@/core/clients/spotify'
 import { recordFailureSafely } from '@/core/jobs/record-failure-safely'
 import { resolveSpotifyToken } from '@/core/spotify-auth'
+import { getUserConnections } from '@/db/queries/users'
 import { mergePreferences } from '@/db/schema'
 import type { AppDependencies } from '@/server'
 import { resolveUserPreferences } from '@/server/helpers/preferences'
@@ -95,6 +97,56 @@ function extractSpotifyArtistId(url?: string): string | null {
   return match?.[1] ? decodeURIComponent(match[1]) : null
 }
 
+/** Distinguishes "no popularity source available" from "source had no usable albums". */
+export type PopularAlbumsErrorCode = 'no_source' | 'no_match'
+
+export class PopularAlbumsError extends Error {
+  constructor(
+    readonly code: PopularAlbumsErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'PopularAlbumsError'
+  }
+}
+
+/** Top albums by Spotify popularity; empty when Spotify is unavailable for this user/artist. */
+async function spotifyPopularCandidates(
+  deps: AppDependencies,
+  userId: number,
+  artist: ApprovalArtist,
+): Promise<PopularAlbumCandidate[]> {
+  try {
+    const accessToken = await resolveSpotifyToken(deps.db, userId)
+    const spotify = createSpotifyClient(accessToken)
+    const spotifyId =
+      extractSpotifyArtistId(artist.streamingUrls?.spotify) ??
+      (await spotify.findExactArtistByName(artist.name))?.id
+    if (!spotifyId) return []
+    return await spotify.getPopularAlbumsForArtist(spotifyId, POPULAR_ALBUM_LIMIT)
+  } catch {
+    // Spotify not connected, token expired, or lookup failed: let the next source try.
+    return []
+  }
+}
+
+/** Top albums by Last.fm global playcount; empty when no Last.fm API key is configured. */
+async function lastfmPopularCandidates(
+  deps: AppDependencies,
+  userId: number,
+  artist: ApprovalArtist,
+): Promise<PopularAlbumCandidate[]> {
+  try {
+    const connections = await getUserConnections(deps.db, userId)
+    if (!connections?.lastfmApiKey) return []
+    // Username is unused by artist.getTopAlbums (API-key only); fall back to empty.
+    const client = createLastFmClient(connections.lastfmUsername ?? '', connections.lastfmApiKey)
+    return await client.getTopAlbumsForArtist(artist.name, artist.mbid)
+  } catch {
+    return []
+  }
+}
+
 async function resolvePopularAlbumIds(
   deps: AppDependencies,
   userId: number | undefined,
@@ -107,23 +159,28 @@ async function resolvePopularAlbumIds(
     throw new Error('Popular album approval requires artist metadata')
   }
 
-  const accessToken = await resolveSpotifyToken(deps.db, userId)
-  const spotify = createSpotifyClient(accessToken)
-  const spotifyId =
-    extractSpotifyArtistId(artist.streamingUrls?.spotify) ??
-    (await spotify.findExactArtistByName(artist.name))?.id
+  // MB release groups are the matching target for whichever popularity source wins.
+  const releaseGroups = await createMusicBrainzClient().getReleaseGroups(artist.mbid)
 
-  if (!spotifyId) {
-    throw new Error(`Could not resolve Spotify artist for ${artist.name}`)
+  // Spotify gives normalized popularity; Last.fm gives global playcount. Never
+  // blend the two scales in one list - take the first source that returns albums.
+  let candidates = await spotifyPopularCandidates(deps, userId, artist)
+  if (candidates.length === 0) {
+    candidates = await lastfmPopularCandidates(deps, userId, artist)
+  }
+  if (candidates.length === 0) {
+    throw new PopularAlbumsError(
+      'no_source',
+      `No popularity source returned albums for ${artist.name}. Connect Spotify or Last.fm.`,
+    )
   }
 
-  const [spotifyAlbums, releaseGroups] = await Promise.all([
-    spotify.getPopularAlbumsForArtist(spotifyId, POPULAR_ALBUM_LIMIT),
-    createMusicBrainzClient().getReleaseGroups(artist.mbid),
-  ])
-  const selected = selectPopularReleaseGroups(spotifyAlbums, releaseGroups, POPULAR_ALBUM_LIMIT)
+  const selected = selectPopularReleaseGroups(candidates, releaseGroups, POPULAR_ALBUM_LIMIT)
   if (selected.length === 0) {
-    throw new Error(`Could not map popular Spotify albums to Lidarr albums for ${artist.name}`)
+    throw new PopularAlbumsError(
+      'no_match',
+      `Could not map popular albums to library albums for ${artist.name}.`,
+    )
   }
 
   return selected.map((album) => album.id)
@@ -500,6 +557,22 @@ export function recommendationRoutes(deps: AppDependencies) {
     return c.json({ summary })
   })
 
+  // Backs the approve menu's "Popular albums" gating: true when at least one
+  // popularity source (Spotify OAuth or a Last.fm API key) is available.
+  router.get('/api/v1/recommendations/popular-albums/availability', async (c) => {
+    const userId = c.get('userId')
+    if (!userId) return c.json({ available: false, spotify: false, lastfm: false })
+    const [spotify, connections] = await Promise.all([
+      resolveSpotifyToken(deps.db, userId).then(
+        () => true,
+        () => false,
+      ),
+      getUserConnections(deps.db, userId),
+    ])
+    const lastfm = Boolean(connections?.lastfmApiKey)
+    return c.json({ available: spotify || lastfm, spotify, lastfm })
+  })
+
   router.get('/api/v1/recommendations/:id', zParam(recommendationIdParamSchema), async (c) => {
     const { id } = c.req.valid('param')
     const loaded = await loadOwnedRecommendation(c, id)
@@ -615,7 +688,10 @@ export function recommendationRoutes(deps: AppDependencies) {
         } catch (err) {
           if (monitorOption !== 'popular') throw err
           return c.json(
-            { error: err instanceof Error ? err.message : 'Popular albums could not be resolved' },
+            {
+              error: err instanceof Error ? err.message : 'Popular albums could not be resolved',
+              code: err instanceof PopularAlbumsError ? err.code : undefined,
+            },
             400,
           )
         }

--- a/src/web/components/monitoring-options.tsx
+++ b/src/web/components/monitoring-options.tsx
@@ -9,12 +9,25 @@ type Props = {
   onOpenAlbumPicker: () => void
   loading?: boolean
   fill?: boolean
+  /** When false, the "Popular albums" option is disabled (no Spotify/Last.fm source). */
+  popularAvailable?: boolean
 }
 
-export function MonitoringOptions({ onApprove, onOpenAlbumPicker, loading, fill }: Props) {
+export function MonitoringOptions({
+  onApprove,
+  onOpenAlbumPicker,
+  loading,
+  fill,
+  popularAvailable = true,
+}: Props) {
   const { t } = useI18n()
   const [open, setOpen] = useState(false)
-  const options: Array<{ value: MonitorOption; label: string; description: string }> = [
+  const options: Array<{
+    value: MonitorOption
+    label: string
+    description: string
+    disabled?: boolean
+  }> = [
     {
       value: 'all',
       label: t('settings.monitorAll'),
@@ -33,7 +46,10 @@ export function MonitoringOptions({ onApprove, onOpenAlbumPicker, loading, fill 
     {
       value: 'popular',
       label: t('discover.monitorPopular'),
-      description: t('discover.monitorPopularDescription'),
+      description: popularAvailable
+        ? t('discover.monitorPopularDescription')
+        : t('discover.monitorPopularUnavailable'),
+      disabled: !popularAvailable,
     },
     {
       value: 'none',
@@ -111,11 +127,14 @@ export function MonitoringOptions({ onApprove, onOpenAlbumPicker, loading, fill 
               <button
                 key={opt.value}
                 type="button"
+                disabled={opt.disabled}
+                title={opt.disabled ? opt.description : undefined}
                 onClick={(e) => {
                   e.stopPropagation()
+                  if (opt.disabled) return
                   handleOptionClick(opt.value)
                 }}
-                className="w-full text-left px-3 py-2 hover:bg-bg/50 transition-colors"
+                className="w-full text-left px-3 py-2 transition-colors enabled:hover:bg-bg/50 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <div className="text-sm text-text font-medium">{opt.label}</div>
                 <div className="text-xs text-muted mt-0.5">{opt.description}</div>

--- a/src/web/components/todays-pick.tsx
+++ b/src/web/components/todays-pick.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Sparkles } from 'lucide-react'
 import { Fragment, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useClickOutside } from '../hooks/use-click-outside'
+import { usePopularAlbumsAvailability } from '../hooks/use-popular-albums-availability'
 import { getAlbums } from '../lib/api'
 import { useI18n } from '../lib/i18n'
 import { hueFromName } from '../lib/utils'
@@ -66,6 +67,7 @@ export function TodaysPick({
   const standaloneApproveTarget = actionableTargets.length === 1 ? actionableTargets[0] : undefined
 
   useClickOutside(dropdownRef, () => setDropdownOpen(false), dropdownOpen)
+  const popularAvailable = usePopularAlbumsAvailability()
 
   const { data: albumData } = useQuery({
     queryKey: ['todays-pick-albums', rec?.artist.mbid],
@@ -320,6 +322,7 @@ export function TodaysPick({
               ) : (
                 <MonitoringOptions
                   fill
+                  popularAvailable={popularAvailable}
                   onApprove={(option) => onApproveWithOption(rec.id, option)}
                   onOpenAlbumPicker={() => onOpenAlbumPicker(rec.id)}
                 />

--- a/src/web/hooks/use-popular-albums-availability.ts
+++ b/src/web/hooks/use-popular-albums-availability.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+import { getPopularAlbumsAvailability } from '../lib/api'
+
+/**
+ * True when at least one popularity source (Spotify OAuth or a Last.fm API key)
+ * is connected, so the approve menu can gate the "Popular albums" option.
+ * Defaults to enabled while loading; the backend still validates on approve.
+ */
+export function usePopularAlbumsAvailability(): boolean {
+  const { data } = useQuery({
+    queryKey: ['popular-albums-availability'],
+    queryFn: getPopularAlbumsAvailability,
+    staleTime: 5 * 60 * 1000,
+  })
+  return data?.available ?? true
+}

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -793,6 +793,14 @@ export async function getOAuthStatus(
   return fetchApi(`/auth/oauth/${provider}/status`)
 }
 
+export async function getPopularAlbumsAvailability(): Promise<{
+  available: boolean
+  spotify: boolean
+  lastfm: boolean
+}> {
+  return fetchApi('/recommendations/popular-albums/availability')
+}
+
 // Subscriptions
 export type Subscription = {
   id: number

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -3,6 +3,7 @@ import { Download, Filter as FilterIcon, MoreHorizontal, RefreshCw, Trash2 } fro
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
+import type { MessageKey } from '@/core/i18n/messages/types'
 import type { RejectionReason } from '@/core/recommendations/rejection-reasons'
 import { errMsg } from '@/core/validation'
 import { AlbumPicker } from '../components/album-picker'
@@ -19,8 +20,10 @@ import { canApproveArtistToTarget, resolveApprovalTargetOptions } from '../compo
 import { Skeleton } from '../components/ui/skeleton'
 import { useClickOutside } from '../hooks/use-click-outside'
 import { useKeyboardShortcuts } from '../hooks/use-keyboard-shortcuts'
+import { usePopularAlbumsAvailability } from '../hooks/use-popular-albums-availability'
 import { usePullToRefresh } from '../hooks/use-pull-to-refresh'
 import {
+  ApiError,
   approveRecommendation,
   approveToTarget,
   bulkAction,
@@ -80,6 +83,16 @@ const APPROVE_THRESHOLD_OPTIONS = [50, 60, 70, 80, 90]
 
 const PAGE_SIZE = 50
 const CLEAR_ALL_BATCH_SIZE = 200
+
+/** Surfaces why a "Popular albums" approval failed, falling back to a generic message. */
+function approveErrorMessage(
+  err: unknown,
+  fallback: string,
+  t: (key: MessageKey) => string,
+): string {
+  const code = err instanceof ApiError ? (err.data as { code?: string })?.code : undefined
+  return code === 'no_source' || code === 'no_match' ? t('discover.popularAlbumsFailed') : fallback
+}
 
 function SkeletonGrid() {
   return (
@@ -467,6 +480,7 @@ function MoreMenu({
 export function DiscoverPage() {
   const { t } = useI18n()
   const queryClient = useQueryClient()
+  const popularAvailable = usePopularAlbumsAvailability()
   const [searchParams, setSearchParams] = useSearchParams()
   const [filter, setFilter] = useState<FilterTab>('pending')
   const [kindFilter, setKindFilter] = useState<KindFilter>(() =>
@@ -712,8 +726,8 @@ export function DiscoverPage() {
         })
         if (reportApprovalOutcome(res, t)) showUndo({ id, prevStatus })
         refetch()
-      } catch {
-        toast.error(t('dashboard.approveFailed'))
+      } catch (err) {
+        toast.error(approveErrorMessage(err, t('dashboard.approveFailed'), t))
       } finally {
         setActingIds((prev) => {
           const next = new Set(prev)
@@ -1323,6 +1337,7 @@ export function DiscoverPage() {
                           !hasStandaloneSlskdTarget ? (
                             <MonitoringOptions
                               loading={isActing}
+                              popularAvailable={popularAvailable}
                               onApprove={(option) =>
                                 handleApproveWithOptions(rec.id, option, undefined, rec.status)
                               }
@@ -1385,6 +1400,7 @@ export function DiscoverPage() {
                         !hasStandaloneSlskdTarget ? (
                           <MonitoringOptions
                             loading={isActing}
+                            popularAvailable={popularAvailable}
                             onApprove={(option) =>
                               handleApproveWithOptions(rec.id, option, undefined, rec.status)
                             }
@@ -1561,8 +1577,8 @@ export function DiscoverPage() {
               }
               if (reportApprovalOutcome(res, t)) toast.success(t('dashboard.addedToLidarr'))
               refetch()
-            } catch {
-              toast.error(t('dashboard.addToLidarrFailed'))
+            } catch (err) {
+              toast.error(approveErrorMessage(err, t('dashboard.addToLidarrFailed'), t))
             } finally {
               setActingIds((prev) => {
                 const next = new Set(prev)

--- a/tests/core/clients/lastfm.test.ts
+++ b/tests/core/clients/lastfm.test.ts
@@ -300,4 +300,61 @@ describe('createLastFmClient', () => {
       expect(result).toHaveProperty('message')
     })
   })
+
+  describe('getTopAlbumsForArtist(artist, mbid, limit)', () => {
+    it('GETs artist.getTopAlbums with api_key and maps playcount to popularity', async () => {
+      mockGet.mockResolvedValueOnce({
+        topalbums: {
+          album: [
+            { name: 'OK Computer', playcount: 12345, mbid: 'okc-mbid' },
+            { name: 'Kid A', playcount: 9876, mbid: '' },
+          ],
+        },
+      })
+      const client = createLastFmClient(TEST_USERNAME, TEST_API_KEY)
+      const result = await client.getTopAlbumsForArtist('Radiohead')
+
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('method=artist.getTopAlbums'))
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('artist=Radiohead'))
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining(`api_key=${TEST_API_KEY}`))
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({ title: 'OK Computer', popularity: 12345, mbid: 'okc-mbid' })
+      expect(result[1]).toEqual({ title: 'Kid A', popularity: 9876, mbid: undefined })
+    })
+
+    it('passes mbid when provided (prefers it over name)', async () => {
+      mockGet.mockResolvedValueOnce({ topalbums: { album: [] } })
+      const client = createLastFmClient(TEST_USERNAME, TEST_API_KEY)
+      await client.getTopAlbumsForArtist('Radiohead', 'a74b1b7f-71a5-4011-9441-d0b5e4122711')
+      expect(mockGet).toHaveBeenCalledWith(
+        expect.stringContaining('mbid=a74b1b7f-71a5-4011-9441-d0b5e4122711'),
+      )
+    })
+
+    it('uses a default limit and accepts a custom one', async () => {
+      mockGet.mockResolvedValueOnce({ topalbums: { album: [] } })
+      const client = createLastFmClient(TEST_USERNAME, TEST_API_KEY)
+      await client.getTopAlbumsForArtist('Radiohead', undefined, 10)
+      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('limit=10'))
+    })
+
+    it('parses string playcounts and tolerates missing values', async () => {
+      mockGet.mockResolvedValueOnce({
+        topalbums: {
+          album: [{ name: 'Amnesiac', playcount: '4567', mbid: 'amn-mbid' }, { name: 'The Bends' }],
+        },
+      })
+      const client = createLastFmClient(TEST_USERNAME, TEST_API_KEY)
+      const result = await client.getTopAlbumsForArtist('Radiohead')
+      expect(result[0]).toEqual({ title: 'Amnesiac', popularity: 4567, mbid: 'amn-mbid' })
+      expect(result[1]).toEqual({ title: 'The Bends', popularity: 0, mbid: undefined })
+    })
+
+    it('returns empty array when topalbums is missing', async () => {
+      mockGet.mockResolvedValueOnce({})
+      const client = createLastFmClient(TEST_USERNAME, TEST_API_KEY)
+      const result = await client.getTopAlbumsForArtist('UnknownBand')
+      expect(result).toEqual([])
+    })
+  })
 })

--- a/tests/core/plugins/lastfm.test.ts
+++ b/tests/core/plugins/lastfm.test.ts
@@ -26,6 +26,7 @@ describe('createLastFmSource()', () => {
         { name: 'Portishead', mbid: 'mbid-pt', listeners: 1200000 },
         { name: 'Massive Attack', mbid: 'mbid-ma', listeners: 980000 },
       ]),
+      getTopAlbumsForArtist: vi.fn().mockResolvedValue([]),
       getChartTopArtists: vi.fn().mockResolvedValue([]),
     }
     vi.mocked(createLastFmClient).mockReturnValue(client)

--- a/tests/server/routes/recommendations.test.ts
+++ b/tests/server/routes/recommendations.test.ts
@@ -19,6 +19,15 @@ vi.mock('@/core/clients/spotify', () => ({
   createSpotifyClient: vi.fn(),
 }))
 
+vi.mock('@/core/clients/lastfm', () => ({
+  createLastFmClient: vi.fn(),
+}))
+
+vi.mock('@/db/queries/users', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/db/queries/users')>()),
+  getUserConnections: vi.fn(async () => null),
+}))
+
 vi.mock('@/core/clients/musicbrainz', () => ({
   createMusicBrainzClient: vi.fn(() => ({
     getReleaseGroups: vi.fn(async () => [
@@ -39,8 +48,10 @@ vi.mock('@/core/sessions', () => ({
   setSessionStore: vi.fn(),
 }))
 
+import { createLastFmClient } from '@/core/clients/lastfm'
 import { createLidarrClient } from '@/core/clients/lidarr'
 import { createSpotifyClient } from '@/core/clients/spotify'
+import { getUserConnections } from '@/db/queries/users'
 
 function makeMockOrchestrator() {
   const emitter = new EventEmitter()
@@ -615,6 +626,91 @@ describe('PATCH /api/v1/recommendations/:id', () => {
         selectedAlbumIds: ['rg-third', 'rg-dummy', 'rg-portishead'],
       }),
     )
+  })
+
+  it('falls back to Last.fm top albums when Spotify returns none', async () => {
+    vi.mocked(createSpotifyClient).mockReturnValue({
+      findExactArtistByName: vi.fn(async () => null),
+      getPopularAlbumsForArtist: vi.fn(async () => []),
+    } as unknown as ReturnType<typeof createSpotifyClient>)
+    vi.mocked(getUserConnections).mockResolvedValueOnce({
+      lastfmUsername: 'listener',
+      lastfmApiKey: 'lfm-key',
+    } as Awaited<ReturnType<typeof getUserConnections>>)
+    vi.mocked(createLastFmClient).mockReturnValue({
+      getTopAlbumsForArtist: vi.fn(async () => [
+        { title: 'Third', popularity: 50000, mbid: 'lfm-third' },
+        { title: 'Dummy', popularity: 42000, mbid: 'lfm-dummy' },
+      ]),
+    } as unknown as ReturnType<typeof createLastFmClient>)
+
+    const mockAddArtist = vi.fn().mockResolvedValue({
+      success: true,
+      targetType: 'lidarr',
+      targetId: 1,
+      externalId: 99,
+    })
+    const app = createApp(
+      makeDeps({
+        getEnabledTargetsForUser: vi.fn().mockResolvedValue([
+          {
+            id: 'lidarr-1',
+            name: 'Lidarr',
+            type: 'lidarr',
+            capabilities: ['addArtist'],
+            addArtist: mockAddArtist,
+            testConnection: vi.fn(),
+          },
+        ]),
+      }),
+    )
+
+    const res = await authedRequest(app, '/api/v1/recommendations/1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-token' },
+      body: JSON.stringify({ status: 'approved', monitorOption: 'popular' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockAddArtist).toHaveBeenCalledWith(
+      { mbid: 'mbid-abc-123', name: 'Test Artist' },
+      expect.objectContaining({
+        monitorOption: 'selected',
+        selectedAlbumIds: ['rg-third', 'rg-dummy'],
+      }),
+    )
+  })
+
+  it('returns 400 with code no_source when no popularity source has albums', async () => {
+    vi.mocked(createSpotifyClient).mockReturnValue({
+      findExactArtistByName: vi.fn(async () => null),
+      getPopularAlbumsForArtist: vi.fn(async () => []),
+    } as unknown as ReturnType<typeof createSpotifyClient>)
+    vi.mocked(getUserConnections).mockResolvedValueOnce(null)
+
+    const app = createApp(
+      makeDeps({
+        getEnabledTargetsForUser: vi.fn().mockResolvedValue([
+          {
+            id: 'lidarr-1',
+            name: 'Lidarr',
+            type: 'lidarr',
+            capabilities: ['addArtist'],
+            addArtist: vi.fn(),
+            testConnection: vi.fn(),
+          },
+        ]),
+      }),
+    )
+
+    const res = await authedRequest(app, '/api/v1/recommendations/1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-token' },
+      body: JSON.stringify({ status: 'approved', monitorOption: 'popular' }),
+    })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ code: 'no_source' })
   })
 
   it('returns 400 when targetId does not match an enabled target', async () => {

--- a/tests/web/components/monitoring-options.test.tsx
+++ b/tests/web/components/monitoring-options.test.tsx
@@ -34,4 +34,34 @@ describe('MonitoringOptions', () => {
     expect(screen.getByText('Nessuno')).toBeInTheDocument()
     expect(screen.getByText('Aggiungi senza monitoraggio (solo tracciamento)')).toBeInTheDocument()
   })
+
+  it('keeps all options enabled when popularAvailable defaults to true', () => {
+    render(
+      <I18nProvider>
+        <MonitoringOptions onApprove={vi.fn()} onOpenAlbumPicker={vi.fn()} />
+      </I18nProvider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Opzioni di monitoraggio' }))
+    const disabled = screen.getAllByRole('button').filter((b) => (b as HTMLButtonElement).disabled)
+    expect(disabled).toHaveLength(0)
+  })
+
+  it('disables the Popular option and ignores clicks when popularAvailable is false', () => {
+    const onApprove = vi.fn()
+    render(
+      <I18nProvider>
+        <MonitoringOptions
+          onApprove={onApprove}
+          onOpenAlbumPicker={vi.fn()}
+          popularAvailable={false}
+        />
+      </I18nProvider>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Opzioni di monitoraggio' }))
+    const disabled = screen.getAllByRole('button').filter((b) => (b as HTMLButtonElement).disabled)
+    expect(disabled).toHaveLength(1)
+    // biome-ignore lint/style/noNonNullAssertion: length asserted above
+    fireEvent.click(disabled[0]!)
+    expect(onApprove).not.toHaveBeenCalled()
+  })
 })

--- a/tests/web/pages/dashboard-listening-empty-state.test.tsx
+++ b/tests/web/pages/dashboard-listening-empty-state.test.tsx
@@ -47,6 +47,9 @@ vi.mock('@/web/lib/api', () => ({
   updateRecommendation: vi.fn(),
   approveRecommendation: vi.fn().mockResolvedValue({}),
   approveToTarget: vi.fn().mockResolvedValue({}),
+  getPopularAlbumsAvailability: vi
+    .fn()
+    .mockResolvedValue({ available: true, spotify: true, lastfm: false }),
   listTargets: vi.fn().mockResolvedValue([]),
   getTopArtists: vi.fn(async () => ({
     tracks: [],

--- a/tests/web/pages/dashboard.test.tsx
+++ b/tests/web/pages/dashboard.test.tsx
@@ -45,6 +45,9 @@ vi.mock('@/web/lib/api', () => ({
   approveRecommendation: vi.fn().mockResolvedValue({}),
   approveToTarget: vi.fn().mockResolvedValue({}),
   getPopularAlbums: vi.fn(),
+  getPopularAlbumsAvailability: vi
+    .fn()
+    .mockResolvedValue({ available: true, spotify: true, lastfm: false }),
   deletePlaylistApi: vi.fn(),
   generatePlaylistApi: vi.fn(),
   listTargets: vi.fn().mockResolvedValue([]),

--- a/tests/web/pages/discover.test.tsx
+++ b/tests/web/pages/discover.test.tsx
@@ -46,6 +46,17 @@ vi.mock('@/web/lib/api', () => ({
   bulkAction: vi.fn(),
   getWarmStatuses: vi.fn(),
   getPopularAlbums: vi.fn(),
+  getPopularAlbumsAvailability: vi
+    .fn()
+    .mockResolvedValue({ available: true, spotify: true, lastfm: false }),
+  ApiError: class ApiError extends Error {
+    constructor(
+      public status: number,
+      public data: unknown,
+    ) {
+      super('ApiError')
+    }
+  },
   rescanArtists: vi.fn(),
   triggerPipeline: vi.fn(),
   listTargets: vi.fn().mockResolvedValue([]),

--- a/tests/web/pages/settings.test.tsx
+++ b/tests/web/pages/settings.test.tsx
@@ -38,6 +38,9 @@ function renderWithQuery(ui: ReactElement) {
 vi.mock('@/web/lib/api', () => ({
   getSettings: vi.fn(),
   updateSettings: vi.fn(),
+  getPopularAlbumsAvailability: vi
+    .fn()
+    .mockResolvedValue({ available: true, spotify: true, lastfm: false }),
   testService: vi.fn(),
   getAuthStatus: vi.fn(),
   getLidarrProfiles: vi.fn(),


### PR DESCRIPTION
Closes #321.

## Problem
"Popular albums" monitoring depended solely on the Spotify API. When Spotify was not connected or could not resolve the artist, approval failed with a generic, opaque error (the issue mislabeled this as a Premium requirement; the Spotify Web API albums endpoint needs no Premium).

## Changes
**Backend**
- `lastfm` client: `getTopAlbumsForArtist` (`artist.getTopAlbums`), mapping global playcount to the `popularity` field `selectPopularReleaseGroups` already expects.
- `resolvePopularAlbumIds`: Spotify -> Last.fm -> typed `PopularAlbumsError` (`no_source` / `no_match`), surfaced as a `400 {error, code}`. The two sources are never blended (different popularity scales).
- New non-admin `GET /recommendations/popular-albums/availability` reporting whether a popularity source is connected.

**Frontend**
- `MonitoringOptions` gains `popularAvailable`; the "Popular albums" option is disabled with a tooltip when no source is connected. Wired into discover + today's pick via a `usePopularAlbumsAvailability` hook.
- Approve flows translate the backend error `code` instead of a generic toast.
- Two new i18n keys added across all 16 locales (native translations, i18n-check clean).

## Verification
- `typecheck`: clean
- `lint`: exit 0
- `i18n-check`: 15 locales validated, no orphans/ASCII markers
- `test`: 2518 passed / 0 failed (9 new tests: lastfm method, fallback ordering, no-source 400, menu gating)