### PR TITLE
chore(release): sweep example version pins to v1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ docker run -d --name digarr -p 3000:3000 \
 
 Open `http://localhost:3000` and complete the setup wizard. You can start with Lidarr, Emby, or discovery-only mode. Database migrations run automatically on every startup.
 
-The image pulls `docker.io/iuliandita/digarr:latest`, the newest stable release and the recommended channel for first-time home installs. Use a minor tag like `:1.11` to stay on patch fixes for that line, or pin a specific patch like `:1.11.1` when you want zero surprises. For bleeding-edge testing, `:nightly` (GHCR only) is rebuilt on every change with an immutable `:nightly-<sha>` alongside it; the web footer and `GET /health` report the running `gitSha` so a nightly bug report can be pinned to a commit.
+The image pulls `docker.io/iuliandita/digarr:latest`, the newest stable release and the recommended channel for first-time home installs. Use a minor tag like `:1.12` to stay on patch fixes for that line, or pin a specific patch like `:1.12.0` when you want zero surprises. For bleeding-edge testing, `:nightly` (GHCR only) is rebuilt on every change with an immutable `:nightly-<sha>` alongside it; the web footer and `GET /health` report the running `gitSha` so a nightly bug report can be pinned to a commit.
 
 ### Database backend
 

--- a/deploy/docker/docker-compose.pglite.yml
+++ b/deploy/docker/docker-compose.pglite.yml
@@ -9,9 +9,9 @@ services:
   app:
     image: docker.io/iuliandita/digarr:latest
     # :latest -> newest stable release, recommended for first-time home installs
-    # Track patch fixes only: docker.io/iuliandita/digarr:1.11
-    # Pin a version for zero surprises: docker.io/iuliandita/digarr:1.11.1
-    # Default is alpine; Debian/glibc variant: docker.io/iuliandita/digarr:1.11.1-debian
+    # Track patch fixes only: docker.io/iuliandita/digarr:1.12
+    # Pin a version for zero surprises: docker.io/iuliandita/digarr:1.12.0
+    # Default is alpine; Debian/glibc variant: docker.io/iuliandita/digarr:1.12.0-debian
     user: "1000:1000"
     env_file:
       - path: .env

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -17,11 +17,11 @@ services:
     image: docker.io/iuliandita/digarr:latest
     # Channels:
     #   :latest -> newest stable release, recommended for first-time home installs
-    #   :1.11 -> current minor release line, patch fixes only
+    #   :1.12 -> current minor release line, patch fixes only
     # Pin to a specific patch when you want zero surprises:
-    # image: docker.io/iuliandita/digarr:1.11.1
+    # image: docker.io/iuliandita/digarr:1.12.0
     # Default image is alpine (musl libc). Debian/glibc variant:
-    # image: docker.io/iuliandita/digarr:1.11.1-debian
+    # image: docker.io/iuliandita/digarr:1.12.0-debian
     user: "1000:1000"
     networks:
       - frontend

--- a/scripts/sync-deploy-digests.ts
+++ b/scripts/sync-deploy-digests.ts
@@ -12,6 +12,9 @@
  *   - deploy/k8s/rendered.yaml        (image ref with @sha256:...)
  *   - deploy/unraid/digarr.xml        (digest comment + <Repository> :tag,
  *                                      <Tag>, <TagDescription>)
+ *   - deploy/docker/docker-compose.yml        (example pin comments)
+ *   - deploy/docker/docker-compose.pglite.yml (example pin comments)
+ *   - README.md                               (example tag pins)
  *
  * rendered.yaml is a `helm template` snapshot, but at the digest-sync step the
  * only line that changes is the image digest, so a targeted string replace is
@@ -33,6 +36,7 @@ if (!tagArg) {
   process.exit(1)
 }
 const tag = tagArg.replace(/^v/, '')
+const minor = tag.split('.').slice(0, 2).join('.')
 
 async function bearerToken(): Promise<string> {
   if (process.env.GH_TOKEN) {
@@ -121,6 +125,44 @@ const targets: Target[] = [
     path: 'deploy/unraid/digarr.xml',
     pattern: /<TagDescription>[^<]*<\/TagDescription>/,
     replacement: () => `<TagDescription>v${tag} release</TagDescription>`,
+  },
+  // Example pins in compose comments and the README. Never the active image
+  // (compose defaults to :latest), but stale examples read as the current
+  // release to anyone copying them.
+  {
+    path: 'deploy/docker/docker-compose.yml',
+    pattern: /(# {3}:)\d+\.\d+( -> current minor release line)/,
+    replacement: (_d, _match, prefix, suffix) => `${prefix}${minor}${suffix}`,
+  },
+  {
+    path: 'deploy/docker/docker-compose.yml',
+    pattern: /(# image: docker\.io\/iuliandita\/digarr:)\d+\.\d+\.\d+/g,
+    replacement: (_d, _match, prefix) => `${prefix}${tag}`,
+  },
+  {
+    path: 'deploy/docker/docker-compose.pglite.yml',
+    pattern: /(Track patch fixes only: docker\.io\/iuliandita\/digarr:)\d+\.\d+/,
+    replacement: (_d, _match, prefix) => `${prefix}${minor}`,
+  },
+  {
+    path: 'deploy/docker/docker-compose.pglite.yml',
+    pattern: /(surprises: docker\.io\/iuliandita\/digarr:)\d+\.\d+\.\d+/,
+    replacement: (_d, _match, prefix) => `${prefix}${tag}`,
+  },
+  {
+    path: 'deploy/docker/docker-compose.pglite.yml',
+    pattern: /(variant: docker\.io\/iuliandita\/digarr:)\d+\.\d+\.\d+(-debian)/,
+    replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
+  },
+  {
+    path: 'README.md',
+    pattern: /(minor tag like `:)\d+\.\d+(`)/,
+    replacement: (_d, _match, prefix, suffix) => `${prefix}${minor}${suffix}`,
+  },
+  {
+    path: 'README.md',
+    pattern: /(specific patch like `:)\d+\.\d+\.\d+(`)/,
+    replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
   },
 ]
 


### PR DESCRIPTION
## Summary

Follow-up to #371: the README quickstart and compose example-pin comments still referenced 1.11.x. This bumps the seven example pins to 1.12 / 1.12.0 and extends `scripts/sync-deploy-digests.ts` with targets for them, so future releases rewrite these automatically instead of relying on hand edits.

No behavior change -- the active compose image stays `:latest`; only comments and README prose move.

## Test plan

- `bun scripts/sync-deploy-digests.ts v1.12.0` run output shows all targets matched (existing deploy targets no-op, proving idempotence)
- biome + tsc clean on the script