### PR TITLE
fix(pipeline): derive known-source skip list from shared constant

### DIFF
--- a/src/core/pipeline/orchestrator.ts
+++ b/src/core/pipeline/orchestrator.ts
@@ -16,7 +16,7 @@ import { createJellyfinSource } from '@/core/plugins/jellyfin'
 import { createLastFmSource } from '@/core/plugins/lastfm'
 import { createListenBrainzSource } from '@/core/plugins/listenbrainz'
 import { createPlexSource } from '@/core/plugins/plex'
-import { SourceRegistry } from '@/core/plugins/registry'
+import { LISTENING_SOURCE_IDS, SourceRegistry } from '@/core/plugins/registry'
 import { createSpotifySource } from '@/core/plugins/spotify'
 import { createSubsonicSource } from '@/core/plugins/subsonic'
 import type { AiProviderRegistry } from '@/core/providers/registry'
@@ -394,16 +394,7 @@ export class PipelineOrchestrator extends EventEmitter {
       const sourceResults: Record<string, import('@/core/jobs/types').SourceResult> = {}
 
       // Mark unconfigured sources as skipped
-      const knownSourceIds = [
-        'listenbrainz',
-        'lastfm',
-        'spotify',
-        'plex',
-        'jellyfin',
-        'emby',
-        'discogs',
-      ]
-      for (const id of knownSourceIds) {
+      for (const id of LISTENING_SOURCE_IDS) {
         if (!registry.all().some((s) => s.id === id)) {
           sourceResults[id] = { status: 'skipped', reason: 'not_configured' }
         }

--- a/src/core/plugins/registry.ts
+++ b/src/core/plugins/registry.ts
@@ -1,5 +1,22 @@
 import type { DiscoverySource, SourceCapability } from './types'
 
+/**
+ * Every registrable listening-source id. The orchestrator uses this to emit
+ * `skipped/not_configured` placeholders for sources the user has not set up.
+ * Adding a new source factory REQUIRES adding its id here — enforced by
+ * tests/core/plugins/source-ids.test.ts.
+ */
+export const LISTENING_SOURCE_IDS = [
+  'listenbrainz',
+  'lastfm',
+  'spotify',
+  'plex',
+  'jellyfin',
+  'emby',
+  'discogs',
+  'subsonic',
+] as const
+
 export class SourceRegistry {
   private sources = new Map<string, DiscoverySource>()
 

--- a/tests/core/plugins/source-ids.test.ts
+++ b/tests/core/plugins/source-ids.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { createDiscogsSource } from '@/core/plugins/discogs'
+import { createEmbySource } from '@/core/plugins/emby'
+import { createJellyfinSource } from '@/core/plugins/jellyfin'
+import { createLastFmSource } from '@/core/plugins/lastfm'
+import { createListenBrainzSource } from '@/core/plugins/listenbrainz'
+import { createPlexSource } from '@/core/plugins/plex'
+import { LISTENING_SOURCE_IDS } from '@/core/plugins/registry'
+import { createSpotifySource } from '@/core/plugins/spotify'
+import { createSubsonicSource } from '@/core/plugins/subsonic'
+
+describe('LISTENING_SOURCE_IDS', () => {
+  it('every registrable source id appears in LISTENING_SOURCE_IDS', () => {
+    const sources = [
+      createListenBrainzSource('u', 't'),
+      createLastFmSource('u', 'k'),
+      createSpotifySource('token'),
+      createPlexSource('http://x', 't', undefined),
+      createJellyfinSource('http://x', 'k', 'uid', false, undefined),
+      createEmbySource('http://x', 'k', 'uid', false, undefined),
+      createDiscogsSource('t', 'u'),
+      createSubsonicSource('http://x', 'u', 'p', false),
+    ]
+    expect(new Set(sources.map((s) => s.id))).toEqual(new Set(LISTENING_SOURCE_IDS))
+  })
+})


### PR DESCRIPTION
Closes #397.

The orchestrator's hardcoded `knownSourceIds` list drifted: `subsonic` (first-class source since v1.11.0) was missing, so an unconfigured Subsonic never got its `skipped/not_configured` placeholder in job source results and was invisible in source-health reporting.

## Changes

- New exported `LISTENING_SOURCE_IDS` constant in `src/core/plugins/registry.ts` — the single source of truth for registrable listening-source ids, now including `subsonic`.
- `src/core/pipeline/orchestrator.ts` consumes the constant; inline literal deleted.
- New anti-drift test `tests/core/plugins/source-ids.test.ts`: constructs every source factory and asserts set equality between produced ids and the constant, so adding or removing a source without updating the list fails CI.

## Verification

- `bun run typecheck`, `bun run lint`, targeted test all pass.
- Full `bun run test`: 2592 passed; one pre-existing flake in `tests/db/pglite-integration.test.ts` (statement_timeout test under parallel load) reproduced identically on unmodified develop, passes standalone.
- No orchestrator test asserted an exact `sourceResults` key set, so the new `subsonic` placeholder needed no snapshot updates.