### PR TITLE
fix(docker): use latest for compose defaults

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Install Docker
         id: docker
+        timeout-minutes: 8
+        continue-on-error: true
         run: |
           brew install --cask docker
           open /Applications/Docker.app

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ Digarr ships with an embedded database (PGlite) -- no separate PostgreSQL requir
 ```sh
 docker run -d --name digarr -p 3000:3000 \
   -v digarr-data:/app/data -v digarr-backups:/app/backups \
-  docker.io/iuliandita/digarr:stable
+  docker.io/iuliandita/digarr:latest
 ```
 
 Open `http://localhost:3000` and complete the setup wizard. You can start with Lidarr, Emby, or discovery-only mode. Database migrations run automatically on every startup.
 
-The image pulls `docker.io/iuliandita/digarr:stable`, the channel that only moves once a release has soaked for at least seven days without a follow-up patch. Track `:latest` (or pin to a specific patch like `:1.10.0`) when you want the head of the release line. For bleeding-edge testing, `:nightly` (GHCR only) is rebuilt on every change with an immutable `:nightly-<sha>` alongside it; the web footer and `GET /health` report the running `gitSha` so a nightly bug report can be pinned to a commit.
+The image pulls `docker.io/iuliandita/digarr:latest`, the newest stable release and the recommended channel for first-time home installs. Use a minor tag like `:1.11` to stay on patch fixes for that line, or pin a specific patch like `:1.11.1` when you want zero surprises. For bleeding-edge testing, `:nightly` (GHCR only) is rebuilt on every change with an immutable `:nightly-<sha>` alongside it; the web footer and `GET /health` report the running `gitSha` so a nightly bug report can be pinned to a commit.
 
 ### Database backend
 

--- a/deploy/docker/docker-compose.pglite.yml
+++ b/deploy/docker/docker-compose.pglite.yml
@@ -7,10 +7,11 @@
 
 services:
   app:
-    image: docker.io/iuliandita/digarr:stable
-    # :stable -> last release promoted after >= 7 days (recommended)
-    # Pin a version for zero surprises: docker.io/iuliandita/digarr:1.10.0
-    # Default is alpine; Debian/glibc variant: docker.io/iuliandita/digarr:1.10.0-debian
+    image: docker.io/iuliandita/digarr:latest
+    # :latest -> newest stable release, recommended for first-time home installs
+    # Track patch fixes only: docker.io/iuliandita/digarr:1.11
+    # Pin a version for zero surprises: docker.io/iuliandita/digarr:1.11.1
+    # Default is alpine; Debian/glibc variant: docker.io/iuliandita/digarr:1.11.1-debian
     user: "1000:1000"
     env_file:
       - path: .env

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -14,14 +14,14 @@ networks:
 
 services:
   app:
-    image: docker.io/iuliandita/digarr:stable
+    image: docker.io/iuliandita/digarr:latest
     # Channels:
-    #   :stable -> last release promoted after >= 7 days with no follow-up patch (recommended for self-hosters)
-    #   :latest -> head of the release line, may move multiple times per day
-    # Pin to a specific minor or patch when you want zero surprises:
-    # image: docker.io/iuliandita/digarr:1.10.0
+    #   :latest -> newest stable release, recommended for first-time home installs
+    #   :1.11 -> current minor release line, patch fixes only
+    # Pin to a specific patch when you want zero surprises:
+    # image: docker.io/iuliandita/digarr:1.11.1
     # Default image is alpine (musl libc). Debian/glibc variant:
-    # image: docker.io/iuliandita/digarr:1.10.0-debian
+    # image: docker.io/iuliandita/digarr:1.11.1-debian
     user: "1000:1000"
     networks:
       - frontend

--- a/docs/guides/docker-desktop.md
+++ b/docs/guides/docker-desktop.md
@@ -19,7 +19,7 @@ single container with no database setup and no secret.
 ```sh
 docker run -d --name digarr -p 3000:3000 \
   -v digarr-data:/app/data -v digarr-backups:/app/backups \
-  docker.io/iuliandita/digarr:stable
+  docker.io/iuliandita/digarr:latest
 ```
 
 Or with compose:


### PR DESCRIPTION
## Summary

- Backport the Docker Compose tag fix from develop to main
- Use `latest` for home-user compose defaults so the PGlite compose file pulls a PGlite-capable image
- Keep the macOS Docker compatibility job from hanging forever when Docker Desktop setup stalls

## Checks

- `docker compose -f deploy/docker/docker-compose.pglite.yml config`
- `docker compose -f deploy/docker/docker-compose.yml config`
- `git diff --check HEAD~1..HEAD`

Fixes #352
