### PR TITLE
docs(readme): add feature highlights block and keyword cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,9 @@ A successful verify proves the image was built by this repo's `release.yml` work
 
 ## Friends
 
-Other self-hosted music discovery projects:
+Other self-hosted music discovery projects. For a deeper look at how the
+approaches differ and which tool fits which setup, see
+[Choosing a Self-Hosted Music Discovery Tool](docs/COMPARISON.md).
 
 | Project | Approach |
 |---------|----------|
@@ -288,6 +290,8 @@ Other self-hosted music discovery projects:
 | [Sonobarr](https://github.com/Dodelidoo-Labs/sonobarr) | Last.fm discovery with optional AI assistant. Real-time UI. |
 | [Explo](https://github.com/LumePart/Explo) | Discover Weekly for self-hosted. ListenBrainz recs to your media server. |
 | [MusicSeerr](https://github.com/HabiRabbu/Musicseerr) | Overseerr-style music request and discovery built around Lidarr. |
+| [SoulSync](https://github.com/Nezreka/SoulSync) | Hands-off acquisition: watchlist monitoring, multi-source downloads, rich tagging. |
+| [Kima Hub](https://github.com/Chevron7Locked/kima-hub) | Full music platform: streaming player, embedding similarity, podcasts. |
 | [MusicMoveArr Datasets](https://github.com/MusicMoveArr/Datasets) | MB/Spotify/Deezer/Tidal datasets used by Digarr for genre enrichment. |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@
 
 [More screenshots](docs/SCREENSHOTS.md)
 
+> [!IMPORTANT]
+> **Why people pick Digarr**
+>
+> - 💿 **Album-level discovery** -- recommends and approves *individual albums* (gap-fills, new releases, net-new finds), not just artists. No whole-discography grabs.
+> - 🧠 **AI you control** -- Anthropic, OpenAI, Gemini, Ollama, or any OpenAI-compatible endpoint, scored with **configurable weights** that learn from your approvals and rejections.
+> - 💬 **Mood discovery** -- *"something like Boards of Canada but darker"* is a valid query.
+> - 🧭 **13 discovery modes** -- ListenBrainz radios, Release Radar, Library Gap-Fill, artist relationship graphs, labels, charts, Deezer Flow, Spotify Saved Albums -- all runnable on demand or saved as subscriptions.
+> - 🔓 **No Lidarr required** -- full discovery-only mode with genre-aware scoring from your listening sources.
+> - 👥 **Real multi-user** -- OIDC/SSO plus per-user queues, credentials, scoring weights, and targets.
+> - 🌍 **15 languages** -- the UI *and* the AI's reasoning, localized.
+> - 🛡️ **Ops-grade self-hosting** -- zero-external-database single container, backup/restore, job observability, pre-flight upgrade checks, cosign-signed images.
+
 > [!NOTE]
 > **Built with AI.** A human sets the roadmap, designs the architecture, and reviews the output; most code and tests are AI-generated.
 
@@ -307,3 +319,9 @@ MIT. See [LICENSE](LICENSE).
    <img alt="Star History Chart" src="https://api.star-history.com/image?repos=iuliandita/digarr&type=timeline&legend=top-left" />
  </picture>
 </a>
+
+---
+
+<p align="center"><sub>
+music discovery · AI music recommendations · self-hosted · lidarr companion · *arr stack · album discovery · new music finder · music curation · mood search · playlist generator · music taste profile · plex · jellyfin · emby · navidrome · subsonic · slskd · soulseek · listenbrainz · last.fm · spotify · deezer · musicbrainz · discogs · tidal · bandcamp · release radar · library gap-fill · discovery modes · music subscriptions · genre discovery · similar artists · charts · docker · kubernetes · helm · unraid · synology · homelab · multi-user · OIDC · SSO · webhooks · discord notifications · i18n · 15 languages · open source · MIT
+</sub></p>

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,0 +1,126 @@
+# Choosing a Self-Hosted Music Discovery Tool
+
+There are many good projects in this space, and most of them are not actually
+competing -- they solve different problems and several of them coexist happily
+in one homelab. This page maps the field so you can pick the right tool (or
+combination) for your setup. Accurate as of July 2026; these projects move
+fast, so check their repos for current state. Corrections welcome via
+[issues](https://github.com/iuliandita/digarr/issues).
+
+## Three philosophies
+
+Almost every tool in this space follows one of three models:
+
+1. **Discovery and curation** -- build a taste profile, generate candidates,
+   score them, and put a human review step before anything touches your
+   library. You approve; the tool acts. *Digarr lives here.*
+2. **Acquisition automation** -- watch artists or feeds, find the files, and
+   download them with no review step. Discovery is an input; the product is a
+   growing, well-organized library. *SoulSync, Explo, and Aurral live here.*
+3. **Request fulfillment** -- the Overseerr pattern: users browse and request,
+   an admin (or auto-approval) fulfills through Lidarr. *MusicSeerr lives
+   here.*
+
+None of these is "better" -- they answer different questions. "What should I
+listen to next, and do I trust it enough to add?" is a different problem from
+"keep my collection complete without me touching it" and from "let my
+household request music like they request movies."
+
+## Capability matrix
+
+| | Digarr | SoulSync | Explo | Aurral | Kima Hub | MusicSeerr | MixArr | Lidify |
+|---|---|---|---|---|---|---|---|---|
+| Album-level recommendations (gap-fill, new releases, net-new) | Yes | Partial [^1] | -- | -- | -- | -- | -- | -- |
+| LLM-assisted recommendations (bring your own provider) | Yes | -- | -- | -- | -- | -- | Yes | -- |
+| Configurable scoring weights | Yes | -- | -- | -- | -- | -- | -- | -- |
+| Review-then-approve workflow | Yes | -- | -- | -- | -- | Yes | -- | -- |
+| Natural-language mood search | Yes | -- | -- | -- | -- | -- | -- | -- |
+| Works without Lidarr | Yes | Yes | Yes | -- | Yes | -- | -- | -- |
+| Multi-user with per-user credentials | Yes | -- | -- | -- | Yes | Partial [^2] | -- | -- |
+| OIDC / SSO | Yes | -- | -- | -- | Yes | Yes | Yes | -- |
+| Localized UI (multiple languages) | Yes (15) | -- | -- | -- | -- | -- | -- | -- |
+| Scheduled discovery subscriptions | Yes | Yes | Yes | Yes | -- | -- | Yes | -- |
+| Playlist generation / export | Yes | Yes | Yes | Yes | Yes | -- | -- | -- |
+| Automated downloading (built-in) | Partial [^3] | Yes | Yes | Yes | Yes | Partial [^3] | -- | -- |
+| Media-server library sync (Plex/Jellyfin/Emby/Subsonic) | Yes | Yes | Partial | Partial | Yes | -- | -- | -- |
+| Backup/restore, job history, upgrade pre-flight checks | Yes | -- | -- | -- | -- | -- | -- | -- |
+| Built-in music player / streaming | -- | -- | -- | -- | Yes | -- | -- | -- |
+
+[^1]: New-release detection for watchlisted artists; not a recommendation
+    queue of individual albums with per-album approval.
+[^2]: Multi-user auth shipped recently; per-user service credentials are not
+    the core model.
+[^3]: Digarr and MusicSeerr queue downloads through `slskd` and/or Lidarr as
+    an *outcome of an approval*, rather than shipping their own downloader.
+
+"--" means the capability is absent or out of scope for that project's design,
+not that the project is deficient -- see the philosophy section above.
+
+## The projects, briefly
+
+- **[SoulSync](https://github.com/Nezreka/SoulSync)** -- the most popular
+  acquisition-automation tool. Watchlist monitoring, auto playlists,
+  multi-source downloading with fingerprint verification, heavy metadata
+  enrichment and tagging. Pick it if you want a hands-off pipeline from
+  streaming taste to organized files and you do not want a review step.
+- **[Explo](https://github.com/LumePart/Explo)** -- "Discover Weekly for
+  self-hosted." ListenBrainz recommendations downloaded straight to your media
+  server. Small, focused, Go binary. Pick it for zero-ceremony weekly fresh
+  music.
+- **[Aurral](https://github.com/lklynet/aurral)** -- Last.fm tag similarity
+  plus Weekly Flow playlists with built-in Soulseek downloading and Navidrome
+  sync. Pick it if you live in Navidrome and want flow-style playlists.
+- **[Kima Hub](https://github.com/Chevron7Locked/kima-hub)** -- a full music
+  platform: streaming player, audio-embedding similarity, 3D library
+  visualization, podcasts. Closer to a Plexamp alternative than a discovery
+  companion. Pick it if you want one app that plays *and* explores.
+- **[MusicSeerr](https://github.com/HabiRabbu/Musicseerr)** -- Overseerr-style
+  requests for music on top of Lidarr. Pick it if your household already knows
+  the Overseerr/Jellyseerr flow.
+- **[MixArr](https://github.com/aquantumofdonuts/mixarr)** -- the widest
+  subscription net in the space (dozens of feed types across many services)
+  with local-LLM recommendation support. Pick it for feed breadth.
+- **[Lidify](https://github.com/TheWicklowWolf/Lidify)** -- the original.
+  Lidarr library plus Last.fm similar artists, intentionally minimal and
+  feature-complete. Pick it if you want exactly that and nothing else.
+- **[Curatorr](https://github.com/MickyGX/curatorr)** -- behavior-first:
+  scores artists on skip/completion telemetry from Plex/Jellyfin/Emby and
+  builds smart playlists. Pick it if you trust your playback behavior more
+  than your stated taste.
+- **[Brainarr](https://github.com/RicherTunes/Brainarr)** -- a native Lidarr
+  plugin (no separate app) doing privacy-first AI recommendations inside
+  Lidarr's own UI. Pick it if you want zero extra containers.
+- **[Sonobarr](https://github.com/Dodelidoo-Labs/sonobarr)** -- Last.fm
+  discovery with a real-time UI and per-user auto-approve. Development is
+  currently paused.
+
+## Where Digarr fits
+
+Digarr is the discovery-and-curation option: it assumes you *want* to be in
+the loop. Its distinguishing choices:
+
+- **Albums are first-class.** Digarr recommends individual albums -- studio
+  albums you are missing from artists you track, new releases, and net-new
+  finds -- and approving one adds *only* that album, not a whole discography.
+- **Scoring you can see and tune.** Recommendations carry a weighted composite
+  score (consensus, similarity, genre overlap, AI confidence, feedback
+  learning, popularity) with user-adjustable weights that learn from your
+  approve/reject history.
+- **Your AI, your choice.** Hosted providers or fully local inference through
+  Ollama and OpenAI-compatible endpoints, with the reasoning shown per
+  recommendation -- and mood search in plain language.
+- **No Lidarr required.** Discovery-only mode builds its genre reference from
+  your listening sources instead of a library.
+- **Built for more than one person.** Multi-user with per-user queues,
+  credentials, scoring weights, and targets; OIDC/SSO; a UI and AI output
+  localized in 15 languages.
+- **Run like infrastructure.** Backup/restore, pre-flight upgrade checks with
+  auto-backup, job history with stuck-task detection, signed images, and a
+  nightly / latest / stable release channel model.
+
+It deliberately does **not** ship its own downloader or player. Acquisition
+goes through Lidarr or `slskd` after approval; playback stays in your media
+server. If you want the opposite trade-offs, the projects above are good at
+exactly that -- and several of them pair well with Digarr in the same stack
+(for example: Digarr for curated additions, SoulSync or Explo for hands-off
+freshness, your media server for playback).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,6 +50,7 @@ Ideas we're considering. If any of these matter to you, open an issue or discuss
 
 ### Integrations
 
+- Multiple Lidarr instances as approval targets
 - Prowlarr integration
 - Odesli / song.link resolution
 - Apple Music / iTunes metadata enrichment


### PR DESCRIPTION
## What

- **README**: adds a highlighted "Why people pick Digarr" callout directly under the hero screenshot -- the eight strongest differentiators (album-level discovery, configurable AI scoring, mood discovery, 13 discovery modes, discovery-only mode, multi-user/OIDC, 15 languages, ops maturity) in one visible block for readers who don't scroll.
- **README**: adds a keyword-cloud footer after the star-history chart (small `<sub>` text, centered) for search discoverability.
- **NEW `docs/COMPARISON.md`**: "Choosing a Self-Hosted Music Discovery Tool" -- philosophy framing (discovery/curation vs acquisition automation vs request fulfillment), a capability matrix across 8 projects, respectful per-project summaries, and a "Where Digarr fits" positioning section. Linked from the README Friends section; SoulSync and Kima Hub added to the Friends table. Addresses #312.
- **docs/ROADMAP.md**: adds "Multiple Lidarr instances as approval targets" to Exploring > Integrations.

## Why

The README front-loads setup detail; first-time visitors had to scroll past the note blocks to learn what makes the project different. The comparison page answers the recurring "how is this different from X" question once, factually, without disparaging neighboring projects.

## Verification

- `bun run check:versions` passes (no version-surface drift).
- Docs-only change; no app code touched.