### PR TITLE
fix(oidc): lowercase email claim before user creation

### DIFF
--- a/src/server/routes/oidc.ts
+++ b/src/server/routes/oidc.ts
@@ -77,6 +77,9 @@ export function oidcRoutes(deps: OidcRouteDeps) {
 
       if (!user) {
         const isFirstUser = (await deps.getUserCount()) === 0
+        // Local registration lowercases emails and the unique index is
+        // case-sensitive; store the claim lowercased so lookups keep matching.
+        const email = result.claims.email?.toLowerCase()
         const rawPreferred =
           result.claims.preferredUsername ??
           result.claims.email?.split('@')[0] ??
@@ -98,7 +101,7 @@ export function oidcRoutes(deps: OidcRouteDeps) {
             username,
             passwordHash: hashPassword(crypto.randomUUID()),
             isAdmin: isFirstUser,
-            email: result.claims.email,
+            email,
             oidcSubject: result.claims.sub,
             authProvider: 'oidc',
           })
@@ -110,7 +113,7 @@ export function oidcRoutes(deps: OidcRouteDeps) {
             username,
             passwordHash: hashPassword(crypto.randomUUID()),
             isAdmin: false,
-            email: result.claims.email,
+            email,
             oidcSubject: result.claims.sub,
             authProvider: 'oidc',
           })

--- a/tests/server/routes/oidc.test.ts
+++ b/tests/server/routes/oidc.test.ts
@@ -204,6 +204,30 @@ describe('GET /api/v1/auth/oidc/callback', () => {
     )
   })
 
+  it('lowercases the email claim before creating the user', async () => {
+    // Local registration and getUserByEmail lowercase; the unique index is
+    // case-sensitive, so a raw mixed-case claim would create an account
+    // invisible to email lookups and allow same-email duplicates.
+    const deps = makeDeps()
+    deps.mockOidcService.handleCallback.mockResolvedValue({
+      claims: {
+        sub: 'oidc-subject-999',
+        email: 'Carol.MixedCase@Example.COM',
+        emailVerified: true,
+        preferredUsername: 'carol',
+      },
+      accessToken: 'at',
+      expiresIn: 3600,
+    })
+    const app = createTestApp(deps)
+
+    await app.request('/api/v1/auth/oidc/callback?state=abc&code=auth-code-123')
+
+    expect(deps.createUser).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'carol.mixedcase@example.com' }),
+    )
+  })
+
   it('creates non-admin user when users already exist', async () => {
     const deps = makeDeps({
       getUserCount: vi.fn(async () => 3),


### PR DESCRIPTION
## Summary

Second correctness sweep over develop (4 parallel review passes: pipeline core + jobs/ops, server routes, DB layer + crypto, frontend hooks/lib). One confirmed finding, fixed here.

**Bug**: the OIDC callback stored the raw `email` claim from the IdP. Local registration lowercases emails (`auth.ts`) and `getUserByEmail` lowercases its lookup (`users.ts`), while `users_email_unique_idx` is case-sensitive. An IdP emitting `User@Example.com` therefore created an account that:
- never matches any email lookup (lookup normalizes, stored value doesn't), and
- slips past the unique index, allowing a duplicate local account with the same email in different casing.

**Fix**: lowercase the claim once in the callback and use it for both `createUser` call sites (first-user and admin-collision retry paths).

## Reviewed but intentionally left alone

- Quick-discover returning 200 instead of 202 for its fire-and-forget run: REST-semantics nit; changing the status code risks breaking API consumers for zero functional gain.
- Claimed enqueue/startRun race in the pipeline orchestrator: false positive - the async `run()` body executes synchronously up to its first `await`, so `running=true` is set before `enqueue()` returns; no interleaving window exists on a single-threaded event loop.
- Frontend hooks/lib pass came back clean.

## Test plan

- [x] New test: mixed-case email claim -> `createUser` receives lowercased email
- [x] `bun run lint` (9-warning baseline), `bun run typecheck` clean
- [x] Full suite: 2561 passed, 0 failed