### PR TITLE
Phase 0 release blockers: Lidarr orphan, pipeline contract, migration tests

### DIFF
--- a/src/core/targets/lidarr.ts
+++ b/src/core/targets/lidarr.ts
@@ -67,22 +67,30 @@ export function createLidarrTarget(
 
         // Monitor (and search) the selected albums after the add. The artist
         // was added unmonitored, so without this the selected album is never
-        // grabbed.
+        // grabbed. This step is best-effort: the artist add already succeeded,
+        // so a monitoring failure must NOT fail the result (that would drop the
+        // Lidarr artist id and orphan the artist -> a retry re-adds a duplicate).
+        // Partial/failed monitoring surfaces as a warning instead.
+        let warning: string | undefined
         if (options?.monitorOption === 'selected' && options.selectedAlbumIds?.length && added.id) {
-          const matched = await findSelectedAlbums(added.id, options.selectedAlbumIds)
+          const wanted = options.selectedAlbumIds
+          const matched = await findSelectedAlbums(added.id, wanted)
           if (matched.length === 0) {
-            return {
-              success: false,
-              targetType: 'lidarr',
-              targetId,
-              externalId: added.id,
-              error: 'artist added, but the selected album was not found in Lidarr',
+            warning =
+              'artist added, but the selected album was not found in Lidarr (it may still be populating; retry to finish monitoring)'
+          } else {
+            try {
+              for (const album of matched) {
+                await client.updateAlbum(album.id, { monitored: true })
+              }
+              await client.triggerCommand('AlbumSearch', { albumIds: matched.map((a) => a.id) })
+              if (matched.length < wanted.length) {
+                warning = `artist added; ${matched.length} of ${wanted.length} selected albums monitored, the rest were not found in Lidarr`
+              }
+            } catch (monErr: unknown) {
+              warning = `artist added, but monitoring the selected album failed: ${errMsg(monErr)}`
             }
           }
-          for (const album of matched) {
-            await client.updateAlbum(album.id, { monitored: true })
-          }
-          await client.triggerCommand('AlbumSearch', { albumIds: matched.map((a) => a.id) })
         }
 
         return {
@@ -90,6 +98,7 @@ export function createLidarrTarget(
           targetType: 'lidarr',
           targetId,
           externalId: added.id,
+          ...(warning ? { warning } : {}),
         }
       } catch (err: unknown) {
         return {

--- a/src/core/targets/types.ts
+++ b/src/core/targets/types.ts
@@ -31,6 +31,8 @@ export type TargetResult = {
   targetId: number
   externalId?: number | string
   error?: string
+  /** Non-fatal partial-failure note (e.g. artist added but album monitoring did not complete). */
+  warning?: string
 }
 
 export type PlaylistItem = {

--- a/src/server/routes/pipeline.ts
+++ b/src/server/routes/pipeline.ts
@@ -113,11 +113,20 @@ export function pipelineRoutes(deps: AppDependencies) {
       promptLocale: null,
     } as unknown as PipelineDeps)
 
-    const queued = enqueued.status !== 'started'
+    // Surface the real enqueue outcome. A same-user re-submit during an
+    // in-flight run is a no-op 'duplicate' and must not masquerade as a fresh
+    // 'queued' run at position 0.
+    const message =
+      enqueued.status === 'started'
+        ? 'Pipeline started'
+        : enqueued.status === 'duplicate'
+          ? 'Pipeline already running'
+          : 'Pipeline queued'
     return c.json(
       {
-        message: queued ? 'Pipeline queued' : 'Pipeline started',
-        queued,
+        message,
+        status: enqueued.status,
+        queued: enqueued.status === 'queued',
         position: enqueued.position,
       },
       202,

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -31,13 +31,14 @@ type ApproveResult = {
   lidarrError?: string
 }
 
-type TargetActionRecord = { status?: string; error?: string } | null
+type TargetActionRecord = { status?: string; error?: string; warning?: string } | null
 
 type TargetSummary = {
   total: number
   succeeded: number
   failed: number
   failures: Array<{ id: string; name: string; error?: string }>
+  warnings: string[]
 }
 
 const isTargetSuccess = (action: TargetActionRecord): boolean =>
@@ -50,15 +51,17 @@ function summarizeTargetActions(
 ): TargetSummary {
   const entries = Object.entries(targetActions) as [string, TargetActionRecord][]
   const failures: TargetSummary['failures'] = []
+  const warnings: string[] = []
   let succeeded = 0
   for (const [id, action] of entries) {
     if (isTargetSuccess(action)) {
       succeeded++
+      if (action?.warning) warnings.push(action.warning)
     } else {
       failures.push({ id, name: targetsById.get(id)?.name ?? id, error: action?.error })
     }
   }
-  return { total: entries.length, succeeded, failed: failures.length, failures }
+  return { total: entries.length, succeeded, failed: failures.length, failures, warnings }
 }
 
 /**
@@ -191,6 +194,7 @@ type TargetExecutionResult = {
     status: TargetActionStatus
     externalId?: number | string
     error?: string
+    warning?: string
   }
   success: boolean
   lidarrArtistId?: number | string
@@ -251,6 +255,7 @@ async function addArtistToTarget(
       status: result.success ? (target.type === 'slskd' ? 'queued' : 'added') : 'failed',
       externalId: result.externalId,
       error: result.error,
+      ...(result.warning ? { warning: result.warning } : {}),
     },
     success: result.success,
     lidarrArtistId: target.type === 'lidarr' && result.success ? result.externalId : undefined,

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -573,14 +573,15 @@ function AppShell({ children }: { children: React.ReactNode }) {
                   triggerPipeline()
                     .then((res) =>
                       toast.success(
-                        res.queued
-                          ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
-                          : t('discover.scanStarted'),
+                        res.status === 'duplicate'
+                          ? t('discover.scanAlreadyRunning')
+                          : res.queued
+                            ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
+                            : t('discover.scanStarted'),
                       ),
                     )
                     .catch((err) => {
-                      const msg = errMsg(err)
-                      toast.error(msg.includes('409') ? t('discover.scanAlreadyRunning') : msg)
+                      toast.error(errMsg(err))
                     })
                 }
                 className="flex min-h-11 items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-sm font-medium text-accent-fg hover:opacity-90 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2 disabled:opacity-60 sm:min-h-9 sm:px-4"

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -240,6 +240,7 @@ export type ApprovalTargetSummary = {
   succeeded: number
   failed: number
   failures: Array<{ id: string; name: string; error?: string | null }>
+  warnings?: string[]
 }
 export type ApprovalResponse = {
   status: string

--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -215,7 +215,12 @@ export const testWebhook = () => fetchApi<void>('/settings/test-webhook', { meth
 
 // Pipeline
 export const triggerPipeline = () =>
-  fetchApi<{ message: string; queued?: boolean; position?: number }>('/pipeline/run', {
+  fetchApi<{
+    message: string
+    status?: 'started' | 'queued' | 'duplicate'
+    queued?: boolean
+    position?: number
+  }>('/pipeline/run', {
     method: 'POST',
   })
 export const getPipelineStatus = () =>

--- a/src/web/lib/approval.ts
+++ b/src/web/lib/approval.ts
@@ -31,5 +31,10 @@ export function reportApprovalOutcome(res: ApprovalResponse, t: Translate): bool
     toast.error(t('dashboard.approveFailed'))
     return false
   }
+  // Full success, but a target reported a non-fatal partial outcome (e.g. the
+  // artist was added but the selected album could not be monitored yet).
+  if (summary?.warnings?.length) {
+    toast.warning(summary.warnings.join('; '))
+  }
   return true
 }

--- a/src/web/pages/dashboard.tsx
+++ b/src/web/pages/dashboard.tsx
@@ -650,9 +650,11 @@ export function Dashboard() {
             triggerPipeline()
               .then((res) =>
                 toast.success(
-                  res.queued
-                    ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
-                    : t('discover.scanStarted'),
+                  res.status === 'duplicate'
+                    ? t('discover.scanAlreadyRunning')
+                    : res.queued
+                      ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
+                      : t('discover.scanStarted'),
                 ),
               )
               .catch(() => toast.error(t('discover.scanStartFailed')))

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -140,9 +140,11 @@ function EmptyState({ filter }: { filter: FilterTab }) {
               triggerPipeline()
                 .then((res) =>
                   toast.success(
-                    res.queued
-                      ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
-                      : t('discover.scanStarted'),
+                    res.status === 'duplicate'
+                      ? t('discover.scanAlreadyRunning')
+                      : res.queued
+                        ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
+                        : t('discover.scanStarted'),
                   ),
                 )
                 .catch((err) => {
@@ -150,7 +152,7 @@ function EmptyState({ filter }: { filter: FilterTab }) {
                     typeof err === 'object' && err !== null && 'message' in err
                       ? String(err.message)
                       : String(err)
-                  toast.error(msg.includes('409') ? t('discover.scanAlreadyRunning') : msg)
+                  toast.error(msg)
                 })
             }
             className="px-3 py-1.5 text-sm bg-accent text-accent-fg rounded-md hover:opacity-90 transition-opacity"
@@ -1521,14 +1523,15 @@ export function DiscoverPage() {
             triggerPipeline()
               .then((res) =>
                 toast.success(
-                  res.queued
-                    ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
-                    : t('discover.scanStarted'),
+                  res.status === 'duplicate'
+                    ? t('discover.scanAlreadyRunning')
+                    : res.queued
+                      ? t('discover.scanQueued').replace('{0}', String(res.position ?? 0))
+                      : t('discover.scanStarted'),
                 ),
               )
               .catch((err) => {
-                const msg = errMsg(err)
-                toast.error(msg.includes('409') ? t('discover.scanAlreadyRunning') : msg)
+                toast.error(errMsg(err))
               })
           }
           aria-label={t('app.runScan')}

--- a/tests/api/admin-migrate-failure.test.ts
+++ b/tests/api/admin-migrate-failure.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MigrationReport } from '@/core/ops/migrate-backend'
+import { clearAllSessions, createSession } from '@/core/sessions'
+import { createTestApp } from '../helpers/test-app'
+
+// Keep MigrateBackendError real (the route narrows on it); stub only the
+// migrateBackend call so we can drive the verification-failure (ok:false) branch
+// that maps to HTTP 422 -- a branch no other test exercises.
+vi.mock('@/core/ops/migrate-backend', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/ops/migrate-backend')>()
+  return { ...actual, migrateBackend: vi.fn() }
+})
+
+const { migrateBackend } = await import('@/core/ops/migrate-backend')
+
+const SESSION_TOKEN = 'admin-migrate-fail-session-abc'
+
+beforeEach(async () => {
+  await clearAllSessions()
+  await createSession(1, SESSION_TOKEN)
+  process.env.DIGARR_MIGRATE_DATA_ROOT = '/tmp/digarr-migrate-fail-root'
+})
+
+afterEach(async () => {
+  await clearAllSessions()
+  delete process.env.DIGARR_MIGRATE_DATA_ROOT
+  vi.mocked(migrateBackend).mockReset()
+})
+
+describe('POST /api/v1/admin/migrate-backend (verification failure)', () => {
+  it('returns 422 carrying the report when verification finds a content mismatch', async () => {
+    const failedReport: MigrationReport = {
+      ok: false,
+      verified: true,
+      contentVerified: false,
+      targetBackend: 'pglite',
+      targetDescription: 'PGlite file',
+      tablesMigrated: { users: 1 },
+      excludedTables: ['sessions', 'rateLimitBuckets'],
+      mismatches: [{ table: 'genres', source: 1, target: 1, contentDiffers: true }],
+      targetEnvHint: 'Unset DATABASE_URL/DB_HOST and set DB_PATH=/x, then restart.',
+    }
+    vi.mocked(migrateBackend).mockResolvedValue(failedReport)
+
+    const { app } = createTestApp()
+    const res = await app.request('/api/v1/admin/migrate-backend', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${SESSION_TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        target: { backend: 'pglite', path: '/tmp/digarr-migrate-fail-root/x' },
+      }),
+    })
+
+    // A verification failure must NOT be reported as success.
+    expect(res.status).toBe(422)
+    const body = (await res.json()) as MigrationReport
+    expect(body.ok).toBe(false)
+    expect(body.mismatches[0]).toMatchObject({ table: 'genres', contentDiffers: true })
+  })
+})

--- a/tests/core/targets/lidarr.test.ts
+++ b/tests/core/targets/lidarr.test.ts
@@ -123,7 +123,7 @@ describe('createLidarrTarget()', () => {
     }
   })
 
-  it('addArtist fails loudly when the selected album never appears in Lidarr', async () => {
+  it('addArtist succeeds with a warning (no orphan) when the selected album never appears', async () => {
     vi.useFakeTimers()
     try {
       const client = mockLidarrClient() // getAlbums always returns []
@@ -136,11 +136,58 @@ describe('createLidarrTarget()', () => {
       await vi.runAllTimersAsync()
       const result = await pending
 
-      expect(result?.success).toBe(false)
-      expect(result?.error).toMatch(/not found in Lidarr/)
+      // The artist WAS added; only the secondary monitoring step came up empty.
+      // Surfacing success:true keeps the Lidarr artist id persisted so a retry
+      // reconciles instead of orphaning + re-adding (duplicate).
+      expect(result?.success).toBe(true)
       expect(result?.externalId).toBe(42)
+      expect(result?.error).toBeUndefined()
+      expect(result?.warning).toMatch(/not found in Lidarr/)
       expect(client.updateAlbum).not.toHaveBeenCalled()
       expect(client.triggerCommand).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('addArtist succeeds with a warning when monitoring the selected album throws', async () => {
+    const client = mockLidarrClient()
+    client.getAlbums.mockResolvedValue([{ id: 10, foreignAlbumId: 'album-1', monitored: false }])
+    client.updateAlbum.mockRejectedValue(new Error('Lidarr 500'))
+    const target = createLidarrTarget(1, { url: 'http://lidarr:8686', apiKey: 'abc' })
+
+    const result = await target.addArtist?.(
+      { mbid: 'mbid-rh', name: 'Radiohead' },
+      { monitorOption: 'selected', selectedAlbumIds: ['album-1'] },
+    )
+
+    // Monitoring is best-effort and must never fail the add.
+    expect(result?.success).toBe(true)
+    expect(result?.externalId).toBe(42)
+    expect(result?.warning).toMatch(/Lidarr 500/)
+  })
+
+  it('addArtist monitors found albums and warns about the ones not in Lidarr (partial)', async () => {
+    vi.useFakeTimers()
+    try {
+      const client = mockLidarrClient()
+      // album-2 never appears, so the poll runs out of attempts with a partial match.
+      client.getAlbums.mockResolvedValue([{ id: 10, foreignAlbumId: 'album-1', monitored: false }])
+      const target = createLidarrTarget(1, { url: 'http://lidarr:8686', apiKey: 'abc' })
+
+      const pending = target.addArtist?.(
+        { mbid: 'mbid-rh', name: 'Radiohead' },
+        { monitorOption: 'selected', selectedAlbumIds: ['album-1', 'album-2'] },
+      )
+      await vi.runAllTimersAsync()
+      const result = await pending
+
+      expect(result?.success).toBe(true)
+      expect(result?.externalId).toBe(42)
+      expect(client.updateAlbum).toHaveBeenCalledWith(10, { monitored: true })
+      expect(client.triggerCommand).toHaveBeenCalledWith('AlbumSearch', { albumIds: [10] })
+      // Not silently success: the user must learn album-2 was not monitored.
+      expect(result?.warning).toMatch(/1 of 2/)
     } finally {
       vi.useRealTimers()
     }

--- a/tests/server/routes/pipeline.test.ts
+++ b/tests/server/routes/pipeline.test.ts
@@ -215,6 +215,19 @@ describe('POST /api/v1/pipeline/run', () => {
     expect(body.position).toBe(1)
   })
 
+  it('reports duplicate (not queued) when the same user re-submits during their in-flight run', async () => {
+    const orchestrator = makeMockOrchestrator(true) as unknown as AppDependencies['orchestrator']
+    // Same-user re-submit: enqueue returns a no-op duplicate at position 0.
+    orchestrator.enqueue = vi.fn(() => ({ status: 'duplicate', position: 0 })) as never
+    const app = createApp(makeDeps({ orchestrator }))
+    const res = await authedRequest(app, '/api/v1/pipeline/run', { method: 'POST' })
+    expect(res.status).toBe(202)
+    const body = await res.json()
+    // Must NOT be reported as a fresh queue at position 0 (silent no-op as success).
+    expect(body.status).toBe('duplicate')
+    expect(body.queued).toBe(false)
+  })
+
   it('returns 400 when settings are missing', async () => {
     const orchestrator = makeMockOrchestrator(false) as unknown as AppDependencies['orchestrator']
     const app = createApp(

--- a/tests/server/routes/recommendations-targets.test.ts
+++ b/tests/server/routes/recommendations-targets.test.ts
@@ -93,6 +93,47 @@ describe('target-aware approval', () => {
     )
   })
 
+  it('partial Lidarr add (artist added, album not monitored) persists the artist link and warns, not orphaned', async () => {
+    mockDeps.getRecommendation.mockResolvedValue({
+      id: 1,
+      artist: { mbid: 'mbid-1', name: 'Radiohead' },
+    })
+    const mockTarget = {
+      id: 'lidarr-1',
+      name: 'Lidarr',
+      type: 'lidarr',
+      capabilities: ['addArtist'],
+      addArtist: vi.fn().mockResolvedValue({
+        success: true,
+        targetType: 'lidarr',
+        targetId: 1,
+        externalId: 42,
+        warning: 'artist added, but the selected album was not found in Lidarr',
+      }),
+    }
+    mockDeps.getEnabledTargetsForUser.mockResolvedValue([mockTarget])
+
+    const app = createTestApp()
+    const res = await app.request('/api/v1/recommendations/1', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'approved' }),
+    })
+
+    const body = await res.json()
+    // The artist link must persist (no orphan -> retry reconciles, no duplicate).
+    expect(body.status).toBe('added_to_lidarr')
+    expect(mockDeps.updateRecommendationStatus).toHaveBeenCalledWith(
+      1,
+      'added_to_lidarr',
+      expect.objectContaining({ lidarrArtistId: 42 }),
+    )
+    // The partial outcome is surfaced, not silent.
+    expect(body.targetSummary.warnings).toContain(
+      'artist added, but the selected album was not found in Lidarr',
+    )
+  })
+
   it('approves with failing Lidarr target - sets add_failed', async () => {
     mockDeps.getRecommendation.mockResolvedValue({
       id: 1,
@@ -358,6 +399,7 @@ describe('target-aware approval', () => {
       succeeded: 1,
       failed: 1,
       failures: [{ id: 'lidarr-2', name: 'Lidarr Backup', error: 'connection refused' }],
+      warnings: [],
     })
   })
 
@@ -416,6 +458,7 @@ describe('target-aware approval', () => {
       succeeded: 0,
       failed: 1,
       failures: [{ id: 'lidarr-2', name: 'Lidarr Backup', error: 'still down' }],
+      warnings: [],
     })
   })
 })

--- a/tests/unit/migrate-backend-failure.test.ts
+++ b/tests/unit/migrate-backend-failure.test.ts
@@ -1,0 +1,88 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as schema from '@/db/schema'
+import { makeTestDb } from '../helpers/test-db'
+
+// PGlite WASM cold-start + migrations can exceed the 5s default under full-suite
+// parallel contention; these failure paths still spin up a real target.
+vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 })
+
+// Keep createBackup + BACKUP_TABLE_BY_KEY real (the verification loop and the
+// source snapshot rely on them); override only restoreBackup so we can simulate
+// a target that diverges from the source after the copy, or a restore that
+// blows up mid-flight.
+vi.mock('@/core/ops/backup', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/ops/backup')>()
+  return { ...actual, restoreBackup: vi.fn() }
+})
+
+const { migrateBackend } = await import('@/core/ops/migrate-backend')
+const { restoreBackup } = await import('@/core/ops/backup')
+
+function tgt(name: string) {
+  return join(process.env.DIGARR_MIGRATE_DATA_ROOT as string, name)
+}
+
+describe('migrateBackend failure paths', () => {
+  beforeEach(() => {
+    process.env.DIGARR_MIGRATE_DATA_ROOT = mkdtempSync(join(tmpdir(), 'digarr-migfail-'))
+    vi.mocked(restoreBackup).mockReset()
+  })
+  afterEach(() => {
+    delete process.env.DIGARR_MIGRATE_DATA_ROOT
+  })
+
+  it('reports ok:false with mismatches when the target is missing rows after restore', async () => {
+    const src = await makeTestDb()
+    try {
+      await src.db.insert(schema.users).values({ username: 'mig', passwordHash: 'x' })
+      await src.db
+        .insert(schema.genres)
+        .values({ name: 'Synthwave', slug: 'synthwave', source: 'manual' })
+
+      // No-op restore: the freshly created target stays empty, so the post-copy
+      // verification must detect the row-count mismatch and refuse to claim success.
+      vi.mocked(restoreBackup).mockResolvedValue({
+        tablesRestored: {},
+        warnings: [],
+        encryptionMismatch: false,
+        affectedEncryptedFields: [],
+      })
+
+      const report = await migrateBackend({
+        sourceDb: src.db as never,
+        target: { backend: 'pglite', path: tgt('mismatch') },
+        isPipelineRunning: () => false,
+      })
+
+      expect(report.ok).toBe(false)
+      expect(report.verified).toBe(false)
+      expect(report.contentVerified).toBe(false)
+      expect(report.mismatches.length).toBeGreaterThan(0)
+      const users = report.mismatches.find((m) => m.table === 'users')
+      expect(users).toMatchObject({ source: 1, target: 0 })
+    } finally {
+      await src.close()
+    }
+  })
+
+  it('rejects (no silent ok:true) when restoreBackup throws mid-restore', async () => {
+    const src = await makeTestDb()
+    try {
+      await src.db.insert(schema.users).values({ username: 'mig', passwordHash: 'x' })
+      vi.mocked(restoreBackup).mockRejectedValue(new Error('constraint violation mid-restore'))
+
+      await expect(
+        migrateBackend({
+          sourceDb: src.db as never,
+          target: { backend: 'pglite', path: tgt('throw') },
+          isPipelineRunning: () => false,
+        }),
+      ).rejects.toThrow(/constraint violation mid-restore/)
+    } finally {
+      await src.close()
+    }
+  })
+})


### PR DESCRIPTION
## Phase 0 release blockers (deep-audit, v1.11.0)

The merge-gating fixes from the pre-release audit of `develop`. Three commits.

### `fix(lidarr)` — keep the artist link on a partial album-monitor (#329)
The album-monitor step after `addArtist` could fail the whole add (album not
found after polling, or `updateAlbum`/`triggerCommand` throwing), returning
`success:false`. The consumer only persists `lidarrArtistId` on success, so the
artist was left added-but-unmonitored with no stored link — a retry re-added a
duplicate.

Monitoring is now best-effort: the add always reports `success:true` with the
`externalId` once the artist exists; a not-found / partial / failed monitor
becomes a non-fatal `warning` surfaced to the user (submit-time toast) instead
of failing the result. Adds `TargetResult.warning` and 4 failure-path tests.

### `fix(pipeline)` — distinguish a duplicate re-submit from a queued run (#334)
`POST /pipeline/run` collapsed the enqueue result to a `queued` boolean, so a
same-user re-submit during their own in-flight run (status `duplicate`,
position 0) was reported as "Pipeline queued, position 0" — a silent no-op
shown as success. The response now surfaces the real `status`
(`started`/`queued`/`duplicate`); the web clients show "scan already running"
for a duplicate. Reuses the previously-orphaned `discover.scanAlreadyRunning`
string and drops the dead `msg.includes('409')` catch branches.

### `test(migrate-backend)` — cover the verification-failure paths (#334)
The migration tool had only happy-path coverage. Adds: verification detects a
row-count mismatch → `ok:false`; `restoreBackup` throwing mid-restore →
`migrateBackend` rejects (no silent `ok:true`); the route maps a non-ok report
to HTTP 422 (a previously untested branch). `restoreBackup`'s atomic rollback
is already covered elsewhere, so it is not duplicated.

---

Full test suite green (2527 passing). Closes #329, closes #334.
