### PR TITLE
fix(ci): normalize helm template output across helm major versions

### DIFF
--- a/deploy/k8s/rendered.yaml
+++ b/deploy/k8s/rendered.yaml
@@ -109,7 +109,6 @@ spec:
         - protocol: TCP
           port: 5432
   egress: []
-
 ---
 # Source: digarr/templates/serviceaccount.yaml
 apiVersion: v1
@@ -124,7 +123,6 @@ metadata:
     app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: false
-
 ---
 # Source: digarr/templates/secret.yaml
 apiVersion: v1
@@ -142,7 +140,6 @@ type: Opaque
 stringData:
   POSTGRES_PASSWORD: "REPLACE_ME"
   DATABASE_URL: "postgresql://digarr:REPLACE_ME@digarr-postgresql:5432/digarr"
-
 ---
 # Source: digarr/templates/configmap.yaml
 apiVersion: v1
@@ -159,7 +156,6 @@ metadata:
 data:
   PORT: "3000"
   LOG_LEVEL: "info"
-
 ---
 # Source: digarr/templates/postgresql.yaml
 apiVersion: v1
@@ -210,7 +206,6 @@ spec:
     app.kubernetes.io/name: digarr
     app.kubernetes.io/instance: digarr
     app.kubernetes.io/component: app
-
 ---
 # Source: digarr/templates/deployment.yaml
 apiVersion: apps/v1
@@ -323,7 +318,6 @@ spec:
           emptyDir: {}
         - name: backups
           emptyDir: {}
-
 ---
 # Source: digarr/templates/postgresql.yaml
 apiVersion: apps/v1

--- a/scripts/k8s-sync.sh
+++ b/scripts/k8s-sync.sh
@@ -30,9 +30,17 @@ CHART_VERSION="$(awk '/^version:/ {print $2; exit}' "${CHART_DIR}/Chart.yaml")"
 # chart directly with \`helm install\`; this snapshot exists only so
 # reviewers can see raw manifest shape without running helm locally.
 HEADER
+  # Normalize across helm major versions: helm 4 emits a blank line before
+  # each `---` document separator, helm 3 does not. Drop those (and trailing
+  # blanks) so the snapshot is byte-identical regardless of the helm on PATH -
+  # otherwise CI's pinned helm and a contributor's local helm fight over
+  # whitespace-only diffs.
   helm template digarr "${CHART_DIR}" \
     --namespace digarr \
-    --set postgresql.auth.password=REPLACE_ME
+    --set postgresql.auth.password=REPLACE_ME |
+    awk 'BEGIN { blanks = 0 }
+         /^$/ { blanks++; next }
+         { if ($0 != "---") for (i = 0; i < blanks; i++) print ""; blanks = 0; print }'
 } > "${OUT_FILE}"
 
 printf 'wrote %s (chart %s)\n' "${OUT_FILE#"${REPO_ROOT}"/}" "${CHART_VERSION}"


### PR DESCRIPTION
The helm-drift job has been red on every branch since the v1.12.0 release: rendered.yaml was regenerated with a local helm 4, which emits a blank line before each `---` document separator, while CI pins helm 3.16.4 which does not. Byte-compare fails on whitespace only.

`k8s-sync.sh` now strips separator-adjacent blank lines from the template output, so the snapshot is identical under either helm major. rendered.yaml regenerated with the normalized script (6 blank lines removed, no manifest changes).

Unblocks helm-drift on #376 and #377.