### PR TITLE
chore(release): sync deploy digests to v1.11.1

### DIFF
--- a/deploy/helm/digarr/values.yaml
+++ b/deploy/helm/digarr/values.yaml
@@ -7,8 +7,8 @@ image:
   # channel for clusters where reproducibility is not a goal, set tag: "stable" and remove
   # the digest line - :stable is promoted only after a release has been live >= 7 days
   # without a follow-up patch.
-  tag: "1.11.0"
-  digest: "sha256:0778b615cc73d834ca456a68c678bee424f4e85b06beb4f3cebf163a066270a4"
+  tag: "1.11.1"
+  digest: "sha256:bb3c9f5d7c3ba671da7ae83f24987da9d86cf3c475079a5f90b663f3120f3fec"
   pullPolicy: Always
 
 podSecurityContext:

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -55,7 +55,7 @@ spec:
               drop:
                 - ALL
           # Pin the digest after publishing each release image. The digest comes from the published registry artifact.
-          image: ghcr.io/iuliandita/digarr@sha256:0778b615cc73d834ca456a68c678bee424f4e85b06beb4f3cebf163a066270a4
+          image: ghcr.io/iuliandita/digarr@sha256:bb3c9f5d7c3ba671da7ae83f24987da9d86cf3c475079a5f90b663f3120f3fec
           imagePullPolicy: Always
           ports:
             - name: http

--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -253,7 +253,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: digarr
-          image: "ghcr.io/iuliandita/digarr@sha256:0778b615cc73d834ca456a68c678bee424f4e85b06beb4f3cebf163a066270a4"
+          image: "ghcr.io/iuliandita/digarr@sha256:bb3c9f5d7c3ba671da7ae83f24987da9d86cf3c475079a5f90b663f3120f3fec"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/unraid/digarr.xml
+++ b/deploy/unraid/digarr.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Digarr</Name>
-  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:0778b615cc73d834ca456a68c678bee424f4e85b06beb4f3cebf163a066270a4 -->
-  <Repository>docker.io/iuliandita/digarr:1.11.0</Repository>
+  <!-- Digest pin (synced via scripts/sync-deploy-digests.ts): sha256:bb3c9f5d7c3ba671da7ae83f24987da9d86cf3c475079a5f90b663f3120f3fec -->
+  <Repository>docker.io/iuliandita/digarr:1.11.1</Repository>
   <Registry>https://hub.docker.com/r/iuliandita/digarr</Registry>
   <Branch>
-    <Tag>1.11.0</Tag>
-    <TagDescription>v1.11.0 release</TagDescription>
+    <Tag>1.11.1</Tag>
+    <TagDescription>v1.11.1 release</TagDescription>
   </Branch>
   <Network>bridge</Network>
   <Shell>sh</Shell>


### PR DESCRIPTION
## Summary

- Sync Kubernetes, Helm, and Unraid deployment references to the v1.11.1 image digest
- Update human-readable deployment image tags to 1.11.1

## Testing

- `bun scripts/sync-deploy-digests.ts v1.11.1`
- Release workflow `verify-digest-sync` passed for v1.11.1
