### PR TITLE
fix(providers): harden LLM output parsing and redact secrets from error snippets

### DIFF
--- a/src/core/providers/gemini.ts
+++ b/src/core/providers/gemini.ts
@@ -3,7 +3,7 @@ import { errMsg } from '@/core/validation'
 import {
   buildRecommendationPrompt,
   getAiRecommendationsJsonSchema,
-  validateAiRecommendations,
+  parseRecommendationResponse,
 } from './prompt'
 import { fetchWithRetry } from './retry'
 import { timeoutSecondsWithDefaultToMs } from './timeout'
@@ -97,7 +97,9 @@ export class GeminiProvider implements RecommendationProvider {
       const text = data.candidates?.[0]?.content?.parts?.[0]?.text
       if (!text) throw new Error('Empty response from Gemini')
 
-      return validateAiRecommendations(JSON.parse(text))
+      // responseSchema does not guarantee well-formed output (truncation at
+      // maxOutputTokens); the shared parser fails with a clear message instead.
+      return parseRecommendationResponse(text)
     } finally {
       clearTimeout(timer)
     }

--- a/src/core/providers/openai.ts
+++ b/src/core/providers/openai.ts
@@ -4,7 +4,7 @@ import { errMsg } from '@/core/validation'
 import {
   buildRecommendationPrompt,
   getAiRecommendationsJsonSchema,
-  validateAiRecommendations,
+  parseRecommendationResponse,
 } from './prompt'
 import { optionalTimeoutSecondsToMs } from './timeout'
 import type { AiUsage, RecommendationProvider } from './types'
@@ -71,7 +71,9 @@ export class OpenAIProvider implements RecommendationProvider {
       throw new Error('Empty response from OpenAI API')
     }
 
-    return validateAiRecommendations(JSON.parse(content))
+    // strict:false means the model can still emit fenced or truncated output;
+    // the shared parser extracts the array instead of crashing on bare JSON.parse.
+    return parseRecommendationResponse(content)
   }
 
   async testConnection(): Promise<{ success: boolean; message: string }> {

--- a/src/core/providers/retry.ts
+++ b/src/core/providers/retry.ts
@@ -112,10 +112,21 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-/** Read an error response body as a single-line snippet, capped for logs. */
+/**
+ * Read an error response body as a single-line snippet, capped for logs.
+ * Snippets end up in thrown error messages that routes may echo to clients,
+ * so credential-shaped substrings are redacted first.
+ */
 async function errorBodySnippet(res: Response): Promise<string> {
   const text = await res.text().catch(() => '')
-  return text.replace(/\s+/g, ' ').trim().slice(0, 200)
+  return redactSecrets(text.replace(/\s+/g, ' ').trim()).slice(0, 200)
+}
+
+function redactSecrets(text: string): string {
+  return text
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[redacted]')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, 'Bearer [redacted]')
+    .replace(/([?&](?:api_?key|key|token)=)[^&\s"']+/gi, '$1[redacted]')
 }
 
 function isAbortError(err: unknown): boolean {

--- a/tests/core/providers/gemini.test.ts
+++ b/tests/core/providers/gemini.test.ts
@@ -77,6 +77,53 @@ describe('GeminiProvider', () => {
     expect(result.success).toBe(false)
   })
 
+  it('parses recommendations wrapped in markdown code fences', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: `\`\`\`json\n${JSON.stringify([
+                      {
+                        artistName: 'Autechre',
+                        reasoning: 'IDM pioneers.',
+                        confidence: 0.85,
+                        genres: ['idm'],
+                      },
+                    ])}\n\`\`\``,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      ),
+    )
+
+    const provider = new GeminiProvider('test-key')
+    const results = await provider.getRecommendations(sampleProfile)
+    expect(results).toHaveLength(1)
+    expect(results[0]?.artistName).toBe('Autechre')
+  })
+
+  it('throws a clear error on truncated JSON output', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            { content: { parts: [{ text: '[{"artistName": "Squarepusher", "reason' }] } },
+          ],
+        }),
+      ),
+    )
+
+    const provider = new GeminiProvider('test-key')
+    await expect(provider.getRecommendations(sampleProfile)).rejects.toThrow(/Malformed JSON array/)
+  })
+
   it('handles empty response from Gemini', async () => {
     fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ candidates: [] })))
 

--- a/tests/core/providers/openai.test.ts
+++ b/tests/core/providers/openai.test.ts
@@ -116,6 +116,33 @@ describe('OpenAIProvider', () => {
       expect(result[0]?.artistName).toBe('Jon Hopkins')
     })
 
+    test('parses recommendations wrapped in markdown code fences', async () => {
+      mockChatCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: `\`\`\`json\n${JSON.stringify(sampleRecommendations)}\n\`\`\``,
+            },
+          },
+        ],
+      })
+
+      const result = await provider.getRecommendations(sampleProfile)
+
+      expect(result).toHaveLength(2)
+      expect(result[0]?.artistName).toBe('Jon Hopkins')
+    })
+
+    test('throws a clear error on truncated JSON output', async () => {
+      mockChatCreate.mockResolvedValueOnce({
+        choices: [{ message: { content: '{"recommendations": [{"artistName": "Jon' } }],
+      })
+
+      await expect(provider.getRecommendations(sampleProfile)).rejects.toThrow(
+        /Malformed JSON array/,
+      )
+    })
+
     test('sends prompt that includes top artists from profile', async () => {
       mockChatCreate.mockResolvedValueOnce({
         choices: [{ message: { content: JSON.stringify(sampleRecommendations) } }],

--- a/tests/core/providers/retry.test.ts
+++ b/tests/core/providers/retry.test.ts
@@ -88,6 +88,27 @@ describe('fetchWithRetry', () => {
     ).rejects.toThrow(/upstream 500: upstream exploded/)
   })
 
+  test('redacts credential-shaped substrings from error body snippets', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        '{"error":"Invalid key sk-proj-abc123def456ghi789 for https://api.example.com/v1?api_key=topsecret123 Bearer eyJhbGciOiJIUzI1NiJ9.payload"}',
+        { status: 401 },
+      ),
+    )
+    const err = await fetchWithRetry(
+      'https://example.com',
+      {},
+      { minTimeout: 1, retries: 1 },
+    ).catch((e: Error) => e)
+    expect(err).toBeInstanceOf(Error)
+    const message = (err as Error).message
+    expect(message).toContain('client error 401')
+    expect(message).not.toContain('sk-proj-abc123def456ghi789')
+    expect(message).not.toContain('topsecret123')
+    expect(message).not.toContain('eyJhbGciOiJIUzI1NiJ9')
+    expect(message).toContain('[redacted]')
+  })
+
   test('collapses whitespace and truncates long error bodies', async () => {
     const longBody = `line one\nline two   spaced\n${'x'.repeat(500)}`
     fetchSpy.mockResolvedValueOnce(new Response(longBody, { status: 400 }))


### PR DESCRIPTION
## Summary

Follow-up hardening from a correctness sweep over `develop` (post #364).

- **OpenAI + Gemini providers**: `getRecommendations` parsed model output with bare `JSON.parse`, so markdown-fenced or truncated responses crashed with an opaque `SyntaxError: Unexpected token`. Both now use the shared `parseRecommendationResponse` (already used by Anthropic, Ollama, and OpenAI-compatible), which strips code fences and reasoning blocks, extracts the recommendations array, and fails with a clear message (`Malformed JSON array in AI response`) that flows into the mood 502 detail from #364.
- **Retry layer**: `errorBodySnippet` echoes upstream error bodies into thrown error messages that routes may return to clients (mood 502) and logs. Credential-shaped substrings are now redacted first: `sk-*` keys, `Bearer` tokens, and `key`/`token`/`api_key` query-param values.

Reviewed but intentionally left alone: `testConnection` uses bare `fetch` (no retry) in gemini/ollama/openai-compatible - the settings test button wants fast one-shot feedback, retries would just delay the failure signal.

## Tests

- openai/gemini: fenced output parses; truncated output throws the clear parser error (2 new tests each)
- retry: snippet redacts sk- key, Bearer token, and query-param secret while keeping the status context

`bun run lint` (9-warning baseline), `bun run typecheck`, full `bun run test` pass. Known pre-existing flake: `tests/db/pglite-integration.test.ts` statement_timeout times out under full-suite load, passes isolated.