### PR TITLE
chore: migrate biome config to 2.5.2, document monitorOption default

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "files": {
     "includes": [
       "**",
@@ -16,7 +16,7 @@
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
-    "rules": { "recommended": true }
+    "rules": { "preset": "recommended" }
   },
   "formatter": {
     "enabled": true,

--- a/docs/API.md
+++ b/docs/API.md
@@ -246,7 +246,7 @@ Each item carries a `kind` field (`artist` or `album`). For `kind: "album"`, `re
 
 Approval notes:
 - `approvalMode` defaults to `single_target`
-- `monitorOption` accepts `all`, `new`, `selected`, `popular`, or `none`. `popular` resolves the artist through Spotify, ranks album releases by Spotify popularity, maps the top 3 matches back to MusicBrainz release groups, and sends them to Lidarr as selected albums.
+- `monitorOption` accepts `all`, `new`, `selected`, `popular`, or `none`, and defaults to `none` when omitted: the artist is added to Lidarr without monitoring any albums and no search is triggered. `popular` resolves the artist through Spotify, ranks album releases by Spotify popularity, maps the top 3 matches back to MusicBrainz release groups, and sends them to Lidarr as selected albums.
 - `selectedAlbumIds` contains MusicBrainz release-group MBIDs when `monitorOption` is `selected`; clients may omit it for `popular` because Digarr resolves the top albums server-side.
 - use `approvalMode: "combined_lidarr_slskd"` with an `slskd-*` `targetId` to add to Lidarr first and then queue the matched release in `slskd`
 - `lidarrTargetId` is optional; when the selected `slskd` target is linked to a Lidarr target, Digarr uses that linked target as the fallback, and an explicit `lidarrTargetId` only overrides that default


### PR DESCRIPTION
Two small follow-ups from the recent dependabot/lidarr work:

## biome config migration (biome.json)

`bunx biome migrate --write` after the dev-tools bump to biome 2.5.2 (config schema was still 2.5.0, causing a version nag on every lint run).

**Migrator bug caught and corrected**: the migration rewrote `"rules": { "recommended": true }` to `"rules": { "preset": "none" }`, which silently disables the entire recommended rule set. Symptom: 50 warnings instead of the 9-warning develop baseline, most of them "suppression comment has no effect" from now-dead `biome-ignore` comments. Fixed to `"preset": "recommended"` -- lint output now matches develop exactly (9 pre-existing warnings, 0 errors).

## docs (docs/API.md)

Documented that `monitorOption` on recommendation approval defaults to `none` when omitted (artist added without monitored albums, no search triggered). Matches `src/core/targets/lidarr.ts` / `src/core/clients/lidarr.ts` fallbacks.

## Verification

- `bun run lint`: 9 warnings (develop baseline), 0 errors
- `bun run typecheck`: clean
- `bun run test`: 2548 passed; the single failure is the known pglite `statement_timeout` 5s-timeout flake under full-suite load (passes isolated, pre-existing on develop)