### PR TITLE
fix(auth): close IPv6 CIDR gaps in proxy trust matching

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -88,9 +88,12 @@ oauth2-proxy) already authenticates users, Digarr trusts the
 Set:
 
 - `PROXY_AUTH_ENABLED=true`
-- `PROXY_AUTH_TRUSTED_PROXIES=10.0.0.0/8,192.168.0.0/16`
+- `PROXY_AUTH_TRUSTED_PROXIES=10.0.0.0/8,192.168.0.0/16,fd00::/8`
   (comma-separated IPv4 or IPv6 CIDRs; unbounded ranges like `0.0.0.0/0`
   are rejected at boot)
+
+IPv6 CIDRs are supported, and IPv4-mapped IPv6 client addresses are normalized
+to IPv4 before matching.
 
 The CIDR parser validates strictly. Misconfigured entries crash boot with a
 clear error rather than silently widening trust. Use tight ranges that match

--- a/src/core/auth/cidr.ts
+++ b/src/core/auth/cidr.ts
@@ -11,6 +11,16 @@ function parseIpv4(ip: string): bigint | null {
   return acc
 }
 
+// RFC 4291 section 2.2 form 3: expand a trailing dotted quad (e.g. ::ffff:10.0.0.1)
+// into two 16-bit hex groups so the main group loop can stay hex-only.
+function expandDottedQuad(groups: string[]): string[] | null {
+  const last = groups[groups.length - 1] ?? ''
+  if (!last.includes('.')) return groups
+  const v4 = parseIpv4(last)
+  if (v4 === null) return null
+  return [...groups.slice(0, -1), ((v4 >> 16n) & 0xffffn).toString(16), (v4 & 0xffffn).toString(16)]
+}
+
 function parseIpv6(ip: string): bigint | null {
   if (!ip.includes(':')) return null
   const zoneStripped = ip.split('%')[0] as string
@@ -19,8 +29,18 @@ function parseIpv6(ip: string): bigint | null {
 
   const headRaw = parts[0] ?? ''
   const tailRaw = parts.length === 2 ? (parts[1] ?? '') : ''
-  const head = headRaw === '' ? [] : headRaw.split(':')
-  const tail = parts.length === 2 ? (tailRaw === '' ? [] : tailRaw.split(':')) : []
+  let head = headRaw === '' ? [] : headRaw.split(':')
+  let tail = parts.length === 2 ? (tailRaw === '' ? [] : tailRaw.split(':')) : []
+
+  if (parts.length === 2 && tail.length > 0) {
+    const expanded = expandDottedQuad(tail)
+    if (expanded === null) return null
+    tail = expanded
+  } else if (parts.length === 1) {
+    const expanded = expandDottedQuad(head)
+    if (expanded === null) return null
+    head = expanded
+  }
 
   if (parts.length === 1 && head.length !== 8) return null
 
@@ -86,10 +106,17 @@ export function assertCidr(cidr: string): void {
   }
 }
 
+// Any textual form of an IPv4-mapped IPv6 address (::ffff:10.0.0.1, ::ffff:a00:1,
+// uppercase variants) is normalized to dotted-quad IPv4 so it matches v4 trust CIDRs.
+function unmapIpv4(ip: string): string {
+  if (!ip.includes(':')) return ip
+  const num = parseIpv6(ip)
+  if (num === null || num >> 32n !== 0xffffn) return ip
+  const v4 = num & 0xffffffffn
+  return [(v4 >> 24n) & 0xffn, (v4 >> 16n) & 0xffn, (v4 >> 8n) & 0xffn, v4 & 0xffn].join('.')
+}
+
 export function isIpTrusted(ip: string, cidrs: string[]): boolean {
-  let cleanIp = ip
-  if (cleanIp.startsWith('::ffff:')) {
-    cleanIp = cleanIp.slice(7)
-  }
+  const cleanIp = unmapIpv4(ip)
   return cidrs.some((cidr) => ipInCidr(cleanIp, cidr))
 }

--- a/tests/core/auth/cidr.test.ts
+++ b/tests/core/auth/cidr.test.ts
@@ -49,6 +49,14 @@ describe('ipv6InCidr', () => {
   it('rejects malformed /bits', () => {
     expect(() => ipv6InCidr('fd00::1', 'fd00::/129')).toThrow()
   })
+
+  it('matches embedded dotted-quad tails', () => {
+    expect(ipv6InCidr('::ffff:10.0.0.1', '::ffff:0:0/96')).toBe(true)
+  })
+
+  it('rejects malformed embedded dotted-quad tails', () => {
+    expect(ipv6InCidr('::ffff:999.0.0.1', '::ffff:0:0/96')).toBe(false)
+  })
 })
 
 describe('ipv6InCidr zone IDs', () => {
@@ -103,7 +111,21 @@ describe('isIpTrusted', () => {
   it('returns false for empty cidr list', () => {
     expect(isIpTrusted('10.0.0.1', [])).toBe(false)
   })
+  it('matches IPv4 and IPv6 CIDRs in mixed trust lists', () => {
+    const cidrs = ['10.0.0.0/8', 'fd00::/8']
+
+    expect(isIpTrusted('fd00::1', cidrs)).toBe(true)
+    expect(isIpTrusted('10.1.2.3', cidrs)).toBe(true)
+    expect(isIpTrusted('192.168.1.5', cidrs)).toBe(false)
+  })
   it('strips IPv4-mapped IPv6 prefix before matching', () => {
     expect(isIpTrusted('::ffff:192.168.1.5', ['192.168.0.0/16'])).toBe(true)
+  })
+  it('normalizes IPv4-mapped IPv6 forms before matching IPv4 CIDRs', () => {
+    const cidrs = ['192.168.0.0/16']
+
+    expect(isIpTrusted('::ffff:c0a8:105', cidrs)).toBe(true)
+    expect(isIpTrusted('::FFFF:192.168.1.5', cidrs)).toBe(true)
+    expect(isIpTrusted('0:0:0:0:0:ffff:192.168.1.5', cidrs)).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #388.

The CIDR layer already parsed and matched IPv6 (phase-1 audit), so this closes the remaining gaps from the issue checklist:

- `parseIpv6` accepts RFC 4291 embedded dotted-quad tails (`::ffff:10.0.0.1` as a literal IPv6 form).
- `isIpTrusted` normalizes every textual form of an IPv4-mapped IPv6 address (dotted `::ffff:10.0.0.1`, hex `::ffff:a00:1`, uppercase `::FFFF:...`, full `0:0:0:0:0:ffff:...`) to dotted IPv4 before matching, instead of only string-stripping the lowercase dotted prefix.
- Tests: mixed v4/v6 trust lists, all mapped forms, embedded dotted-quad parse and malformed-quad rejection.
- Docs: reverse-proxy auth guide now shows a mixed v4/v6 `PROXY_AUTH_TRUSTED_PROXIES` example and states the mapped-address normalization.

Verified: lint, typecheck, i18n:check, check:versions, full vitest run (one pre-existing flake: `pglite-integration.test.ts` 5s timeout under full-suite load on a slow machine; passes in isolation).