### PR TITLE
perf(library): use bulk Lidarr editor for unmonitored health fix

### DIFF
--- a/src/core/library/health.ts
+++ b/src/core/library/health.ts
@@ -190,6 +190,21 @@ export class LibraryHealthService {
       errors: [],
     }
 
+    if (checkId === 'unmonitored') {
+      const ids = items.map((i) => i.artistId).filter((id) => id > 0)
+      if (ids.length > 0) {
+        try {
+          await this.deps.lidarrClient.setArtistsMonitored(ids, true)
+          progress.completed = ids.length
+        } catch (err: unknown) {
+          progress.failed = ids.length
+          progress.errors.push(errMsg(err))
+        }
+      }
+      progress.status = progress.failed === 0 ? 'completed' : 'failed'
+      return progress
+    }
+
     const queue = new PQueue({ concurrency: 1, interval: 1000, intervalCap: 1 })
 
     for (const item of items) {
@@ -422,10 +437,6 @@ export class LibraryHealthService {
       case 'missing-metadata':
       case 'genre-gaps':
         await this.deps.lidarrClient.triggerCommand('RefreshArtist', { artistId: item.artistId })
-        break
-
-      case 'unmonitored':
-        await this.deps.lidarrClient.setArtistsMonitored([item.artistId], true)
         break
 
       case 'missing-albums':

--- a/tests/core/library/health.test.ts
+++ b/tests/core/library/health.test.ts
@@ -692,6 +692,70 @@ describe('LibraryHealthService', () => {
       expect(progress.completed).toBe(0)
       expect(progress.status).toBe('completed')
     })
+
+    it('bulk-flips all unmonitored artists in a single setArtistsMonitored call', async () => {
+      const unmonitoredArtists = [
+        { ...ARTIST_RADIOHEAD, monitored: false },
+        { ...ARTIST_PORTISHEAD, monitored: false },
+        ARTIST_BJORK,
+      ]
+      mocks.getArtists.mockResolvedValue(unmonitoredArtists)
+      mocks.cacheGetAll.mockResolvedValue([])
+      await service.runChecks()
+      mocks.setArtistsMonitored.mockResolvedValue(
+        unmonitoredArtists.map((a) => ({ ...a, monitored: true })),
+      )
+
+      const progress = await service.fixCheck('unmonitored')
+
+      expect(mocks.setArtistsMonitored).toHaveBeenCalledTimes(1)
+      expect(mocks.setArtistsMonitored).toHaveBeenCalledWith(
+        [ARTIST_RADIOHEAD.id, ARTIST_PORTISHEAD.id, ARTIST_BJORK.id],
+        true,
+      )
+      expect(progress).toMatchObject({ total: 3, completed: 3, failed: 0, status: 'completed' })
+    })
+
+    it('records a single batch error when the bulk unmonitored call fails', async () => {
+      const unmonitoredArtists = [
+        { ...ARTIST_RADIOHEAD, monitored: false },
+        { ...ARTIST_PORTISHEAD, monitored: false },
+        ARTIST_BJORK,
+      ]
+      mocks.getArtists.mockResolvedValue(unmonitoredArtists)
+      mocks.cacheGetAll.mockResolvedValue([])
+      await service.runChecks()
+      mocks.setArtistsMonitored.mockRejectedValue(new Error('Lidarr down'))
+
+      const progress = await service.fixCheck('unmonitored')
+
+      expect(mocks.setArtistsMonitored).toHaveBeenCalledTimes(1)
+      expect(progress.completed).toBe(0)
+      expect(progress.failed).toBe(3)
+      expect(progress.status).toBe('failed')
+      expect(progress.errors).toHaveLength(1)
+      expect(progress.errors[0]).toContain('Lidarr down')
+    })
+
+    it('still queues one triggerCommand call per item for missing-albums (non-bulk path unchanged)', async () => {
+      mocks.getArtists.mockResolvedValue([ARTIST_PORTISHEAD, ARTIST_RADIOHEAD])
+      mocks.getAlbums.mockResolvedValue([ALBUM_NO_FILES])
+      mocks.cacheGetAll.mockResolvedValue([])
+      await service.runChecks()
+      mocks.triggerCommand.mockResolvedValue({})
+
+      const progress = await service.fixCheck('missing-albums')
+
+      expect(mocks.triggerCommand).toHaveBeenCalledTimes(2)
+      expect(mocks.triggerCommand).toHaveBeenCalledWith('ArtistSearch', {
+        artistId: ARTIST_PORTISHEAD.id,
+      })
+      expect(mocks.triggerCommand).toHaveBeenCalledWith('ArtistSearch', {
+        artistId: ARTIST_RADIOHEAD.id,
+      })
+      expect(progress.completed).toBe(2)
+      expect(progress.status).toBe('completed')
+    })
   })
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes #398.

The library-health "unmonitored" fix flipped the monitored flag one artist at a time through a 1 req/s queue -- ~8 minutes for 500 artists. The bulk `PUT /artist/editor` client method (from #394) does it in one call.

## Changes

- `fixCheck('unmonitored')` now takes an early-return bulk branch: one `setArtistsMonitored(ids, true)` call for the whole batch, with all-or-nothing accounting (single error line for the batch on failure -- deliberate trade-off vs. the old per-artist error lines).
- Deleted the now-unreachable `case 'unmonitored'` from `applyFix` (private, sole caller is `fixCheck`).
- Other health checks (`missing-albums`, `missing-metadata`, etc.) keep the rate-limited queue -- they are genuinely per-artist.

## Tests

- Bulk happy path: 3 items -> exactly one `setArtistsMonitored([id1,id2,id3], true)` call, `completed: 3`.
- Bulk failure: single call, `failed: 3`, one batch error line.
- Regression guard: `missing-albums` with 2 items still issues 2 `triggerCommand` calls.

`HealthFixProgress` shape unchanged; no frontend edits. Full suite: 2596 passed.
