### PR TITLE
fix: sweep 3 corrections (first-sync detection, Lidarr addAlbum poll)

### DIFF
--- a/src/core/library/store.ts
+++ b/src/core/library/store.ts
@@ -106,6 +106,8 @@ export interface LibrarySyncStore {
 
   userHasAnySyncState(userId: number): Promise<boolean>
 
+  userHasOwnSyncState(userId: number): Promise<boolean>
+
   listSyncStateForUser(userId: number): Promise<LibrarySyncStateRow[]>
 
   listUnreconciledForUser(userId: number): Promise<LibraryArtistRow[]>
@@ -518,6 +520,18 @@ export function createLibrarySyncStore(database: Db): LibrarySyncStore {
         .select({ id: librarySyncState.id })
         .from(librarySyncState)
         .where(or(eq(librarySyncState.userId, userId), isNull(librarySyncState.userId)))
+        .limit(1)
+      return rows.length > 0
+    },
+
+    // Unlike userHasAnySyncState this ignores global (userId=null) states:
+    // first-sync detection must ask whether THIS user's own sources ever
+    // synced, not whether any library data is visible to them.
+    async userHasOwnSyncState(userId) {
+      const rows = await database
+        .select({ id: librarySyncState.id })
+        .from(librarySyncState)
+        .where(eq(librarySyncState.userId, userId))
         .limit(1)
       return rows.length > 0
     },

--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -267,7 +267,7 @@ export class PipelineOrchestrator extends EventEmitter {
         deps.userId === undefined ||
         deps.librarySync === undefined ||
         typeof db.getLibraryArtistsForUser !== 'function' ||
-        typeof db.userHasAnySyncState !== 'function'
+        typeof db.userHasOwnSyncState !== 'function'
       ) {
         throw new Error(
           'Pipeline orchestrator requires librarySync, userId, and library StoreDb methods',
@@ -279,8 +279,11 @@ export class PipelineOrchestrator extends EventEmitter {
       this.emit('progress', { stage: 'collect', message: t('pipeline.message.loadingLibrary') })
 
       const userIdForSync = deps.userId
-      const hasAnyState = await db.userHasAnySyncState(userIdForSync)
-      if (!hasAnyState) {
+      // Own states only: a global (userId=null) sync state must not mask a
+      // user whose personal sources never synced, or their slow first sync
+      // would run awaited instead of in the background.
+      const hasOwnState = await db.userHasOwnSyncState(userIdForSync)
+      if (!hasOwnState) {
         // First-sync detection: fire-and-forget so the pipeline doesn't hang
         // for the slow MB lookups on a fresh install.
         void deps.librarySync

--- a/src/core/pipeline/store.ts
+++ b/src/core/pipeline/store.ts
@@ -75,7 +75,7 @@ export interface StoreDb {
     }>
   >
 
-  userHasAnySyncState?: (userId: number) => Promise<boolean>
+  userHasOwnSyncState?: (userId: number) => Promise<boolean>
 
   // Optional atomic variant: wraps upsertArtist + insertRecommendation in a
   // single DB transaction so a crash between the two cannot leave an artist

--- a/src/core/targets/lidarr.ts
+++ b/src/core/targets/lidarr.ts
@@ -134,7 +134,11 @@ export function createLidarrTarget(
           artistId = added.id
         }
 
-        const albums = await client.getAlbums(artistId)
+        // A just-added artist populates its album list asynchronously (see the
+        // poll note at the top); an already-tracked artist has it ready.
+        const albums = existing
+          ? await client.getAlbums(artistId)
+          : await findSelectedAlbums(artistId, [album.releaseGroupMbid])
         const match = albums.find((a) => a.foreignAlbumId === album.releaseGroupMbid)
         if (!match) {
           return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,7 +301,7 @@ const storeDb: StoreDb = {
       .from(libraryArtists)
       .where(and(...conds.filter((c): c is NonNullable<typeof c> => c !== undefined)))
   },
-  userHasAnySyncState: (userId) => librarySyncStore.userHasAnySyncState(userId),
+  userHasOwnSyncState: (userId) => librarySyncStore.userHasOwnSyncState(userId),
   tryConsumeRateLimit: (key, config) => tryConsume(db, key, config),
 }
 

--- a/tests/core/discovery-modes/run.test.ts
+++ b/tests/core/discovery-modes/run.test.ts
@@ -32,7 +32,7 @@ function makePipelineDeps(): Omit<
       getBlockedMbids: vi.fn(async () => new Set<string>()),
       getFeedbackHistory: vi.fn(async () => new Map()),
       getLibraryArtistsForUser: vi.fn(async () => []),
-      userHasAnySyncState: vi.fn(async () => false),
+      userHasOwnSyncState: vi.fn(async () => false),
     },
     settings: {
       lidarrUrl: null,

--- a/tests/core/library/store.test.ts
+++ b/tests/core/library/store.test.ts
@@ -552,6 +552,20 @@ describe.skipIf(!SHOULD_RUN)('LibrarySyncStore', () => {
     expect(rows).toHaveLength(1)
   })
 
+  // Regression: a global (userId=null) sync state must not count as the user's
+  // own state, or first-sync detection in the pipeline would run a new user's
+  // slow first sync awaited instead of in the background.
+  it('userHasOwnSyncState ignores global sync states; userHasAnySyncState includes them', async () => {
+    const store = createLibrarySyncStore(db)
+    await store.upsertLibrarySyncState(null, LIDARR_SOURCE, { lastSyncStatus: 'completed' })
+
+    expect(await store.userHasAnySyncState(userId)).toBe(true)
+    expect(await store.userHasOwnSyncState(userId)).toBe(false)
+
+    await store.upsertLibrarySyncState(userId, PLEX_SOURCE, { lastSyncStatus: 'completed' })
+    expect(await store.userHasOwnSyncState(userId)).toBe(true)
+  })
+
   it('upsertOverride concurrent calls do not duplicate', async () => {
     const store = createLibrarySyncStore(db)
     await Promise.all([

--- a/tests/core/library/sync.test.ts
+++ b/tests/core/library/sync.test.ts
@@ -48,6 +48,7 @@ function makeStore(): LibrarySyncStore {
     listAlbumOverrides: vi.fn(async () => []),
     getKnownMbidsForUser: vi.fn(async () => new Set<string>()),
     userHasAnySyncState: vi.fn(async () => false),
+    userHasOwnSyncState: vi.fn(async () => false),
     listSyncStateForUser: vi.fn(async () => []),
     listUnreconciledForUser: vi.fn(async () => []),
     listUnreconciledAlbumsForUser: vi.fn(async () => []),

--- a/tests/core/pipeline/orchestrator.test.ts
+++ b/tests/core/pipeline/orchestrator.test.ts
@@ -160,7 +160,7 @@ function makeDb() {
         matchConfidence: 1.0,
       },
     ]),
-    userHasAnySyncState: vi.fn().mockResolvedValue(true),
+    userHasOwnSyncState: vi.fn().mockResolvedValue(true),
     // Extra methods the orchestrator needs for stale batch cleanup
     updateBatch: vi.fn().mockResolvedValue(undefined),
   }
@@ -733,7 +733,7 @@ describe('PipelineOrchestrator', () => {
           matchConfidence: 1.0,
         },
       ]),
-      userHasAnySyncState: vi.fn(async () => true),
+      userHasOwnSyncState: vi.fn(async () => true),
     }
     const syncForUser = vi.fn(async () => ({ userId: 1, results: [] })) as SyncForUser
 
@@ -858,7 +858,7 @@ describe('PipelineOrchestrator', () => {
     const dbWithLibrary: import('@/core/pipeline/store').StoreDb = {
       ...db,
       getLibraryArtistsForUser: vi.fn(async () => []),
-      userHasAnySyncState: vi.fn(async () => false), // first sync ever
+      userHasOwnSyncState: vi.fn(async () => false), // first sync ever
     }
     const syncForUser = vi.fn(
       () =>

--- a/tests/core/targets/lidarr-add-album.test.ts
+++ b/tests/core/targets/lidarr-add-album.test.ts
@@ -106,13 +106,76 @@ describe('createLidarrTarget().addAlbum', () => {
   })
 
   it('returns success:false with "album not found in Lidarr" when the release group is absent after add', async () => {
+    vi.useFakeTimers()
+    try {
+      const client = mockLidarrClient()
+      client.getArtists.mockResolvedValue([])
+      client.addArtist.mockResolvedValue({ id: 42 })
+      // Lidarr has the artist but never surfaces this release group
+      client.getAlbums.mockResolvedValue([
+        { id: 7, foreignAlbumId: 'some-other-rg', monitored: false, title: 'Other' },
+      ])
+
+      const target = createLidarrTarget(1, {
+        url: 'http://lidarr:8686',
+        apiKey: 'abc',
+      })
+
+      const pending = target.addAlbum?.(
+        { artistMbid: 'a1', artistName: 'Artist', releaseGroupMbid: 'rg-missing' },
+        { qualityProfileId: 1, metadataProfileId: 1, rootFolderId: 1 },
+      )
+      await vi.runAllTimersAsync()
+      const result = await pending
+
+      expect(result?.success).toBe(false)
+      expect(result?.error).toBe('album not found in Lidarr')
+      expect(client.updateAlbum).not.toHaveBeenCalled()
+      expect(client.triggerCommand).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Regression: Lidarr populates a just-added artist's album list
+  // asynchronously; addAlbum must poll like addArtist does instead of failing
+  // on the first empty getAlbums response.
+  it('polls until the album appears after adding a new artist', async () => {
+    vi.useFakeTimers()
+    try {
+      const client = mockLidarrClient()
+      client.getArtists.mockResolvedValue([])
+      client.addArtist.mockResolvedValue({ id: 42 })
+      client.getAlbums
+        .mockResolvedValueOnce([])
+        .mockResolvedValue([{ id: 7, foreignAlbumId: 'rg-1', monitored: false, title: 'One' }])
+
+      const target = createLidarrTarget(1, {
+        url: 'http://lidarr:8686',
+        apiKey: 'abc',
+      })
+
+      const pending = target.addAlbum?.(
+        { artistMbid: 'a1', artistName: 'Artist', releaseGroupMbid: 'rg-1' },
+        { qualityProfileId: 1, metadataProfileId: 1, rootFolderId: 1 },
+      )
+      await vi.runAllTimersAsync()
+      const result = await pending
+
+      expect(result?.success).toBe(true)
+      expect(result?.externalId).toBe(7)
+      expect(client.getAlbums).toHaveBeenCalledTimes(2)
+      expect(client.updateAlbum).toHaveBeenCalledWith(7, { monitored: true })
+      expect(client.triggerCommand).toHaveBeenCalledWith('AlbumSearch', { albumIds: [7] })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not poll for an already-tracked artist with the album absent', async () => {
     const client = mockLidarrClient()
-    client.getArtists.mockResolvedValue([])
-    client.addArtist.mockResolvedValue({ id: 42 })
-    // Lidarr has the artist but not this release group yet
-    client.getAlbums.mockResolvedValue([
-      { id: 7, foreignAlbumId: 'some-other-rg', monitored: false, title: 'Other' },
-    ])
+    client.getArtists.mockResolvedValue([{ id: 99, foreignArtistId: 'a1' }])
+    client.getAlbums.mockResolvedValue([])
 
     const target = createLidarrTarget(1, {
       url: 'http://lidarr:8686',
@@ -120,13 +183,11 @@ describe('createLidarrTarget().addAlbum', () => {
     })
 
     const result = await target.addAlbum?.(
-      { artistMbid: 'a1', artistName: 'Artist', releaseGroupMbid: 'rg-missing' },
+      { artistMbid: 'a1', artistName: 'Artist', releaseGroupMbid: 'rg-1' },
       { qualityProfileId: 1, metadataProfileId: 1, rootFolderId: 1 },
     )
 
     expect(result?.success).toBe(false)
-    expect(result?.error).toBe('album not found in Lidarr')
-    expect(client.updateAlbum).not.toHaveBeenCalled()
-    expect(client.triggerCommand).not.toHaveBeenCalled()
+    expect(client.getAlbums).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/helpers/test-app.ts
+++ b/tests/helpers/test-app.ts
@@ -136,6 +136,7 @@ export function makeDeps(overrides: Partial<AppDependencies> = {}): AppDependenc
       deleteOverride: vi.fn(async () => {}),
       getKnownMbidsForUser: vi.fn(async () => new Set<string>()),
       userHasAnySyncState: vi.fn(async () => false),
+      userHasOwnSyncState: vi.fn(async () => false),
       listSyncStateForUser: vi.fn(async () => []),
       listUnreconciledForUser: vi.fn(async () => []),
     } as unknown as AppDependencies['librarySyncStore'],

--- a/tests/server/routes/library.test.ts
+++ b/tests/server/routes/library.test.ts
@@ -112,6 +112,7 @@ function makeMockLibrarySyncStore() {
     deleteOverride: vi.fn(async () => {}),
     getKnownMbidsForUser: vi.fn(async () => new Set<string>()),
     userHasAnySyncState: vi.fn(async () => false),
+    userHasOwnSyncState: vi.fn(async () => false),
     listSyncStateForUser: vi.fn(async () => []),
     listUnreconciledForUser: vi.fn(async () => []),
     listUnreconciledAlbumsForUser: vi.fn(async () => []),


### PR DESCRIPTION
## Summary

Proactive correctness sweep #3 over develop. Two confirmed bugs fixed.

### fix(library): scope pipeline first-sync detection to user-owned sync states
A global (`userId=null`) sync state -- created by the shared Lidarr library source -- made `userHasAnySyncState` return true for every user. A new user's first per-user library sync (full MusicBrainz reconciliation, rate-limited) then ran **awaited** inside the pipeline instead of the documented fire-and-forget background path, blocking the run for minutes.

Fix: new `userHasOwnSyncState` (own states only) backs first-sync detection. The discovery connection snapshot keeps `userHasAnySyncState` deliberately -- global library data is visible to every user, so `hasLibrarySync` should include it.

### fix(targets): poll album list after adding a new artist in Lidarr addAlbum
Lidarr populates a just-added artist's album list asynchronously (documented in the file header, and `addArtist` already polls for this reason), but `addAlbum` did an immediate `getAlbums` -- so gap-fill adds for artists not yet in Lidarr failed with "album not found in Lidarr" even though the album appears seconds later. Now reuses the `findSelectedAlbums` poll when the artist was just added; already-tracked artists keep the single immediate lookup.

### Verification
- lint: 9-warning baseline, no new
- typecheck: clean
- vitest: 2563 passed / 0 failed
- library store suite run against real Postgres (19/19) including the new regression test

### Reviewed clean (no action)
- jobs/ops/crypto/sessions/validation zone
- non-auth server routes + notifications + url-safety zone
- pipeline stages: one finding rejected as intentional (resolve.ts first-positive-overlap early break -- deliberate MB rate-limit trade-off, commented)