### PR TITLE
fix(lidarr): default artist approvals to unmonitored

### DIFF
--- a/src/core/clients/lidarr.ts
+++ b/src/core/clients/lidarr.ts
@@ -131,7 +131,7 @@ export function createLidarrClient(url: string, apiKey: string, skipTlsVerify = 
       throw new Error(`Root folder with id ${rootFolderId} not found`)
     }
 
-    const monitor = options?.monitorOption ?? 'all'
+    const monitor = options?.monitorOption ?? 'none'
 
     return http.post<LidarrArtist>('/api/v1/artist', {
       foreignArtistId,

--- a/src/core/targets/lidarr.ts
+++ b/src/core/targets/lidarr.ts
@@ -53,7 +53,7 @@ export function createLidarrTarget(
       options?: TargetAddOptions,
     ): Promise<TargetResult> {
       const effectiveMonitor =
-        options?.monitorOption === 'selected' ? 'none' : (options?.monitorOption ?? 'all')
+        options?.monitorOption === 'selected' ? 'none' : (options?.monitorOption ?? 'none')
 
       try {
         const added = await client.addArtist(

--- a/src/server/routes/recommendations.ts
+++ b/src/server/routes/recommendations.ts
@@ -687,7 +687,7 @@ export function recommendationRoutes(deps: AppDependencies) {
               streamingUrls: rec.artist.streamingUrls,
             },
             {
-              monitorOption: isAlbumRec ? undefined : ((monitorOption ?? 'all') as MonitorOption),
+              monitorOption: isAlbumRec ? undefined : ((monitorOption ?? 'none') as MonitorOption),
               selectedAlbumIds: isAlbumRec ? undefined : selectedAlbumIds,
               qualityProfileId: qpOverride,
               metadataProfileId: mpOverride,

--- a/src/web/components/approve-dialog.tsx
+++ b/src/web/components/approve-dialog.tsx
@@ -24,6 +24,7 @@ export function ApproveDialog({ defaults, monitorOption, onConfirm, onCancel }: 
   const [profiles, setProfiles] = useState<Profile[]>([])
   const [metadataProfiles, setMetadataProfiles] = useState<Profile[]>([])
   const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
+  const [monitor, setMonitor] = useState<MonitorOption>(monitorOption)
   const [qp, setQp] = useState(String(defaults.qualityProfileId))
   const [mp, setMp] = useState(String(defaults.metadataProfileId))
   const [rf, setRf] = useState(String(defaults.rootFolderId))
@@ -77,6 +78,25 @@ export function ApproveDialog({ defaults, monitorOption, onConfirm, onCancel }: 
             <p className="text-sm text-red-400">{t('approveDialog.loadFailed')}</p>
           ) : (
             <div className="space-y-3">
+              <label className="block">
+                <span className="text-xs text-muted">{t('discover.monitoringOptions')}</span>
+                <select
+                  value={monitor}
+                  onChange={(e) => setMonitor(e.target.value as MonitorOption)}
+                  className="mt-1 w-full bg-bg border border-border rounded text-sm text-text px-2 py-1.5"
+                >
+                  <option value="none">{t('common.none')}</option>
+                  <option value="new">{t('settings.monitorNew')}</option>
+                  <option value="all">{t('settings.monitorAll')}</option>
+                </select>
+                <span className="block text-[11px] text-muted mt-1">
+                  {monitor === 'all'
+                    ? t('discover.monitorAllDescription')
+                    : monitor === 'new'
+                      ? t('discover.monitorNewDescription')
+                      : t('discover.monitorNoneDescription')}
+                </span>
+              </label>
               <label className="block">
                 <span className="text-xs text-muted">{t('approveDialog.qualityProfile')}</span>
                 <select
@@ -138,7 +158,7 @@ export function ApproveDialog({ defaults, monitorOption, onConfirm, onCancel }: 
               }
               onClick={() =>
                 onConfirm({
-                  monitorOption,
+                  monitorOption: monitor,
                   qualityProfileId: parseInt(qp, 10),
                   metadataProfileId: parseInt(mp, 10),
                   rootFolderId: parseInt(rf, 10),

--- a/src/web/components/monitoring-options.tsx
+++ b/src/web/components/monitoring-options.tsx
@@ -114,7 +114,8 @@ export function MonitoringOptions({
 
   return (
     <div className={`relative inline-flex ${fill ? 'w-full' : ''}`}>
-      {/* Primary approve button - defaults to 'all' */}
+      {/* Primary approve button - safe default: add the artist unmonitored.
+          Use the dropdown for eager monitoring/searching all albums. */}
       <Button
         size="sm"
         variant="outline"
@@ -122,7 +123,7 @@ export function MonitoringOptions({
         disabled={loading}
         onClick={(e) => {
           e.stopPropagation()
-          onApprove('all')
+          onApprove('none')
         }}
       >
         {t('recommendation.approve')}

--- a/src/web/pages/dashboard.tsx
+++ b/src/web/pages/dashboard.tsx
@@ -588,7 +588,7 @@ export function Dashboard() {
       (t) => `${t.type}-${t.id}` === targetId || String(t.id) === targetId,
     )
     if (target?.type === 'lidarr') {
-      setApproveDialogState({ recId, monitorOption: 'all', targetId })
+      setApproveDialogState({ recId, monitorOption: 'none', targetId })
       return
     }
 

--- a/src/web/pages/discover.tsx
+++ b/src/web/pages/discover.tsx
@@ -630,7 +630,7 @@ export function DiscoverPage() {
         (t) => `${t.type}-${t.id}` === targetId || String(t.id) === targetId,
       )
       if (target?.type === 'lidarr') {
-        setApproveDialogState({ recId, monitorOption: 'all', targetId })
+        setApproveDialogState({ recId, monitorOption: 'none', targetId })
         return
       }
 

--- a/tests/core/clients/lidarr.test.ts
+++ b/tests/core/clients/lidarr.test.ts
@@ -147,7 +147,7 @@ describe('createLidarrClient', () => {
           qualityProfileId: 1,
           rootFolderPath: '/music',
           monitored: true,
-          addOptions: { monitor: 'all', searchForMissingAlbums: true },
+          addOptions: { monitor: 'none', searchForMissingAlbums: false },
         }),
       )
       expect(result).toMatchObject({ id: 10 })
@@ -173,7 +173,7 @@ describe('createLidarrClient', () => {
       expect(rootFolderGetCalls).toHaveLength(1)
     })
 
-    it('defaults to monitor:"all" and searchForMissingAlbums:true when no options provided', async () => {
+    it('defaults to monitor:"none" and searchForMissingAlbums:false when no options provided', async () => {
       mockGet.mockResolvedValueOnce(mockFolders)
       mockPost.mockResolvedValueOnce({ ...mockArtists[0], id: 12 })
 
@@ -183,7 +183,7 @@ describe('createLidarrClient', () => {
       expect(mockPost).toHaveBeenCalledWith(
         '/api/v1/artist',
         expect.objectContaining({
-          addOptions: { monitor: 'all', searchForMissingAlbums: true },
+          addOptions: { monitor: 'none', searchForMissingAlbums: false },
         }),
       )
     })

--- a/tests/server/routes/recommendations.test.ts
+++ b/tests/server/routes/recommendations.test.ts
@@ -413,6 +413,10 @@ describe('PATCH /api/v1/recommendations/:id', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.status).toBe('added_to_lidarr')
+    expect(mockTarget.addArtist).toHaveBeenCalledWith(
+      { mbid: 'mbid-abc-123', name: 'Test Artist' },
+      expect.objectContaining({ monitorOption: 'none' }),
+    )
     expect(updateRecommendationStatus).toHaveBeenCalledWith(
       1,
       'added_to_lidarr',

--- a/tests/web/pages/discover.test.tsx
+++ b/tests/web/pages/discover.test.tsx
@@ -275,7 +275,7 @@ describe('DiscoverPage', () => {
     await waitFor(() => {
       expect(mockApproveRecommendation).toHaveBeenCalledWith(
         1,
-        expect.objectContaining({ monitorOption: 'all' }),
+        expect.objectContaining({ monitorOption: 'none' }),
       )
     })
   })


### PR DESCRIPTION
## Summary
- default Lidarr artist approvals to unmonitored instead of monitoring/searching the full catalog
- keep explicit all/new/popular monitoring options available from the split-button UI
- expose safe monitoring choice in the Lidarr approval dialog before sending to Lidarr
- add regression coverage for the safe default API/client behavior

Refs #356

## Verification
- bun run test tests/core/clients/lidarr.test.ts tests/server/routes/recommendations.test.ts
- bunx biome check src/web/components/approve-dialog.tsx src/web/components/monitoring-options.tsx src/core/clients/lidarr.ts src/core/targets/lidarr.ts src/server/routes/recommendations.ts tests/core/clients/lidarr.test.ts tests/server/routes/recommendations.test.ts

## Notes
- this is the develop-only cherry-pick of #355, to avoid dragging the diverged main history into develop.