### PR TITLE
fix(db): harden the PGlite backend path (#336)

### DIFF
--- a/deploy/docker/docker-compose.pglite.yml
+++ b/deploy/docker/docker-compose.pglite.yml
@@ -44,7 +44,10 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          # WASM Postgres runs in-process, so the DB shares this budget with the
+          # app. 512M OOM-kills under migrations/large backups; 768M is the safe
+          # floor. Raise to 1G for big libraries or heavy concurrent scans.
+          memory: 768M
           cpus: "2.0"
     logging:
       driver: json-file

--- a/deploy/helm/digarr/templates/NOTES.txt
+++ b/deploy/helm/digarr/templates/NOTES.txt
@@ -21,6 +21,13 @@ future pod specs that weaken the securityContext are rejected at admission:
 {{- end }}
 
 2. Database migrations run automatically on startup.
+{{- if and (eq .Values.database.backend "pglite") (not .Values.backups.persistence.enabled) }}
+
+  WARNING: backend=pglite but backups.persistence.enabled=false. The pre-migration
+  auto-backup is your only rollback artifact, and it lives on an emptyDir that is
+  wiped on every pod restart. A migration that fails after a restart leaves no way
+  back. Set backups.persistence.enabled=true so rollback survives pod churn.
+{{- end }}
 
 3. Check health:
   curl http://<host>/health

--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -236,6 +236,9 @@ gateway:
 # ---------------------------------------------------------------------------
 # Default is emptyDir -- backups live only for the pod lifetime. Enable
 # persistence to survive pod restarts and cluster events.
+# Strongly recommended with database.backend=pglite: the pre-migration
+# auto-backup is the only rollback artifact, and an emptyDir loses it on
+# restart (the chart's NOTES.txt warns when this is left disabled in pglite mode).
 backups:
   persistence:
     enabled: false

--- a/src/db/backend.ts
+++ b/src/db/backend.ts
@@ -17,3 +17,38 @@ export function resolveDbBackend(): DbBackend {
 export function getPgliteDataDir(): string {
   return envConfig.dbPath ?? join(process.cwd(), 'data')
 }
+
+/**
+ * Detect a half-configured Postgres setup that silently fell back to PGlite: an
+ * operator set some of DB_HOST/DB_USER/DB_NAME but not enough to resolve a DSN,
+ * so their Postgres database is NOT being used. Returns null when the boot is a
+ * clean PGlite default (no Postgres vars) or a complete Postgres config.
+ */
+/** Server-side cap on any single query, matching the Postgres pool's statement_timeout. */
+export const PGLITE_STATEMENT_TIMEOUT_MS = 30_000
+
+/**
+ * Apply the query cap to a PGlite session. PGlite is in-process single-threaded
+ * WASM Postgres, so a runaway query freezes the event loop and trips k8s liveness;
+ * the timeout aborts it at the next interrupt point. PGlite serializes operations
+ * FIFO, so issuing this right after construction lands it ahead of all app queries.
+ */
+export function applyPgliteStatementTimeout(client: {
+  exec: (query: string) => Promise<unknown>
+}): Promise<unknown> {
+  const setTimeoutSql = `SET statement_timeout = ${PGLITE_STATEMENT_TIMEOUT_MS}`
+  return client.exec(setTimeoutSql)
+}
+
+export function detectPartialPostgresConfig(): { present: string[]; missing: string[] } | null {
+  if (resolveDbBackend() === 'postgres') return null
+  const fields: ReadonlyArray<[string, string | undefined]> = [
+    ['DB_HOST', envConfig.dbHost],
+    ['DB_USER', envConfig.dbUser],
+    ['DB_NAME', envConfig.dbName],
+  ]
+  const present = fields.filter(([, v]) => v).map(([k]) => k)
+  if (present.length === 0) return null
+  const missing = fields.filter(([, v]) => !v).map(([k]) => k)
+  return { present, missing }
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,7 +4,12 @@ import { drizzle as drizzlePg } from 'drizzle-orm/node-postgres'
 import { drizzle as drizzlePglite } from 'drizzle-orm/pglite'
 import pg from 'pg'
 import { buildDatabaseUrl, envConfig } from '@/config/env'
-import { getPgliteDataDir, resolveDbBackend } from './backend'
+import {
+  applyPgliteStatementTimeout,
+  detectPartialPostgresConfig,
+  getPgliteDataDir,
+  resolveDbBackend,
+} from './backend'
 import * as schema from './schema'
 
 export const dbBackend = resolveDbBackend()
@@ -43,6 +48,8 @@ function buildPglite(): Database {
   // In tests with no configured path, stay fully in-memory to avoid touching disk.
   const inMemory = process.env.VITEST && !envConfig.dbPath
   pgliteClient = inMemory ? new PGlite() : new PGlite(getPgliteDataDir())
+  // FIFO-queued ahead of every app query, so the cap is live from the first one.
+  void applyPgliteStatementTimeout(pgliteClient)
   return drizzlePglite(pgliteClient, { schema }) as unknown as Database
 }
 
@@ -55,6 +62,19 @@ console.log(
     ? '[db] backend=postgres (DSN configured)'
     : '[db] backend=pglite (no DATABASE_URL/DB_HOST configured)',
 )
+
+// A half-set Postgres config (e.g. DB_HOST without DB_NAME) silently boots an
+// empty embedded PGlite instead. Shout so the operator does not run on the
+// wrong database without noticing.
+const partialPg = detectPartialPostgresConfig()
+if (partialPg) {
+  console.warn(
+    `[db] WARNING: partial Postgres config (set: ${partialPg.present.join(', ')}; ` +
+      `missing: ${partialPg.missing.join(', ')}) -- falling back to embedded PGlite. ` +
+      'Your Postgres database is NOT in use. Set DATABASE_URL, or all of DB_HOST, ' +
+      'DB_USER, DB_NAME, to connect to Postgres.',
+  )
+}
 
 /** The pg Pool, or null under PGlite (in-process, no socket to wait on). */
 export const pool: pg.Pool | null = pgPool

--- a/tests/db/backend.test.ts
+++ b/tests/db/backend.test.ts
@@ -38,3 +38,33 @@ describe('resolveDbBackend', () => {
     expect((await import('@/db/backend')).getPgliteDataDir()).toBe('/var/lib/digarr')
   })
 })
+
+describe('detectPartialPostgresConfig', () => {
+  beforeEach(clearDbEnv)
+  afterEach(clearDbEnv)
+
+  it('returns null on a clean pglite boot (no postgres vars at all)', async () => {
+    expect((await load()).detectPartialPostgresConfig()).toBeNull()
+  })
+  it('returns null when full postgres config is present', async () => {
+    process.env.DB_HOST = 'pg'
+    process.env.DB_USER = 'digarr'
+    process.env.DB_NAME = 'digarr'
+    expect((await load()).detectPartialPostgresConfig()).toBeNull()
+  })
+  it('returns null when DATABASE_URL is set', async () => {
+    process.env.DATABASE_URL = 'postgresql://u:p@h:5432/d'
+    expect((await load()).detectPartialPostgresConfig()).toBeNull()
+  })
+  it('flags a partial config: DB_HOST set but DB_NAME/DB_USER missing', async () => {
+    process.env.DB_HOST = 'pg'
+    const result = (await load()).detectPartialPostgresConfig()
+    expect(result).toEqual({ present: ['DB_HOST'], missing: ['DB_USER', 'DB_NAME'] })
+  })
+  it('flags a partial config: host+user but no name', async () => {
+    process.env.DB_HOST = 'pg'
+    process.env.DB_USER = 'digarr'
+    const result = (await load()).detectPartialPostgresConfig()
+    expect(result).toEqual({ present: ['DB_HOST', 'DB_USER'], missing: ['DB_NAME'] })
+  })
+})

--- a/tests/db/pglite-integration.test.ts
+++ b/tests/db/pglite-integration.test.ts
@@ -5,6 +5,7 @@ import { migrate } from 'drizzle-orm/pglite/migrator'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { createBackup, restoreBackup } from '@/core/ops/backup'
 import { getPendingMigrations } from '@/core/ops/upgrade'
+import { applyPgliteStatementTimeout } from '@/db/backend'
 import * as schema from '@/db/schema'
 
 type DB = ReturnType<typeof drizzle<typeof schema>>
@@ -34,6 +35,13 @@ describe('pglite backend contract', () => {
     const status = await getPendingMigrations(db as never)
     expect(status.pendingCount).toBe(0)
     expect(status.targetVersion).not.toBeNull()
+  })
+
+  it('caps queries with a 30s statement_timeout, matching the Postgres path', async () => {
+    const client = new PGlite() // in-memory
+    await applyPgliteStatementTimeout(client)
+    const res = await client.query<{ statement_timeout: string }>('SHOW statement_timeout')
+    expect(res.rows[0]?.statement_timeout).toBe('30s')
   })
 
   it('round-trips a backup on pglite', async () => {


### PR DESCRIPTION
Phase 3 of the pre-release deep-audit remediation. Closes #336.

## Changes
- **Query timeout** — PGlite queries get a 30s `statement_timeout` matching the Postgres pool. A runaway query in the in-process WASM Postgres otherwise freezes the event loop and trips k8s liveness into a crash loop. Issued FIFO-ahead of the first app query.
- **Fail-loud fallback** — boot warns when a half-set Postgres config (e.g. `DB_HOST` without `DB_NAME`) silently falls back to an empty embedded PGlite, so an operator does not unknowingly run on the wrong database.
- **Helm backup persistence** — `NOTES.txt` warns when `database.backend=pglite` and `backups.persistence.enabled=false`: the pre-migration auto-backup is the only rollback artifact and an emptyDir loses it on pod restart. Verified rendering in all three modes.
- **Memory limit** — pglite compose stack raised 512M -> 768M (WASM Postgres runs in-process; 512M OOM-kills under migrations/large backups).

## Verification
- New TDD tests: `detectPartialPostgresConfig` (5 cases), PGlite `statement_timeout` SHOW probe.
- Full suite green: 2532 passed. Typecheck + lint clean. Helm `--dry-run` confirms the warning fires only in pglite+no-backup mode.