### PR TITLE
fix(ops): pause background schedulers during backend migration

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,9 @@ READ ONLY` transaction, runs schema migrations on the target, restores the
 snapshot atomically, then verifies every table by row count and SHA-256 content
 hash before returning a `MigrationReport`. During the copy, `maintenanceMiddleware`
 blocks all write methods (`POST/PUT/PATCH/DELETE`) on non-migration routes,
-returning `503 Maintenance in progress`; reads pass through. The routes are
+returning `503 Maintenance in progress`; reads pass through. Background
+schedulers check the same flag (`isMaintenance()` in `src/core/ops/maintenance.ts`)
+and skip their ticks while it is set. The routes are
 `POST /api/v1/admin/migrate-backend/test` (validate target, non-destructive) and
 `POST /api/v1/admin/migrate-backend` (run copy). See
 [`docs/guides/switching-backends.md`](guides/switching-backends.md) for the

--- a/docs/guides/switching-backends.md
+++ b/docs/guides/switching-backends.md
@@ -29,8 +29,11 @@ point-in-time snapshots and disaster recovery, use the Backup & Restore panel
 - Aim for a low-activity window. Digarr blocks write API calls (POST / PUT /
   PATCH / DELETE) for non-migration routes while the copy runs, returning `503
   Maintenance in progress` to any writers. Read operations continue normally.
-  Scheduled scans can still start during that window if a schedule fires; disable
-  or pause them beforehand if you want to avoid that.
+  Background schedulers (pipeline subscriptions, playlists, library sync and
+  health scans, the stuck-job detector) skip their ticks while the lock is held,
+  so scheduled jobs do not write during the copy. A job already running when the
+  migration starts can still finish and write; wait for running jobs to complete
+  before migrating.
 
 ---
 
@@ -75,7 +78,8 @@ Fix any errors before proceeding.
 
 Click **Migrate**. The operation:
 
-1. Freezes writes on all non-migration routes (maintenance lock).
+1. Freezes writes on all non-migration routes and pauses background scheduler
+   ticks (maintenance lock).
 2. Takes a consistent, read-only snapshot of the source database inside a
    `REPEATABLE READ READ ONLY` transaction.
 3. Runs schema migrations on the target (creates all tables).

--- a/src/core/jobs/stuck-detector.ts
+++ b/src/core/jobs/stuck-detector.ts
@@ -1,8 +1,13 @@
 import { Cron } from 'croner'
+import { isMaintenance } from '@/core/ops/maintenance'
 import type { JobRecorder } from './types'
 
 export function startStuckDetector(recorder: JobRecorder): Cron {
   return new Cron('*/5 * * * *', async () => {
+    if (isMaintenance()) {
+      console.log('[stuck-detector] tick skipped: maintenance in progress')
+      return
+    }
     try {
       const count = await recorder.markStuck()
       if (count > 0) {

--- a/src/core/library/health-scheduler.ts
+++ b/src/core/library/health-scheduler.ts
@@ -1,4 +1,5 @@
 import { Cron } from 'croner'
+import { isMaintenance } from '@/core/ops/maintenance'
 
 export type LibraryHealthSchedulerDeps = {
   intervalHours: number
@@ -19,6 +20,10 @@ export function startLibraryHealthScheduler(deps: LibraryHealthSchedulerDeps): C
     `[library-health-scheduler] started, interval=${deps.intervalHours}h, pattern="${pattern}"`,
   )
   return new Cron(pattern, () => {
+    if (isMaintenance()) {
+      console.log('[library-health-scheduler] tick skipped: maintenance in progress')
+      return
+    }
     try {
       deps.libraryHealth.startScan()
     } catch (err: unknown) {

--- a/src/core/library/scheduler.ts
+++ b/src/core/library/scheduler.ts
@@ -1,4 +1,5 @@
 import { Cron } from 'croner'
+import { isMaintenance } from '@/core/ops/maintenance'
 import type { SyncOrchestrator } from './sync'
 
 export type LibrarySchedulerDeps = {
@@ -41,6 +42,10 @@ export function startLibrarySyncScheduler(deps: LibrarySchedulerDeps): Cron {
     `[library-sync-scheduler] started, interval=${deps.intervalHours}h, pattern="${pattern}"`,
   )
   const cron = new Cron(pattern, async () => {
+    if (isMaintenance()) {
+      console.log('[library-sync-scheduler] tick skipped: maintenance in progress')
+      return
+    }
     try {
       await deps.orchestrator.syncGlobal()
       const users = await deps.listUserIds()

--- a/src/core/ops/maintenance.ts
+++ b/src/core/ops/maintenance.ts
@@ -1,0 +1,9 @@
+let active = false
+
+export function setMaintenance(on: boolean): void {
+  active = on
+}
+
+export function isMaintenance(): boolean {
+  return active
+}

--- a/src/core/pipeline/subscription-scheduler.ts
+++ b/src/core/pipeline/subscription-scheduler.ts
@@ -1,4 +1,5 @@
 import { Cron } from 'croner'
+import { isMaintenance } from '@/core/ops/maintenance'
 
 type ScheduledJob = { name: string; cron: Cron; expression: string }
 
@@ -8,6 +9,10 @@ export class SubscriptionScheduler {
   schedule(name: string, cronExpression: string, fn: () => Promise<void>): void {
     this.remove(name)
     const cron = new Cron(cronExpression, async () => {
+      if (isMaintenance()) {
+        console.log('[scheduler] tick skipped: maintenance in progress')
+        return
+      }
       try {
         await fn()
       } catch (err: unknown) {

--- a/src/core/playlists/scheduler.ts
+++ b/src/core/playlists/scheduler.ts
@@ -1,4 +1,5 @@
 import { Cron } from 'croner'
+import { isMaintenance } from '@/core/ops/maintenance'
 
 type ScheduledJob = { name: string; cron: Cron; expression: string }
 
@@ -8,6 +9,10 @@ export class PlaylistScheduler {
   schedule(name: string, cronExpression: string, fn: () => Promise<void>): void {
     this.remove(name)
     const cron = new Cron(cronExpression, async () => {
+      if (isMaintenance()) {
+        console.log('[playlist-scheduler] tick skipped: maintenance in progress')
+        return
+      }
       try {
         await fn()
       } catch (err: unknown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { createSyncOrchestrator, type SyncOrchestrator } from './core/library/sy
 import { markShuttingDown } from './core/lifecycle'
 import { sendWebhook } from './core/notifications'
 import { migrateLegacyListeningConnections } from './core/ops/legacy-listening-connections'
+import { isMaintenance } from './core/ops/maintenance'
 import { runPreFlightCheck } from './core/ops/upgrade'
 import { analyze } from './core/pipeline/analyze'
 import { PipelineOrchestrator } from './core/pipeline/orchestrator'
@@ -1561,6 +1562,10 @@ const server = serve({ fetch: app.fetch, port })
     libraryHealth.startScan()
     void slskdOrchestrator.warmup()
     slskdCron = new Cron('*/10 * * * *', async () => {
+      if (isMaintenance()) {
+        console.log('[slskd-scheduler] tick skipped: maintenance in progress')
+        return
+      }
       try {
         await slskdOrchestrator.triggerSync()
       } catch (err) {
@@ -1581,6 +1586,7 @@ const server = serve({ fetch: app.fetch, port })
 // Clean up expired sessions every 6 hours
 setInterval(
   async () => {
+    if (isMaintenance()) return
     try {
       await sessionQueries(db).deleteExpired()
     } catch {

--- a/src/server/maintenance.ts
+++ b/src/server/maintenance.ts
@@ -1,15 +1,8 @@
 import type { MiddlewareHandler } from 'hono'
+import { isMaintenance } from '@/core/ops/maintenance'
 import { problem } from '@/server/helpers/problem'
 
-let active = false
-
-export function setMaintenance(on: boolean): void {
-  active = on
-}
-
-export function isMaintenance(): boolean {
-  return active
-}
+export { isMaintenance, setMaintenance } from '@/core/ops/maintenance'
 
 // Mutating methods blocked during migration; reads pass through. The migration
 // endpoints are exempt so the operator can drive and inspect the migration
@@ -19,7 +12,7 @@ const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
 export const maintenanceMiddleware: MiddlewareHandler = async (c, next) => {
   if (
-    active &&
+    isMaintenance() &&
     WRITE_METHODS.has(c.req.method) &&
     !EXEMPT_PREFIXES.some((p) => c.req.path === p || c.req.path.startsWith(`${p}/`))
   ) {

--- a/tests/core/ops/maintenance-gating.test.ts
+++ b/tests/core/ops/maintenance-gating.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startStuckDetector } from '@/core/jobs/stuck-detector'
+import { isMaintenance, setMaintenance } from '@/core/ops/maintenance'
+import { SubscriptionScheduler } from '@/core/pipeline/subscription-scheduler'
+import { PlaylistScheduler } from '@/core/playlists/scheduler'
+
+const EVERY_SECOND = '* * * * * *'
+
+describe('maintenance gating of background schedulers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    setMaintenance(false)
+    vi.useRealTimers()
+  })
+
+  describe('maintenance flag', () => {
+    it('toggles', () => {
+      expect(isMaintenance()).toBe(false)
+      setMaintenance(true)
+      expect(isMaintenance()).toBe(true)
+      setMaintenance(false)
+      expect(isMaintenance()).toBe(false)
+    })
+  })
+
+  describe('SubscriptionScheduler', () => {
+    it('skips ticks during maintenance and resumes after', async () => {
+      const scheduler = new SubscriptionScheduler()
+      const fn = vi.fn().mockResolvedValue(undefined)
+      scheduler.schedule('job', EVERY_SECOND, fn)
+
+      setMaintenance(true)
+      await vi.advanceTimersByTimeAsync(1100)
+      expect(fn).not.toHaveBeenCalled()
+
+      setMaintenance(false)
+      await vi.advanceTimersByTimeAsync(1100)
+      expect(fn).toHaveBeenCalled()
+
+      scheduler.stopAll()
+    })
+  })
+
+  describe('PlaylistScheduler', () => {
+    it('skips ticks during maintenance and resumes after', async () => {
+      const scheduler = new PlaylistScheduler()
+      const fn = vi.fn().mockResolvedValue(undefined)
+      scheduler.schedule('job', EVERY_SECOND, fn)
+
+      setMaintenance(true)
+      await vi.advanceTimersByTimeAsync(1100)
+      expect(fn).not.toHaveBeenCalled()
+
+      setMaintenance(false)
+      await vi.advanceTimersByTimeAsync(1100)
+      expect(fn).toHaveBeenCalled()
+
+      scheduler.stopAll()
+    })
+  })
+
+  describe('startStuckDetector', () => {
+    it('skips markStuck during maintenance and resumes after', async () => {
+      const recorder = {
+        start: vi.fn(),
+        complete: vi.fn(),
+        fail: vi.fn(),
+        markStuck: vi.fn().mockResolvedValue(0),
+      }
+      const cron = startStuckDetector(recorder)
+
+      setMaintenance(true)
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1000)
+      expect(recorder.markStuck).not.toHaveBeenCalled()
+
+      setMaintenance(false)
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1000)
+      expect(recorder.markStuck).toHaveBeenCalled()
+
+      cron.stop()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

The maintenance lock set by the in-app backend migration (PGlite <-> PostgreSQL) only blocked HTTP writes. Background croner schedulers kept firing and writing to the source database after the migration snapshot was taken, so those rows were silently lost when the operator switched backends.

- Move the maintenance flag state to `src/core/ops/maintenance.ts` (core must not import from server) and re-export it from `src/server/maintenance.ts` so existing importers keep working.
- Gate every periodic writer tick behind `isMaintenance()`: subscription scheduler, playlist scheduler, library sync, library health, stuck detector, slskd sync cron, and the session-cleanup interval (7 ticks across 6 files).
- The read-only digest notifier is intentionally not gated.
- Docs: `switching-backends.md` no longer tells operators to pause schedulers manually; it documents the automatic pause plus the in-flight-tick caveat. `ARCHITECTURE.md` notes the shared flag.

Known residual window: a tick already in flight when the lock engages can still write. Draining in-flight ticks before the snapshot is deferred (needs scheduler handles in the migrate route).

Closes #396

## Test plan

- New `tests/core/ops/maintenance-gating.test.ts`: flag toggle, SubscriptionScheduler and PlaylistScheduler gated/resumed via fake timers, stuck detector gated/resumed.
- `bun run typecheck && bun run lint && bun run test` all green (2592 passed).