### PR TITLE
chore(release): sync deploy digests to v1.11.0

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -7,8 +7,8 @@ image:
   # channel for clusters where reproducibility is not a goal, set tag: "stable" and remove
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
-  tag: "1.10.0"
-  digest: "sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989"
+  tag: "1.11.0"
+  digest: "sha256:0778b615cc73d834ca456a68c678bee424f4e85b06beb4f3cebf163a066270a4"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989
+          image: ghcr.io/iuliandita/digarr@sha256:0778b615cc73d834ca456a68c678bee424f4e85b06beb4f3cebf163a066270a4
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989"
+          image: "ghcr.io/iuliandita/digarr@sha256:0778b615cc73d834ca456a68c678bee424f4e85b06beb4f3cebf163a066270a4"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:a77200251d244a11b7d4638254c39adfc79c7754cbe208af8a6b46df3ce4a989 -->
-  <Repository>docker.io/iuliandita/digarr:1.10.0</Repository>
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:0778b615cc73d834ca456a68c678bee424f4e85b06beb4f3cebf163a066270a4 -->
+  <Repository>docker.io/iuliandita/digarr:1.11.0</Repository>
   <Registry>https://hub.docker.com/r/iuliandita/digarr</Registry>
   <Branch>
-    <Tag>1.10.0</Tag>
-    <TagDescription>v1.10.0 release</TagDescription>
+    <Tag>1.11.0</Tag>
+    <TagDescription>v1.11.0 release</TagDescription>
   </Branch>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
Repoints the deploy artefacts (Helm values, k8s deployment + rendered, Unraid template) at the published v1.11.0 image digest `sha256:0778b615cc73d834ca456a68c678bee424f4e85b06beb4f3cebf163a066270a4`. Reproducibility follow-up to the v1.11.0 release; not a gate. Generated by `scripts/sync-deploy-digests.ts v1.11.0`.