### PR TITLE
fix(setup): surface backend error in the setup wizard instead of a generic toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Releases that have been promoted to the `:stable` Docker channel carry a `(stabl
 ### Fixed
 
 - **Approving an artist with selected albums now actually monitors and downloads those albums.** When you approved an artist but picked only specific albums, Digarr added the artist to Lidarr unmonitored and then tried to monitor the chosen albums immediately -- but Lidarr populates an artist's album list asynchronously, so that lookup usually ran before the albums existed and silently monitored nothing. The album never got grabbed, and the approval still reported success. Digarr now polls Lidarr until the selected albums appear, monitors them, and triggers an album search so they download. If an album genuinely never shows up, the approval now fails loudly with a clear message instead of reporting a false success. The job record also captures the monitor mode and selected album IDs so the case is debuggable from the job list.
+- **The setup wizard now tells you why it failed.** When the initial setup submission was rejected by the backend (a missing or invalid field, a validation error, or a setup-already-complete conflict), the wizard showed a single generic "Setup failed" toast and discarded the actual reason, leaving new users stuck with nothing to act on. The wizard now surfaces the backend's specific error message -- including the list of missing fields when applicable -- so the problem is fixable without reading server logs.
 
 ## v1.10.0 - 2026-06-24
 

--- a/src/web/pages/setup.tsx
+++ b/src/web/pages/setup.tsx
@@ -6,7 +6,7 @@ import { LanguageSwitcher } from '../components/language-switcher'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Select } from '../components/ui/select'
-import { completeSetup } from '../lib/api'
+import { ApiError, completeSetup } from '../lib/api'
 import { useI18n } from '../lib/i18n'
 
 type FormState = {
@@ -478,8 +478,16 @@ export function SetupWizard({ onComplete }: { onComplete: () => void }) {
     try {
       await completeSetup(config)
       onComplete()
-    } catch {
-      toast.error(t('setup.failed'))
+    } catch (err) {
+      // Surface the backend's reason (missing field, validation, conflict)
+      // instead of an opaque generic toast. ApiError.message already carries
+      // the translated/server message; the missing-fields list adds detail.
+      if (err instanceof ApiError) {
+        const fields = (err.data as { fields?: string[] } | null)?.fields
+        toast.error(fields?.length ? `${err.message}: ${fields.join(', ')}` : err.message)
+      } else {
+        toast.error(t('setup.failed'))
+      }
       setStarting(false)
     }
   }

--- a/tests/web/pages/setup.test.tsx
+++ b/tests/web/pages/setup.test.tsx
@@ -13,6 +13,14 @@ vi.mock('@/web/lib/locale-storage', () => ({
 
 vi.mock('@/web/lib/api', () => ({
   completeSetup: vi.fn(),
+  ApiError: class ApiError extends Error {
+    constructor(
+      public status: number,
+      public data: unknown,
+    ) {
+      super('Missing required fields')
+    }
+  },
 }))
 
 vi.mock('sonner', () => ({
@@ -22,10 +30,14 @@ vi.mock('sonner', () => ({
   },
 }))
 
+import { toast } from 'sonner'
+import { ApiError, completeSetup } from '@/web/lib/api'
 import { getStoredLocale } from '@/web/lib/locale-storage'
 import { SetupWizard } from '@/web/pages/setup'
 
 const mockGetStoredLocale = vi.mocked(getStoredLocale)
+const mockCompleteSetup = vi.mocked(completeSetup)
+const mockToastError = vi.mocked(toast.error)
 
 describe('SetupWizard', () => {
   beforeEach(() => {
@@ -143,6 +155,24 @@ describe('SetupWizard', () => {
     await screen.findByText('Fournisseur IA')
     expect(screen.getByText('Haiku 4.5 (rapide, le moins cher)')).toBeInTheDocument()
     expect(screen.getByText('Sonnet 4.6 (équilibré)')).toBeInTheDocument()
+  })
+
+  it('surfaces the backend error (and missing fields) when setup completion fails', async () => {
+    mockCompleteSetup.mockRejectedValueOnce(
+      new ApiError(400, { error: 'Missing required fields', fields: ['aiModel'] }),
+    )
+    renderSetupWizard()
+
+    fireEvent.click(screen.getByRole('button', { name: /Just discover/i }))
+    await screen.findByText('AI Provider')
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'test-model' } })
+    fireEvent.change(screen.getByLabelText('API Key'), { target: { value: 'secret-key' } })
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }))
+
+    fireEvent.click(await screen.findByRole('button', { name: /Start Digging/i }))
+
+    await vi.waitFor(() => expect(mockToastError).toHaveBeenCalled())
+    expect(mockToastError).toHaveBeenCalledWith('Missing required fields: aiModel')
   })
 
   it('uses a translated fallback model placeholder in French for openai-compatible', async () => {


### PR DESCRIPTION
Closes #330.

## Problem

The setup wizard caught completion failures with a bare `catch {}` and showed a single static `setup.failed` toast, discarding the backend's actual reason. New users reported being stuck on onboarding with no actionable detail. The backend already returns structured errors (`{error, fields}` 400s, zod validation, 409 conflict) that never reached the user.

## Fix

`src/web/pages/setup.tsx`: when the failure is an `ApiError`, surface `ApiError.message` (which already extracts the server/translated message) plus the `fields` list when present. Non-`ApiError` failures (e.g. network) still fall back to the generic `setup.failed` string, so i18n coverage is unchanged and no new locale keys are needed.

## Tests

`tests/web/pages/setup.test.tsx`: new test drives discover-mode setup to the final step, makes `completeSetup` reject with `ApiError(400, {error, fields})`, and asserts the toast shows `"Missing required fields: aiModel"`. 10/10 pass; typecheck + lint clean.

## Note

Both this PR and #331 add a `### Fixed` block to the same CHANGELOG spot. Merge #331 first, then I'll rebase this branch so the changelog merges cleanly.