### PR TITLE
fix(lidarr): snap stale approval profile ids

### DIFF
--- a/src/web/components/approve-dialog.tsx
+++ b/src/web/components/approve-dialog.tsx
@@ -37,9 +37,19 @@ export function ApproveDialog({ defaults, monitorOption, onConfirm, onCancel }: 
         setProfiles(opts.qualityProfiles)
         setMetadataProfiles(opts.metadataProfiles)
         setRootFolders(opts.rootFolders)
-        // If the pre-filled default isn't an actual Lidarr root folder
-        // (e.g. stale id 1 after a folder was deleted/recreated), snap to
-        // the first available folder so we never send a non-existent id.
+        // If any pre-filled default isn't an actual Lidarr option (for example,
+        // stale id 1 after profiles/folders were deleted), snap to the first
+        // available option so we never send a non-existent id.
+        const firstProfile = opts.qualityProfiles[0]
+        if (firstProfile && !opts.qualityProfiles.some((p) => String(p.id) === qp)) {
+          setQp(String(firstProfile.id))
+        }
+
+        const firstMetadataProfile = opts.metadataProfiles[0]
+        if (firstMetadataProfile && !opts.metadataProfiles.some((p) => String(p.id) === mp)) {
+          setMp(String(firstMetadataProfile.id))
+        }
+
         const firstFolder = opts.rootFolders[0]
         if (firstFolder && !opts.rootFolders.some((f) => String(f.id) === rf)) {
           setRf(String(firstFolder.id))

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -1625,6 +1625,25 @@ function LidarrPreferencesSection() {
     setRootFolderId(p.rootFolderId != null ? String(p.rootFolderId) : '')
   }, [userPrefs])
 
+  // Snap selectors to the first real Lidarr option when none is set or the
+  // stored id no longer exists among the loaded options. Otherwise the browser
+  // can visibly select the first option while React state still holds stale id 1.
+  useEffect(() => {
+    if (!qualityProfiles || qualityProfiles.length === 0) return
+    const first = qualityProfiles[0]
+    if (first && !qualityProfiles.some((p) => String(p.id) === qualityProfileId)) {
+      setQualityProfileId(String(first.id))
+    }
+  }, [qualityProfiles, qualityProfileId])
+
+  useEffect(() => {
+    if (!metadataProfiles || metadataProfiles.length === 0) return
+    const first = metadataProfiles[0]
+    if (first && !metadataProfiles.some((p) => String(p.id) === metadataProfileId)) {
+      setMetadataProfileId(String(first.id))
+    }
+  }, [metadataProfiles, metadataProfileId])
+
   // Snap root folder selector to the first real folder when none is set
   // or the stored id no longer exists among the loaded folders.
   useEffect(() => {

--- a/tests/web/components/approve-dialog.test.tsx
+++ b/tests/web/components/approve-dialog.test.tsx
@@ -42,7 +42,7 @@ describe('ApproveDialog', () => {
     vi.clearAllMocks()
   })
 
-  it('snaps to first available folder when default id is not in the loaded list', async () => {
+  it('snaps to first available Lidarr options when defaults are not in the loaded lists', async () => {
     vi.mocked(getLidarrApproveOptions).mockResolvedValue({
       qualityProfiles: [{ id: 2, name: 'Standard' }],
       metadataProfiles: [{ id: 3, name: 'Standard' }],
@@ -69,7 +69,9 @@ describe('ApproveDialog', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /add to lidarr/i }))
 
-    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ rootFolderId: 5 }))
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ qualityProfileId: 2, metadataProfileId: 3, rootFolderId: 5 }),
+    )
   })
 
   it('keeps default id when it exists among loaded folders', async () => {

--- a/tests/web/pages/settings.test.tsx
+++ b/tests/web/pages/settings.test.tsx
@@ -185,6 +185,7 @@ import {
   updatePreferredLocale,
   updateSettings,
   updateTargetApi,
+  updateUserPreferences,
 } from '@/web/lib/api'
 import { getStoredLocale } from '@/web/lib/locale-storage'
 import { SettingsPage } from '@/web/pages/settings'
@@ -206,6 +207,7 @@ const mockUpdatePreferredLocale = updatePreferredLocale as ReturnType<typeof vi.
 const mockCreateTargetApi = createTargetApi as ReturnType<typeof vi.fn>
 const mockListTargets = listTargets as ReturnType<typeof vi.fn>
 const mockUpdateTargetApi = updateTargetApi as ReturnType<typeof vi.fn>
+const mockUpdateUserPreferences = updateUserPreferences as ReturnType<typeof vi.fn>
 const mockListJobs = listJobs as ReturnType<typeof vi.fn>
 const mockGetJobHealth = getJobHealth as ReturnType<typeof vi.fn>
 
@@ -505,6 +507,34 @@ describe('SettingsPage', () => {
       expect(mockUpdateSettings).toHaveBeenCalledWith(
         expect.objectContaining({ lidarrUrl: 'http://localhost:8686' }),
       )
+    })
+  })
+
+  it('snaps stale per-user Lidarr preference ids before saving', async () => {
+    setupMocks()
+    mockGetLidarrProfiles.mockResolvedValue([{ id: 3, name: 'Stefan' }])
+    mockGetLidarrMetadataProfiles.mockResolvedValue([{ id: 4, name: 'Standard' }])
+    mockGetLidarrRootFolders.mockResolvedValue([{ id: 10, path: '/music' }])
+
+    renderWithQuery(<SettingsPage />)
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Stefan')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('/music')).toBeInTheDocument()
+    })
+
+    const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+    const preferencesSaveButton = saveButtons.at(-1)
+    expect(preferencesSaveButton).toBeDefined()
+    if (!preferencesSaveButton) return
+    fireEvent.click(preferencesSaveButton)
+
+    await waitFor(() => {
+      expect(mockUpdateUserPreferences).toHaveBeenCalledWith({
+        qualityProfileId: 3,
+        metadataProfileId: 4,
+        rootFolderId: 10,
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

- Snap stale Lidarr quality and metadata profile defaults to real loaded options in the approve dialog
- Apply the same stale-id correction in per-user Lidarr preferences before saving
- Add regression coverage for non-1 profile IDs shown by the UI but previously submitted as 1

Fixes #348.

## Testing

- `bun run lint`
- `bun run test tests/web/components/approve-dialog.test.tsx`
- `bun run test tests/web/pages/settings.test.tsx -t "snaps stale per-user Lidarr preference ids before saving"`
- `bun run test tests/server/routes/recommendations.test.ts`
- `bun run test tests/server/routes/recommendations-targets.test.ts tests/core/targets/lidarr.test.ts tests/web/lib/approval.test.ts`

## Notes

- `bun run typecheck` timed out locally after 600s, so CI should be treated as authoritative for typecheck.
