### PR TITLE
fix(providers): surface AI provider error detail, validate Ollama model in test connection

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -505,6 +505,10 @@ Locale notes:
 - `POST /api/v1/mood/discover` honors `X-Digarr-Locale`
 - The response reasoning follows the resolved UI locale, while prompt-language detection uses the submitted mood text
 
+Errors:
+- `400` when no AI provider is configured
+- `502` with `{ "error": "AI provider request failed (<provider>/<model>): <detail>" }` when the provider call fails; `<detail>` includes the upstream status and response body (e.g. an Ollama `model not found` -- pull the model or fix the model name in Settings, and use the Settings test button, which verifies the configured model exists)
+
 ---
 
 ## Search

--- a/src/core/providers/ollama.ts
+++ b/src/core/providers/ollama.ts
@@ -94,11 +94,23 @@ export class OllamaProvider implements RecommendationProvider {
       }
 
       const data = (await response.json()) as OllamaTagsResponse
-      const modelCount = data.models?.length ?? 0
+      const models = data.models?.map((m) => m.name) ?? []
+
+      // Ollama treats a tagless name as ":latest", so "llama3" must match a
+      // pulled "llama3:latest" - compare both the full name and the base name.
+      const available = models.some(
+        (name) => name === this.model || name.split(':')[0] === this.model,
+      )
+      if (!available) {
+        return {
+          success: false,
+          message: `Connected to Ollama, but model "${this.model}" is not available (${models.length} model(s) installed). Pull it first: ollama pull ${this.model}`,
+        }
+      }
 
       return {
         success: true,
-        message: `Connected to Ollama - ${modelCount} model(s) available`,
+        message: `Connected to Ollama - model "${this.model}" is available (${models.length} model(s) installed)`,
       }
     } catch (err: unknown) {
       return { success: false, message: errMsg(err) }

--- a/src/core/providers/retry.ts
+++ b/src/core/providers/retry.ts
@@ -78,13 +78,16 @@ export async function fetchWithRetry(
       }
 
       if (res.status >= 500 && res.status <= 599) {
-        await res.arrayBuffer().catch(() => undefined)
-        throw new Error(`upstream ${res.status}`)
+        const snippet = await errorBodySnippet(res)
+        throw new Error(`upstream ${res.status}${snippet ? `: ${snippet}` : ''}`)
       }
 
       if (!res.ok) {
-        // 4xx (not 429): give up. Clone so caller can still read the body.
-        throw new AbortError(`client error ${res.status}`)
+        // 4xx (not 429): give up, but keep the body - a bare status code
+        // ("client error 404") gives users nothing to act on, while provider
+        // bodies name the missing model or malformed field.
+        const snippet = await errorBodySnippet(res)
+        throw new AbortError(`client error ${res.status}${snippet ? `: ${snippet}` : ''}`)
       }
 
       return res
@@ -107,6 +110,12 @@ function parseRetryAfter(raw: string | null): number | null {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Read an error response body as a single-line snippet, capped for logs. */
+async function errorBodySnippet(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '')
+  return text.replace(/\s+/g, ' ').trim().slice(0, 200)
 }
 
 function isAbortError(err: unknown): boolean {

--- a/src/server/routes/mood.ts
+++ b/src/server/routes/mood.ts
@@ -4,6 +4,7 @@ import { createLidarrClient } from '@/core/clients/lidarr'
 import { detectPromptLocale } from '@/core/i18n/prompt-locale'
 import { buildMoodPrompt } from '@/core/providers/prompt'
 import type { AiProviderRegistry } from '@/core/providers/registry'
+import { errMsg } from '@/core/validation'
 import { resolveRequestLocale } from '@/server/locale'
 import { moodDiscoverSchema } from '@/server/schemas/mood'
 import { zJson } from '@/server/schemas/validator'
@@ -53,14 +54,24 @@ export function moodRoutes(deps: MoodDeps) {
     const promptLocale = detectPromptLocale(trimmedQuery)
     const responseLocale = uiLocale
     const prompt = buildMoodPrompt(trimmedQuery, [], responseLocale)
-    const recs = await provider.getRecommendations({
-      topArtists: [],
-      topGenres: [],
-      listeningPatterns: { totalListens: 0, recentTrend: 'stable' },
-      responseLocale,
-      promptLocale,
-      _rawPrompt: prompt,
-    })
+    let recs: Awaited<ReturnType<typeof provider.getRecommendations>>
+    try {
+      recs = await provider.getRecommendations({
+        topArtists: [],
+        topGenres: [],
+        listeningPatterns: { totalListens: 0, recentTrend: 'stable' },
+        responseLocale,
+        promptLocale,
+        _rawPrompt: prompt,
+      })
+    } catch (err) {
+      const detail = errMsg(err)
+      console.error(`[mood] ${aiProvider} request failed:`, detail)
+      return c.json(
+        { error: `AI provider request failed (${aiProvider}/${aiModel}): ${detail}` },
+        502,
+      )
+    }
 
     // Check which results are already in the user's Lidarr library
     let libraryNames = new Set<string>()

--- a/src/web/components/mood-prompt-bar.tsx
+++ b/src/web/components/mood-prompt-bar.tsx
@@ -29,8 +29,10 @@ export function MoodPromptBar({
     try {
       const res = await moodDiscover(query.trim())
       setResults(res.results)
-    } catch {
-      toast.error(t('discover.moodFailed'))
+    } catch (err) {
+      const detail = err instanceof Error ? err.message.trim() : ''
+      // ApiError.message falls back to "API Error <status>" - still worth showing.
+      toast.error(detail ? `${t('discover.moodFailed')}: ${detail}` : t('discover.moodFailed'))
     } finally {
       setLoading(false)
     }

--- a/tests/core/providers/ollama.test.ts
+++ b/tests/core/providers/ollama.test.ts
@@ -166,6 +166,29 @@ describe('OllamaProvider', () => {
       expect(result.message).toContain('2')
     })
 
+    test('fails when the configured model is not installed', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ models: [{ name: 'mistral:latest' }] }), { status: 200 }),
+      )
+
+      const result = await provider.testConnection()
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain('"llama3" is not available')
+      expect(result.message).toContain('ollama pull llama3')
+    })
+
+    test('matches a tagless configured model against its tagged variant', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ models: [{ name: 'llama3:latest' }] }), { status: 200 }),
+      )
+
+      const result = await provider.testConnection()
+
+      expect(result.success).toBe(true)
+      expect(result.message).toContain('"llama3" is available')
+    })
+
     test('returns failure on non-OK response', async () => {
       fetchSpy.mockResolvedValueOnce(new Response('Service unavailable', { status: 503 }))
 

--- a/tests/core/providers/retry.test.ts
+++ b/tests/core/providers/retry.test.ts
@@ -69,4 +69,36 @@ describe('fetchWithRetry', () => {
     // 1 initial + 2 retries = 3 calls
     expect(fetchSpy).toHaveBeenCalledTimes(3)
   })
+
+  test('includes the response body snippet in 4xx errors', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('{"error":"model \'llama3\' not found, try pulling it first"}', { status: 404 }),
+    )
+    await expect(
+      fetchWithRetry('https://example.com', {}, { minTimeout: 1, retries: 2 }),
+    ).rejects.toThrow(/client error 404: .*model 'llama3' not found/)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('includes the response body snippet in 5xx errors', async () => {
+    // Fresh Response per attempt - a body can only be consumed once.
+    fetchSpy.mockImplementation(async () => new Response('upstream exploded', { status: 500 }))
+    await expect(
+      fetchWithRetry('https://example.com', {}, { minTimeout: 1, retries: 1 }),
+    ).rejects.toThrow(/upstream 500: upstream exploded/)
+  })
+
+  test('collapses whitespace and truncates long error bodies', async () => {
+    const longBody = `line one\nline two   spaced\n${'x'.repeat(500)}`
+    fetchSpy.mockResolvedValueOnce(new Response(longBody, { status: 400 }))
+    const err = await fetchWithRetry(
+      'https://example.com',
+      {},
+      { minTimeout: 1, retries: 1 },
+    ).catch((e: Error) => e)
+    expect(err).toBeInstanceOf(Error)
+    const message = (err as Error).message
+    expect(message).toContain('client error 400: line one line two spaced')
+    expect(message.length).toBeLessThanOrEqual('client error 400: '.length + 200)
+  })
 })

--- a/tests/server/routes/mood.test.ts
+++ b/tests/server/routes/mood.test.ts
@@ -78,6 +78,36 @@ describe('POST /api/v1/mood/discover', () => {
     expect(res.status).toBe(400)
   })
 
+  it('returns 502 with provider detail when the AI call fails', async () => {
+    const app = new Hono()
+    app.route(
+      '/',
+      moodRoutes(
+        makeDeps({
+          providerRegistry: {
+            create: vi.fn().mockResolvedValue({
+              getRecommendations: vi
+                .fn()
+                .mockRejectedValue(new Error('client error 404: model "gpt-4o-mini" not found')),
+              testConnection: vi.fn(),
+            }),
+          } as unknown as MoodDeps['providerRegistry'],
+        }),
+      ),
+    )
+
+    const res = await app.request('/api/v1/mood/discover', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: 'chill vibes' }),
+    })
+
+    expect(res.status).toBe(502)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toContain('openai/gpt-4o-mini')
+    expect(body.error).toContain('client error 404')
+  })
+
   it('passes responseLocale into the AI prompt builder', async () => {
     const getRecommendations = vi.fn().mockResolvedValue([
       {


### PR DESCRIPTION
Motivated by a user report: mood/genre search failed with a generic "mood search failed" toast, and the server log said only `client error 404` -- no way to tell the Ollama model was never pulled.

## Error context (all providers)

- `fetchWithRetry` now includes a truncated (200 char, whitespace-collapsed) response-body snippet in 4xx and 5xx error messages, so an Ollama 404 reads `client error 404: {"error":"model ... not found, try pulling it first"}` instead of a bare status.
- `POST /api/v1/mood/discover` catches provider failures and returns `502 { error: "AI provider request failed (<provider>/<model>): <detail>" }` instead of dropping into the generic 500 handler. Anthropic/OpenAI SDK errors flow through the same catch.
- The mood toast appends the server-provided detail (existing i18n key reused, no new strings).

## Ollama test connection

Previously only hit `/api/tags`, so "test connection" passed even when the configured model was missing -- exactly the trap in the user report. Now verifies the configured model is in the tags list (tag-aware: `llama3` matches `llama3:latest`) and fails with an `ollama pull <model>` hint. The other four providers already ping with the exact model, so they were unaffected.

## Docs

- API.md: documented the mood discover error contract.

## Verification

- New tests: retry body-snippet (4xx/5xx/truncation), Ollama missing-model + tag-match, mood route 502 detail. Targeted files 27/27.
- `bun run lint`: 9 warnings (develop baseline), 0 errors. `bun run typecheck`: clean.
- Full suite: 2554 passed; single failure is the known pglite `statement_timeout` flake (passes isolated, pre-existing).