### PR TITLE
feat(search): wire TIDAL search behind admin client-credential settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The setup wizard supports three starting points: Lidarr, Emby, or discovery-only
 In addition to approval-driven queueing, Digarr now runs a background `slskd` worker for linked Lidarr targets. It polls Lidarr wanted releases, creates deduped `slskd` jobs per target, advances them through search and transfer states, and only marks Lidarr-backed jobs complete after import verification. Admins can trigger a manual sync and inspect active `slskd` jobs from the API.
 
 ### Cross-Platform Search
-Search across Spotify, Deezer, MusicBrainz, TIDAL, and Bandcamp in one pass. Digarr merges the results, deduplicates them, and lets you launch Quick Discover from any match.
+Search across Spotify, Deezer, MusicBrainz, TIDAL, and Bandcamp in one pass. Digarr merges the results, deduplicates them, and lets you launch Quick Discover from any match. TIDAL is experimental and needs admin-configured client credentials (Settings -> Connections) before it becomes active.
 
 ## Features
 

--- a/drizzle/0040_gorgeous_sasquatch.sql
+++ b/drizzle/0040_gorgeous_sasquatch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "settings" ADD COLUMN IF NOT EXISTS "tidal_client_id" text;--> statement-breakpoint
+ALTER TABLE "settings" ADD COLUMN IF NOT EXISTS "tidal_client_secret" text;

--- a/drizzle/meta/0040_snapshot.json
+++ b/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,3444 @@
+{
+  "id": "9fe75568-8d05-49b0-b28c-d2792182786f",
+  "prevId": "24ea7679-32ef-4b27-b654-6b0a306132ff",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.album_blocks": {
+      "name": "album_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_group_mbid": {
+          "name": "release_group_mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_text": {
+          "name": "reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rejection'"
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "album_blocks_user_release_group_idx": {
+          "name": "album_blocks_user_release_group_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "release_group_mbid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_blocks_user_idx": {
+          "name": "album_blocks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "album_blocks_artist_idx": {
+          "name": "album_blocks_artist_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "album_blocks_user_id_users_id_fk": {
+          "name": "album_blocks_user_id_users_id_fk",
+          "tableFrom": "album_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "album_blocks_artist_id_artists_id_fk": {
+          "name": "album_blocks_artist_id_artists_id_fk",
+          "tableFrom": "album_blocks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_blocks": {
+      "name": "artist_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_text": {
+          "name": "reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rejection'"
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "artist_blocks_user_artist_idx": {
+          "name": "artist_blocks_user_artist_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_blocks_user_idx": {
+          "name": "artist_blocks_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_blocks_artist_idx": {
+          "name": "artist_blocks_artist_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_blocks_user_id_users_id_fk": {
+          "name": "artist_blocks_user_id_users_id_fk",
+          "tableFrom": "artist_blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "artist_blocks_artist_id_artists_id_fk": {
+          "name": "artist_blocks_artist_id_artists_id_fk",
+          "tableFrom": "artist_blocks",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_metadata": {
+      "name": "artist_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_normalized": {
+          "name": "name_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spotify_genres": {
+          "name": "spotify_genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_popularity": {
+          "name": "spotify_popularity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deezer_fans": {
+          "name": "deezer_fans",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_metadata_name_normalized_unique": {
+          "name": "artist_metadata_name_normalized_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name_normalized"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artists": {
+      "name": "artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disambiguation": {
+          "name": "disambiguation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_urls": {
+          "name": "streaming_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_failed_at": {
+          "name": "image_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "begin_year": {
+          "name": "begin_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_year": {
+          "name": "end_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_tracks": {
+          "name": "top_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_links": {
+          "name": "external_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_id": {
+          "name": "wikidata_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_fetched_at": {
+          "name": "wikidata_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_failed_at": {
+          "name": "wikidata_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artists_mbid_unique": {
+          "name": "artists_mbid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "mbid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_genre_id": {
+          "name": "parent_genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_count": {
+          "name": "artist_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "genres_parent_genre_id_idx": {
+          "name": "genres_parent_genre_id_idx",
+          "columns": [
+            {
+              "expression": "parent_genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "genres_parent_genre_id_genres_id_fk": {
+          "name": "genres_parent_genre_id_genres_id_fk",
+          "tableFrom": "genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "parent_genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_slug_unique": {
+          "name": "genres_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_runs": {
+      "name": "job_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source_results": {
+          "name": "source_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_runs_user_id_idx": {
+          "name": "job_runs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_runs_batch_id_idx": {
+          "name": "job_runs_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_job_runs_subscription": {
+          "name": "idx_job_runs_subscription",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"job_runs\".\"subscription_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_runs_type_started_at_idx": {
+          "name": "job_runs_type_started_at_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_runs_user_id_users_id_fk": {
+          "name": "job_runs_user_id_users_id_fk",
+          "tableFrom": "job_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "job_runs_subscription_id_subscriptions_id_fk": {
+          "name": "job_runs_subscription_id_subscriptions_id_fk",
+          "tableFrom": "job_runs",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "job_runs_batch_id_recommendation_batches_id_fk": {
+          "name": "job_runs_batch_id_recommendation_batches_id_fk",
+          "tableFrom": "job_runs",
+          "tableTo": "recommendation_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_album_match_overrides": {
+      "name": "library_album_match_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_album_id": {
+          "name": "source_album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_album_mbid": {
+          "name": "correct_album_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_album_match_overrides_natural_key_idx": {
+          "name": "library_album_match_overrides_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_album_match_overrides_user_id_users_id_fk": {
+          "name": "library_album_match_overrides_user_id_users_id_fk",
+          "tableFrom": "library_album_match_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_albums": {
+      "name": "library_albums",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_album_id": {
+          "name": "source_album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_normalized": {
+          "name": "title_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_mbid": {
+          "name": "album_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_mbid": {
+          "name": "artist_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_type": {
+          "name": "primary_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_albums_natural_key_idx": {
+          "name": "library_albums_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_albums_artist_idx": {
+          "name": "library_albums_artist_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_mbid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_albums_user_id_users_id_fk": {
+          "name": "library_albums_user_id_users_id_fk",
+          "tableFrom": "library_albums",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_artists": {
+      "name": "library_artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_normalized": {
+          "name": "name_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_gap_check_at": {
+          "name": "last_gap_check_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_artists_natural_key_idx": {
+          "name": "library_artists_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_artists_dedup_idx": {
+          "name": "library_artists_dedup_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mbid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_artists_name_idx": {
+          "name": "library_artists_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_artists_user_id_users_id_fk": {
+          "name": "library_artists_user_id_users_id_fk",
+          "tableFrom": "library_artists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_health_state": {
+      "name": "library_health_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checks": {
+          "name": "checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_started_at": {
+          "name": "last_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_completed_at": {
+          "name": "last_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_match_overrides": {
+      "name": "library_match_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_artist_id": {
+          "name": "source_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_mbid": {
+          "name": "correct_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_match_overrides_natural_key_idx": {
+          "name": "library_match_overrides_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_match_overrides_user_id_users_id_fk": {
+          "name": "library_match_overrides_user_id_users_id_fk",
+          "tableFrom": "library_match_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_sync_state": {
+      "name": "library_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_status": {
+          "name": "last_sync_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_counts": {
+          "name": "last_sync_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "library_sync_state_natural_key_idx": {
+          "name": "library_sync_state_natural_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_sync_state_user_id_users_id_fk": {
+          "name": "library_sync_state_user_id_users_id_fk",
+          "tableFrom": "library_sync_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_tokens": {
+      "name": "oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_tokens_user_id_users_id_fk": {
+          "name": "oauth_tokens_user_id_users_id_fk",
+          "tableFrom": "oauth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_tokens_user_provider": {
+          "name": "oauth_tokens_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_tokens": {
+      "name": "oidc_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oidc_tokens_user_id_users_id_fk": {
+          "name": "oidc_tokens_user_id_users_id_fk",
+          "tableFrom": "oidc_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oidc_tokens_user_id_unique": {
+          "name": "oidc_tokens_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_tracks": {
+      "name": "playlist_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spotify_uri": {
+          "name": "spotify_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deezer_id": {
+          "name": "deezer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_tracks_playlist_position_idx": {
+          "name": "playlist_tracks_playlist_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_tracks_playlist_id_playlists_id_fk": {
+          "name": "playlist_tracks_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_tracks",
+          "tableTo": "playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlists": {
+      "name": "playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_ids": {
+          "name": "target_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_generated_at": {
+          "name": "last_generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track_count": {
+          "name": "track_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "playlists_user_id_idx": {
+          "name": "playlists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlists_enabled_last_generated_idx": {
+          "name": "playlists_enabled_last_generated_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlists_user_id_users_id_fk": {
+          "name": "playlists_user_id_users_id_fk",
+          "tableFrom": "playlists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendation_batches": {
+      "name": "recommendation_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recommendation_batches_subscription_id_idx": {
+          "name": "recommendation_batches_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_batches_created_at_id_idx": {
+          "name": "recommendation_batches_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendation_batches_subscription_id_subscriptions_id_fk": {
+          "name": "recommendation_batches_subscription_id_subscriptions_id_fk",
+          "tableFrom": "recommendation_batches",
+          "tableTo": "subscriptions",
+          "columnsFrom": [
+            "subscription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendations": {
+      "name": "recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_reasoning": {
+          "name": "ai_reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'artist'"
+        },
+        "lidarr_artist_id": {
+          "name": "lidarr_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lidarr_error": {
+          "name": "lidarr_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_release_group_id": {
+          "name": "recommended_release_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommended_release_group_title": {
+          "name": "recommended_release_group_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_actions": {
+          "name": "target_actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason_text": {
+          "name": "rejection_reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acted_on_at": {
+          "name": "acted_on_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recommendations_batch_idx": {
+          "name": "recommendations_batch_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_artist_idx": {
+          "name": "recommendations_artist_idx",
+          "columns": [
+            {
+              "expression": "artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_user_status_score_idx": {
+          "name": "recommendations_user_status_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_user_created_idx": {
+          "name": "recommendations_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_user_acted_on_idx": {
+          "name": "recommendations_user_acted_on_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acted_on_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendations_status_acted_on_idx": {
+          "name": "recommendations_status_acted_on_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "acted_on_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendations_user_id_users_id_fk": {
+          "name": "recommendations_user_id_users_id_fk",
+          "tableFrom": "recommendations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recommendations_artist_id_artists_id_fk": {
+          "name": "recommendations_artist_id_artists_id_fk",
+          "tableFrom": "recommendations",
+          "tableTo": "artists",
+          "columnsFrom": [
+            "artist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "recommendations_batch_id_recommendation_batches_id_fk": {
+          "name": "recommendations_batch_id_recommendation_batches_id_fk",
+          "tableFrom": "recommendations",
+          "tableTo": "recommendation_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recording_artist_cache": {
+      "name": "recording_artist_cache",
+      "schema": "",
+      "columns": {
+        "recording_mbid": {
+          "name": "recording_mbid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_mbid": {
+          "name": "artist_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_user_expires_idx": {
+          "name": "sessions_user_expires_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lidarr_url": {
+          "name": "lidarr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lidarr_api_key": {
+          "name": "lidarr_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listenbrainz_username": {
+          "name": "listenbrainz_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listenbrainz_token": {
+          "name": "listenbrainz_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm_username": {
+          "name": "lastfm_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm_api_key": {
+          "name": "lastfm_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_api_key": {
+          "name": "ai_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_base_url": {
+          "name": "ai_base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_issuer_url": {
+          "name": "oidc_issuer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_client_id": {
+          "name": "oidc_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_client_secret": {
+          "name": "oidc_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_scopes": {
+          "name": "oidc_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_tls_verify": {
+          "name": "skip_tls_verify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audiodb_api_key": {
+          "name": "audiodb_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audiodb_proxy_images": {
+          "name": "audiodb_proxy_images",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tidal_client_id": {
+          "name": "tidal_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tidal_client_secret": {
+          "name": "tidal_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wikidata_enabled": {
+          "name": "wikidata_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "setup_complete": {
+          "name": "setup_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "library_sync_interval_hours": {
+          "name": "library_sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slskd_jobs": {
+      "name": "slskd_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation_id": {
+          "name": "recommendation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_key": {
+          "name": "work_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_mbid": {
+          "name": "artist_mbid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_group_mbid": {
+          "name": "release_group_mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_title": {
+          "name": "release_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lidarr_artist_id": {
+          "name": "lidarr_artist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lidarr_album_id": {
+          "name": "lidarr_album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slskd_search_id": {
+          "name": "slskd_search_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slskd_queue_id": {
+          "name": "slskd_queue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slskd_download_id": {
+          "name": "slskd_download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_result": {
+          "name": "selected_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "slskd_jobs_active_work_key_idx": {
+          "name": "slskd_jobs_active_work_key_idx",
+          "columns": [
+            {
+              "expression": "work_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"slskd_jobs\".\"state\" in ('pending', 'searching', 'queued', 'downloading', 'import_pending')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slskd_jobs_state_idx": {
+          "name": "slskd_jobs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slskd_jobs_user_state_idx": {
+          "name": "slskd_jobs_user_state_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slskd_jobs_target_id_idx": {
+          "name": "slskd_jobs_target_id_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "slskd_jobs_recommendation_id_idx": {
+          "name": "slskd_jobs_recommendation_id_idx",
+          "columns": [
+            {
+              "expression": "recommendation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slskd_jobs_user_id_users_id_fk": {
+          "name": "slskd_jobs_user_id_users_id_fk",
+          "tableFrom": "slskd_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slskd_jobs_target_id_targets_id_fk": {
+          "name": "slskd_jobs_target_id_targets_id_fk",
+          "tableFrom": "slskd_jobs",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slskd_jobs_recommendation_id_recommendations_id_fk": {
+          "name": "slskd_jobs_recommendation_id_recommendations_id_fk",
+          "tableFrom": "slskd_jobs",
+          "tableTo": "recommendations",
+          "columnsFrom": [
+            "recommendation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_provider": {
+          "name": "source_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_config": {
+          "name": "source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_artists_per_run": {
+          "name": "max_artists_per_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "listener_range": {
+          "name": "listener_range",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'add_to_recommendations'"
+        },
+        "score_threshold": {
+          "name": "score_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scoring_weight_preset": {
+          "name": "scoring_weight_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "scoring_weight_overrides": {
+          "name": "scoring_weight_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_result_count": {
+          "name": "last_result_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_enabled_idx": {
+          "name": "subscriptions_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.targets": {
+      "name": "targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "targets_user_id_idx": {
+          "name": "targets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "targets_type_idx": {
+          "name": "targets_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "targets_user_id_users_id_fk": {
+          "name": "targets_user_id_users_id_fk",
+          "tableFrom": "targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preferred_locale": {
+          "name": "preferred_locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listenbrainz_username": {
+          "name": "listenbrainz_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listenbrainz_token": {
+          "name": "listenbrainz_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm_username": {
+          "name": "lastfm_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastfm_api_key": {
+          "name": "lastfm_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_url": {
+          "name": "plex_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_token": {
+          "name": "plex_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plex_section_id": {
+          "name": "plex_section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jellyfin_url": {
+          "name": "jellyfin_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jellyfin_api_key": {
+          "name": "jellyfin_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jellyfin_user_id": {
+          "name": "jellyfin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jellyfin_library_id": {
+          "name": "jellyfin_library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emby_url": {
+          "name": "emby_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emby_api_key": {
+          "name": "emby_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emby_user_id": {
+          "name": "emby_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emby_library_id": {
+          "name": "emby_library_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_token": {
+          "name": "discogs_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discogs_username": {
+          "name": "discogs_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subsonic_url": {
+          "name": "subsonic_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subsonic_username": {
+          "name": "subsonic_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subsonic_password": {
+          "name": "subsonic_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique_idx": {
+          "name": "users_email_unique_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_oidc_subject_unique_idx": {
+          "name": "users_oidc_subject_unique_idx",
+          "columns": [
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"oidc_subject\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1783256081195,
       "tag": "0039_rainy_thanos",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1783357733815,
+      "tag": "0040_gorgeous_sasquatch",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/crypto.ts
+++ b/src/core/crypto.ts
@@ -144,6 +144,7 @@ export const SENSITIVE_SETTINGS = [
   'aiApiKey',
   'audiodbApiKey',
   'oidcClientSecret',
+  'tidalClientSecret',
 ] as const
 export const SENSITIVE_OAUTH = ['accessToken', 'refreshToken', 'clientSecret'] as const
 // oidc_tokens shape differs from oauth_tokens: no clientSecret, plus an idToken

--- a/src/core/i18n/messages/de.ts
+++ b/src/core/i18n/messages/de.ts
@@ -876,6 +876,8 @@ export const de = {
   'settings.subsonicDescription':
     'Selbst gehosteter Musikserver (Navidrome, Airsonic) für Bibliothekssynchronisierung und Entdeckung',
   'settings.discogsDescription': 'Sammlung und Wunschliste von Discogs.',
+  'settings.tidalDescription':
+    'Experimentelle Suchquelle mit TIDAL-Client-Credentials-Zugriff. Nutzt undokumentierte Endpunkte, die sich ohne Vorankündigung ändern können.',
   'settings.yourAccount': 'dein Konto',
   'settings.lidarrPreferences': 'Deine Lidarr-Einstellungen',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/en.ts
+++ b/src/core/i18n/messages/en.ts
@@ -979,6 +979,8 @@ export const en = {
   'settings.subsonicDescription':
     'Self-hosted music server (Navidrome, Airsonic) for library sync and discovery',
   'settings.discogsDescription': 'Collection and wantlist from Discogs.',
+  'settings.tidalDescription':
+    'Experimental search source using TIDAL client-credentials access. Uses undocumented endpoints that may change without notice.',
   'settings.yourAccount': 'your account',
   'settings.lidarrPreferences': 'Your Lidarr Preferences',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/es.ts
+++ b/src/core/i18n/messages/es.ts
@@ -862,6 +862,8 @@ export const es = {
   'settings.subsonicDescription':
     'Servidor de música autoalojado (Navidrome, Airsonic) para sincronización de biblioteca y descubrimiento',
   'settings.discogsDescription': 'Colección y lista de deseos de Discogs.',
+  'settings.tidalDescription':
+    'Fuente de búsqueda experimental que usa acceso por credenciales de cliente de TIDAL. Utiliza puntos finales no documentados que pueden cambiar sin previo aviso.',
   'settings.yourAccount': 'tu cuenta',
   'settings.lidarrPreferences': 'Tus preferencias de Lidarr',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/fr.ts
+++ b/src/core/i18n/messages/fr.ts
@@ -859,6 +859,8 @@ export const fr = {
   'settings.subsonicDescription':
     'Serveur de musique auto-hébergé (Navidrome, Airsonic) pour la synchronisation de bibliothèque et la découverte',
   'settings.discogsDescription': 'Collection et liste de souhaits depuis Discogs.',
+  'settings.tidalDescription':
+    "Source de recherche expérimentale utilisant l'accès par identifiants client TIDAL. Utilise des points de terminaison non documentés susceptibles de changer sans préavis.",
   'settings.yourAccount': 'votre compte',
   'settings.lidarrPreferences': 'Vos préférences Lidarr',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/it.ts
+++ b/src/core/i18n/messages/it.ts
@@ -864,6 +864,8 @@ export const it = {
   'settings.subsonicDescription':
     'Server musicale self-hosted (Navidrome, Airsonic) per sincronizzazione libreria e scoperta',
   'settings.discogsDescription': 'Collezione e lista dei desideri da Discogs.',
+  'settings.tidalDescription':
+    "Fonte di ricerca sperimentale che utilizza l'accesso tramite credenziali client TIDAL. Utilizza endpoint non documentati che potrebbero cambiare senza preavviso.",
   'settings.yourAccount': 'il tuo account',
   'settings.lidarrPreferences': 'Le tue preferenze Lidarr',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/ja.ts
+++ b/src/core/i18n/messages/ja.ts
@@ -854,6 +854,8 @@ export const ja = {
   'settings.subsonicDescription':
     'ライブラリ同期と発見のためのセルフホスト音楽サーバー（Navidrome、Airsonic）',
   'settings.discogsDescription': 'Discogs のコレクションとウォントリスト。',
+  'settings.tidalDescription':
+    'TIDALのクライアントクレデンシャルアクセスを使用する実験的な検索ソースです。仕様変更の可能性がある非公開のエンドポイントを使用します。',
   'settings.yourAccount': 'あなたのアカウント',
   'settings.lidarrPreferences': 'Lidarr 個人設定',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/ko.ts
+++ b/src/core/i18n/messages/ko.ts
@@ -842,6 +842,8 @@ export const ko = {
   'settings.subsonicDescription':
     '라이브러리 동기화 및 발견을 위한 셀프 호스팅 음악 서버 (Navidrome, Airsonic)',
   'settings.discogsDescription': 'Discogs의 컬렉션과 위시리스트.',
+  'settings.tidalDescription':
+    'TIDAL 클라이언트 자격 증명 액세스를 사용하는 실험적 검색 소스입니다. 예고 없이 변경될 수 있는 비공식 엔드포인트를 사용합니다.',
   'settings.yourAccount': '내 계정',
   'settings.lidarrPreferences': 'Lidarr 개인 설정',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/nl.ts
+++ b/src/core/i18n/messages/nl.ts
@@ -866,6 +866,8 @@ export const nl = {
   'settings.subsonicDescription':
     'Zelf-gehoste muziekserver (Navidrome, Airsonic) voor bibliotheeksynchronisatie en ontdekking',
   'settings.discogsDescription': 'Collectie en verlanglijst van Discogs.',
+  'settings.tidalDescription':
+    'Experimentele zoekbron die gebruikmaakt van TIDAL-clientgegevens. Gebruikt ongedocumenteerde eindpunten die zonder waarschuwing kunnen veranderen.',
   'settings.yourAccount': 'jouw account',
   'settings.lidarrPreferences': 'Jouw Lidarr-voorkeuren',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/pl.ts
+++ b/src/core/i18n/messages/pl.ts
@@ -866,6 +866,8 @@ export const pl = {
   'settings.subsonicDescription':
     'Samodzielnie hostowany serwer muzyczny (Navidrome, Airsonic) do synchronizacji biblioteki i odkrywania',
   'settings.discogsDescription': 'Kolekcja i lista zyczen z Discogs.',
+  'settings.tidalDescription':
+    'Eksperymentalne źródło wyszukiwania korzystające z danych uwierzytelniających klienta TIDAL. Wykorzystuje nieudokumentowane punkty końcowe, które mogą się zmienić bez ostrzeżenia.',
   'settings.yourAccount': 'twoje konto',
   'settings.lidarrPreferences': 'Twoje preferencje Lidarr',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/pt-BR.ts
+++ b/src/core/i18n/messages/pt-BR.ts
@@ -866,6 +866,8 @@ export const ptBR = {
   'settings.subsonicDescription':
     'Servidor de música auto-hospedado (Navidrome, Airsonic) para sincronização de biblioteca e descoberta',
   'settings.discogsDescription': 'Coleção e lista de desejos do Discogs.',
+  'settings.tidalDescription':
+    'Fonte de busca experimental que usa acesso por credenciais de cliente do TIDAL. Utiliza endpoints não documentados que podem mudar sem aviso prévio.',
   'settings.yourAccount': 'sua conta',
   'settings.lidarrPreferences': 'Suas preferências do Lidarr',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/ro.ts
+++ b/src/core/i18n/messages/ro.ts
@@ -867,6 +867,8 @@ export const ro = {
   'settings.subsonicDescription':
     'Server de muzică auto-găzduit (Navidrome, Airsonic) pentru sincronizarea bibliotecii și descoperire',
   'settings.discogsDescription': 'Colecție și listă de dorințe din Discogs.',
+  'settings.tidalDescription':
+    'Sursă de căutare experimentală care utilizează acces prin credențiale de client TIDAL. Folosește puncte finale nedocumentate care se pot schimba fără notificare.',
   'settings.yourAccount': 'contul dvs.',
   'settings.lidarrPreferences': 'Preferințele dvs. Lidarr',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/ru.ts
+++ b/src/core/i18n/messages/ru.ts
@@ -876,6 +876,8 @@ export const ru = {
   'settings.subsonicDescription':
     'Самостоятельно размещённый музыкальный сервер (Navidrome, Airsonic) для синхронизации библиотеки и поиска новинок',
   'settings.discogsDescription': 'Коллекция и список желаний из Discogs.',
+  'settings.tidalDescription':
+    'Экспериментальный источник поиска, использующий доступ по клиентским учётным данным TIDAL. Использует недокументированные конечные точки, которые могут измениться без предупреждения.',
   'settings.yourAccount': 'ваш аккаунт',
   'settings.lidarrPreferences': 'Ваши настройки Lidarr',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/tr.ts
+++ b/src/core/i18n/messages/tr.ts
@@ -863,6 +863,8 @@ export const tr = {
   'settings.subsonicDescription':
     'Kitaplık eşitleme ve keşif için kendi sunucunuzda barındırılan müzik sunucusu (Navidrome, Airsonic)',
   'settings.discogsDescription': "Discogs'tan koleksiyon ve istek listesi.",
+  'settings.tidalDescription':
+    'TIDAL istemci kimlik bilgileri erişimini kullanan deneysel bir arama kaynağı. Önceden haber verilmeden değişebilecek belgelenmemiş uç noktalar kullanır.',
   'settings.yourAccount': 'hesabiniz',
   'settings.lidarrPreferences': 'Lidarr Tercihleriniz',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/uk.ts
+++ b/src/core/i18n/messages/uk.ts
@@ -870,6 +870,8 @@ export const uk = {
   'settings.subsonicDescription':
     'Самостійно розміщений музичний сервер (Navidrome, Airsonic) для синхронізації бібліотеки та відкриття',
   'settings.discogsDescription': 'Колекція та список бажань із Discogs.',
+  'settings.tidalDescription':
+    'Експериментальне джерело пошуку, що використовує доступ за клієнтськими обліковими даними TIDAL. Використовує недокументовані кінцеві точки, які можуть змінитися без попередження.',
   'settings.yourAccount': 'ваш акаунт',
   'settings.lidarrPreferences': 'Ваші налаштування Lidarr',
   'settings.lidarrPreferencesDescription':

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -797,6 +797,8 @@ export const zhCN = {
   'settings.embyDescription': '带收听历史和播放列表导出功能的媒体服务器',
   'settings.subsonicDescription': '自托管音乐服务器（Navidrome、Airsonic），用于媒体库同步和发现',
   'settings.discogsDescription': '来自 Discogs 的收藏和心愿单。',
+  'settings.tidalDescription':
+    '实验性搜索源，使用 TIDAL 客户端凭据访问。使用未记录的接口，可能随时变更且不另行通知。',
   'settings.yourAccount': '你的账户',
   'settings.lidarrPreferences': '你的 Lidarr 偏好设置',
   'settings.lidarrPreferencesDescription':

--- a/src/core/search/sources/tidal.ts
+++ b/src/core/search/sources/tidal.ts
@@ -1,0 +1,34 @@
+import type { createTidalClient } from '@/core/clients/tidal'
+import type { SearchResult, SearchSource } from '@/core/search/multi-source'
+import { rankSearchMatches } from '@/core/search/relevance'
+
+export function createTidalSearchSource(
+  client: ReturnType<typeof createTidalClient>,
+): SearchSource {
+  return {
+    id: 'tidal',
+    name: 'TIDAL',
+    available: true,
+
+    async search(query: string, limit: number): Promise<SearchResult[]> {
+      const results = await client.searchArtists(query, Math.min(limit, 25))
+      const ranked = rankSearchMatches(results, query, {
+        limit,
+        maxResults: Math.min(limit, 8),
+        minScore: query.trim().length >= 4 ? 0.58 : 0.46,
+        fallbackResults: 4,
+        getName: (item) => item.name,
+        getTieBreaker: (item) => item.popularity,
+      })
+      return ranked.map((item) => ({
+        name: item.name,
+        images: item.imageUrl ? [{ url: item.imageUrl, source: 'tidal' }] : [],
+        genres: [],
+        popularity: item.popularity,
+        sourceId: 'tidal',
+        sourceUrl: item.url,
+        externalId: String(item.id),
+      }))
+    },
+  }
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -53,6 +53,8 @@ export const settings = pgTable('settings', {
   skipTlsVerify: boolean('skip_tls_verify').default(false).notNull(),
   audiodbApiKey: text('audiodb_api_key'),
   audiodbProxyImages: boolean('audiodb_proxy_images').notNull().default(false),
+  tidalClientId: text('tidal_client_id'),
+  tidalClientSecret: text('tidal_client_secret'),
   wikidataEnabled: boolean('wikidata_enabled').notNull().default(true),
   preferences: jsonb('preferences').$type<Preferences>(),
   setupComplete: boolean('setup_complete').default(false).notNull(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { tryConsume } from './core/clients/rate-limiter'
 import { createSlskdClient } from './core/clients/slskd'
 import { createSpotifyClient } from './core/clients/spotify'
 import { createSubsonicClient } from './core/clients/subsonic'
+import { createTidalClient } from './core/clients/tidal'
 import { initEncryption, isEncryptionEnabled } from './core/crypto'
 import { resolveDeezerToken } from './core/deezer-auth'
 import { createDefaultDiscoveryModeRegistry } from './core/discovery-modes/registry'
@@ -61,6 +62,7 @@ import { createBandcampSearchSource } from './core/search/sources/bandcamp'
 import { createDeezerSearchSource } from './core/search/sources/deezer'
 import { createMusicBrainzSearchSource } from './core/search/sources/musicbrainz'
 import { createSpotifySearchSource } from './core/search/sources/spotify'
+import { createTidalSearchSource } from './core/search/sources/tidal'
 import { setSessionStore } from './core/sessions'
 import { createSlskdOrchestrator } from './core/slskd/orchestrator'
 import { createSlskdRunner } from './core/slskd/runner'
@@ -1397,9 +1399,10 @@ const app = createApp({
   search: {
     listSources: async (userId) => {
       const spotifyOAuth = userId ? await getOAuthToken(db, userId, 'spotify') : null
+      const storedSettings = await getSettings(db)
       return buildSearchSourceCatalog({
         hasSpotifyOAuth: Boolean(spotifyOAuth),
-        hasTidalSearch: false,
+        hasTidalSearch: Boolean(storedSettings?.tidalClientId && storedSettings?.tidalClientSecret),
       })
     },
     search: async (query, opts) => {
@@ -1420,8 +1423,17 @@ const app = createApp({
           )
         }
       }
-      // TIDAL search requires client credentials (not per-user OAuth). Wire it here
-      // once TIDAL client ID/secret are exposed via settings (not yet implemented).
+      const storedSettings = await getSettings(db)
+      if (storedSettings?.tidalClientId && storedSettings?.tidalClientSecret) {
+        sources.push(
+          createTidalSearchSource(
+            createTidalClient({
+              clientId: storedSettings.tidalClientId,
+              clientSecret: storedSettings.tidalClientSecret,
+            }),
+          ),
+        )
+      }
 
       const filtered = opts?.sources ? sources.filter((s) => opts.sources?.includes(s.id)) : sources
       const merged = await multiSourceSearch(query, filtered, { limit: opts?.limit })

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -3,6 +3,7 @@ import { envConfig } from '@/config/env'
 import { createLastFmClient } from '@/core/clients/lastfm'
 import { createLidarrClient } from '@/core/clients/lidarr'
 import { createListenBrainzClient } from '@/core/clients/listenbrainz'
+import { createTidalClient } from '@/core/clients/tidal'
 import { sendWebhook } from '@/core/notifications'
 import { redactSecrets } from '@/core/providers/retry'
 import { validateAiBaseUrl } from '@/core/url-safety'
@@ -29,6 +30,7 @@ const SECRET_FIELDS = [
   'embyApiKey',
   'discogsToken',
   'subsonicPassword',
+  'tidalClientSecret',
 ] as const
 
 type SettingsResponse = Record<string, unknown>
@@ -241,6 +243,8 @@ export function settingsRoutes(deps: AppDependencies) {
     'oidcClientId',
     'oidcClientSecret',
     'oidcScopes',
+    'tidalClientId',
+    'tidalClientSecret',
   ])
 
   const USER_CONNECTION_FIELDS = new Set([
@@ -622,6 +626,15 @@ export function settingsRoutes(deps: AppDependencies) {
           scopes: 'openid',
         })
         return runProbe(c, () => svc.testConnection(), messages['common.unknownError'])
+      }
+      case 'tidal': {
+        const clientId = body.clientId || (stored?.tidalClientId as string) || ''
+        const clientSecret = body.clientSecret || (stored?.tidalClientSecret as string) || ''
+        if (!clientId || !clientSecret) {
+          return missingInput(`Missing ${!clientId ? 'client ID' : 'client secret'}`)
+        }
+        const client = createTidalClient({ clientId, clientSecret })
+        return runProbe(c, () => client.testConnection(), messages['common.unknownError'])
       }
       default:
         return problem(c, 'unknown-service', `Unknown service: ${service}`, 400)

--- a/src/server/schemas/settings.ts
+++ b/src/server/schemas/settings.ts
@@ -65,6 +65,10 @@ export const updateSettingsSchema = z.object({
   audiodbProxyImages: z.boolean().optional(),
   wikidataEnabled: z.boolean().optional(),
 
+  // TIDAL search (global, admin-only) - client credentials for the experimental search source
+  tidalClientId: z.string().nullable().optional(),
+  tidalClientSecret: z.string().nullable().optional(),
+
   // Preferences (nested)
   preferences: preferencesSchema.optional(),
 

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -87,6 +87,8 @@ type Settings = {
   audiodbApiKey?: string
   audiodbProxyImages?: boolean
   wikidataEnabled?: boolean
+  tidalClientId?: string
+  tidalClientSecret?: string
   oidcIssuerUrl?: string
   oidcClientId?: string
   oidcClientSecret?: string
@@ -269,6 +271,10 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
     settings.aiApiKey === '***' ? '' : (settings.aiApiKey ?? ''),
   )
   const [aiBaseUrl, setAiBaseUrl] = useState(settings.aiBaseUrl ?? '')
+  const [tidalClientId, setTidalClientId] = useState(settings.tidalClientId ?? '')
+  const [tidalClientSecret, setTidalClientSecret] = useState(
+    settings.tidalClientSecret === '***' ? '' : (settings.tidalClientSecret ?? ''),
+  )
   const [webhookUrl, setWebhookUrl] = useState(settings.preferences?.webhookUrl ?? '')
   const [digestCron, setDigestCron] = useState(settings.preferences?.digestCron ?? '')
   const [savingWebhook, setSavingWebhook] = useState(false)
@@ -350,6 +356,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
     listenbrainz: Boolean(settings.listenbrainzUsername && settings.listenbrainzToken),
     lastfm: Boolean(settings.lastfmUsername && settings.lastfmApiKey),
     ai: Boolean(settings.aiProvider && settings.aiModel),
+    tidal: Boolean(settings.tidalClientId && settings.tidalClientSecret),
     plex: Boolean(settings.plexUrl && settings.plexToken),
     jellyfin: Boolean(settings.jellyfinUrl && settings.jellyfinApiKey && settings.jellyfinUserId),
     emby: Boolean(settings.embyUrl && settings.embyApiKey && settings.embyUserId),
@@ -510,6 +517,16 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
     }
   }
 
+  const testTidal = createTester('tidal', 'TIDAL', () =>
+    testService('tidal', { clientId: tidalClientId, clientSecret: tidalClientSecret }),
+  )
+  const saveTidal = createSaver('tidal', 'TIDAL', () =>
+    updateSettings({
+      tidalClientId: tidalClientId || undefined,
+      tidalClientSecret: tidalClientSecret || undefined,
+    }),
+  )
+
   const testPlex = createTester('plex', 'Plex', async () => {
     const res = await testService('plex', {
       url: plexUrl,
@@ -656,6 +673,7 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
   const isLbConfigured = !!(lbUsername || settings.listenbrainzUsername)
   const isLfConfigured = !!(lfUsername || settings.lastfmUsername)
   const isAiConfigured = !!(aiModel || settings.aiModel)
+  const isTidalConfigured = !!(tidalClientId || settings.tidalClientId)
   const isPlexConfigured = !!(plexUrl || settings.plexUrl)
   const isJellyfinConfigured = !!(jellyfinUrl || settings.jellyfinUrl)
   const isEmbyConfigured = !!(embyUrl || settings.embyUrl)
@@ -974,6 +992,60 @@ function ConnectionsTab({ settings, onSaved }: { settings: Settings; onSaved: ()
                 {savingWebhook
                   ? t('settings.saving')
                   : webhookUrl
+                    ? t('settings.save')
+                    : t('settings.configure')}
+              </Button>
+            </div>
+          </ServiceCard>
+
+          {/* TIDAL search */}
+          <ServiceCard
+            name="TIDAL"
+            description={
+              <span>
+                {t('settings.tidalDescription')}{' '}
+                <span className="ml-1 rounded bg-amber-500/20 px-1.5 py-0.5 text-xs text-amber-600">
+                  {t('search.experimental')}
+                </span>
+              </span>
+            }
+            status={serviceStatus('tidal')}
+          >
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Field label={t('settings.fieldClientId')} id="tidal-client-id">
+                <Input
+                  id="tidal-client-id"
+                  value={tidalClientId}
+                  onChange={(e) => setTidalClientId(e.target.value)}
+                />
+              </Field>
+              <Field label={t('settings.fieldClientSecret')} id="tidal-client-secret">
+                <Input
+                  id="tidal-client-secret"
+                  type="password"
+                  placeholder={
+                    settings.tidalClientSecret === '***'
+                      ? `(${t('settings.saved')})`
+                      : t('settings.fieldClientSecret')
+                  }
+                  value={tidalClientSecret}
+                  onChange={(e) => setTidalClientSecret(e.target.value)}
+                />
+              </Field>
+            </div>
+            <div className="flex justify-end gap-2 pt-1">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={testTidal}
+                disabled={tests.tidal === 'testing'}
+              >
+                {tests.tidal === 'testing' ? t('settings.testing') : t('settings.testConnection')}
+              </Button>
+              <Button size="sm" onClick={saveTidal} disabled={saving.tidal}>
+                {saving.tidal
+                  ? t('settings.saving')
+                  : isTidalConfigured
                     ? t('settings.save')
                     : t('settings.configure')}
               </Button>

--- a/tests/core/ops/legacy-listening-connections.test.ts
+++ b/tests/core/ops/legacy-listening-connections.test.ts
@@ -15,6 +15,8 @@ function makeSettings(overrides: Partial<SettingsRow> = {}): SettingsRow {
     audiodbApiKey: null,
     audiodbProxyImages: false,
     wikidataEnabled: true,
+    tidalClientId: null,
+    tidalClientSecret: null,
     listenbrainzUsername: 'global-lb-user',
     listenbrainzToken: 'global-lb-token',
     lastfmUsername: 'global-lastfm-user',

--- a/tests/core/search.test.ts
+++ b/tests/core/search.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { buildSearchSourceCatalog } from '@/core/search/catalog'
 import { createDeezerSearchSource } from '@/core/search/sources/deezer'
 import { createMusicBrainzSearchSource } from '@/core/search/sources/musicbrainz'
+import { createTidalSearchSource } from '@/core/search/sources/tidal'
 
 describe('search source catalog', () => {
   it('marks Spotify and TIDAL unavailable when not configured', () => {
@@ -29,6 +30,20 @@ describe('search source catalog', () => {
       },
       { id: 'bandcamp', label: 'Bandcamp', available: true, stability: 'experimental' },
     ])
+  })
+
+  it('marks TIDAL available once client credentials are configured', () => {
+    const sources = buildSearchSourceCatalog({
+      hasSpotifyOAuth: false,
+      hasTidalSearch: true,
+    })
+
+    expect(sources).toContainEqual({
+      id: 'tidal',
+      label: 'TIDAL',
+      available: true,
+      stability: 'experimental',
+    })
   })
 })
 
@@ -94,5 +109,74 @@ describe('MusicBrainz search source', () => {
 
     expect(results).toHaveLength(8)
     expect(results[0]?.name).toBe('Muse')
+  })
+})
+
+describe('TIDAL search source', () => {
+  it('prioritizes close name matches and trims noisy results', async () => {
+    const source = createTidalSearchSource({
+      searchArtists: async () => [
+        { id: 1, name: 'Head Radio', popularity: 99, url: 'https://tidal.example/head-radio' },
+        { id: 2, name: 'Radiohead', popularity: 80, url: 'https://tidal.example/radiohead' },
+        {
+          id: 3,
+          name: 'Radiohead Tribute Orchestra',
+          popularity: 60,
+          url: 'https://tidal.example/tribute',
+        },
+        { id: 4, name: 'Radioheater', popularity: 70, url: 'https://tidal.example/radioheater' },
+      ],
+      testConnection: async () => ({ success: true, message: 'ok' }),
+    })
+
+    const results = await source.search('radiohead', 20)
+
+    expect(results.map((result) => result.name)).toEqual([
+      'Radiohead',
+      'Radiohead Tribute Orchestra',
+    ])
+  })
+
+  it('maps TIDAL fields to the shared search result shape', async () => {
+    const source = createTidalSearchSource({
+      searchArtists: async () => [
+        {
+          id: 42,
+          name: 'Radiohead',
+          popularity: 88,
+          url: 'https://tidal.example/radiohead',
+          imageUrl: 'https://tidal.example/radiohead.jpg',
+        },
+      ],
+      testConnection: async () => ({ success: true, message: 'ok' }),
+    })
+
+    const results = await source.search('radiohead', 20)
+
+    expect(results).toEqual([
+      {
+        name: 'Radiohead',
+        images: [{ url: 'https://tidal.example/radiohead.jpg', source: 'tidal' }],
+        genres: [],
+        popularity: 88,
+        sourceId: 'tidal',
+        sourceUrl: 'https://tidal.example/radiohead',
+        externalId: '42',
+      },
+    ])
+  })
+
+  it('omits images when TIDAL has no artwork for a match', async () => {
+    const source = createTidalSearchSource({
+      searchArtists: async () => [
+        { id: 7, name: 'Radiohead', popularity: 88, url: 'https://tidal.example/radiohead' },
+      ],
+      testConnection: async () => ({ success: true, message: 'ok' }),
+    })
+
+    const results = await source.search('radiohead', 20)
+
+    expect(results[0]?.images).toEqual([])
+    expect(results[0]?.externalId).toBe('7')
   })
 })

--- a/tests/core/subscriptions/connections.test.ts
+++ b/tests/core/subscriptions/connections.test.ts
@@ -14,6 +14,8 @@ function makeSettings(overrides: Partial<SettingsRow> = {}): SettingsRow {
     audiodbApiKey: null,
     audiodbProxyImages: false,
     wikidataEnabled: true,
+    tidalClientId: null,
+    tidalClientSecret: null,
     listenbrainzUsername: 'global-lb-user',
     listenbrainzToken: 'global-lb-token',
     lastfmUsername: 'global-lastfm-user',

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -62,6 +62,16 @@ const { mockOidcTestConnection } = vi.hoisted(() => ({
   })),
 }))
 
+const { mockCreateTidalClient } = vi.hoisted(() => ({
+  mockCreateTidalClient: vi.fn(() => ({
+    searchArtists: vi.fn(async () => []),
+    testConnection: vi.fn(async () => ({
+      success: true,
+      message: 'Connected to TIDAL - API responding',
+    })),
+  })),
+}))
+
 vi.mock('@/db/queries/users', async () => {
   const actual = await vi.importActual<typeof import('@/db/queries/users')>('@/db/queries/users')
   return {
@@ -112,6 +122,10 @@ vi.mock('@/core/auth/oidc', () => ({
   OidcService: class OidcService {
     testConnection = mockOidcTestConnection
   },
+}))
+
+vi.mock('@/core/clients/tidal', () => ({
+  createTidalClient: mockCreateTidalClient,
 }))
 
 vi.mock('@/core/notifications', () => ({
@@ -349,6 +363,27 @@ describe('GET /api/v1/settings', () => {
     expect(body.aiApiKey).toBeNull()
   })
 
+  it('masks the stored TIDAL client secret', async () => {
+    mockGetUserConnections.mockResolvedValueOnce(defaultUserConnections)
+    const app = createApp(
+      makeDeps({
+        getSettings: vi.fn(
+          async () =>
+            ({
+              ...mockSettings,
+              tidalClientId: 'tidal-id',
+              tidalClientSecret: 'tidal-secret',
+            }) as unknown as SettingsRow,
+        ),
+      }),
+    )
+    const res = await authedRequest(app, '/api/v1/settings')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.tidalClientId).toBe('tidal-id')
+    expect(body.tidalClientSecret).toBe('***')
+  })
+
   it('preserves null secret fields instead of pretending they were saved', async () => {
     mockGetUserConnections.mockResolvedValueOnce(defaultUserConnections)
     const app = createApp(makeDeps())
@@ -388,6 +423,25 @@ describe('PATCH /api/v1/settings', () => {
     expect(updateSettings).toHaveBeenCalledTimes(1)
     const body = await res.json()
     expect(body.lidarrUrl).toBe('http://new:8686')
+  })
+
+  it('accepts TIDAL client credentials through the strict schema and persists them', async () => {
+    const updateSettings = vi.fn(async () => {})
+    const app = createApp(makeDeps({ updateSettings }))
+
+    const res = await authedRequest(app, '/api/v1/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tidalClientId: 'tidal-id', tidalClientSecret: 'tidal-secret' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tidalClientId: 'tidal-id',
+        tidalClientSecret: 'tidal-secret',
+      }),
+    )
   })
 
   it('restarts scheduler when cron is updated', async () => {
@@ -748,6 +802,7 @@ describe('POST /api/v1/settings/test/:service', () => {
       'subsonic',
       'spotify',
       'oidc',
+      'tidal',
     ]
 
     for (const service of services) {
@@ -968,6 +1023,62 @@ describe('POST /api/v1/settings/test/:service', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url: 'http://127.0.0.1:4533', username: 'admin' }),
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.type).toBe('/problems/probe-missing-input')
+  })
+
+  it('tests tidal and invokes the client with the provided credentials', async () => {
+    const app = createApp(makeDeps())
+    const res = await authedRequest(app, '/api/v1/settings/test/tidal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientId: 'tidal-id', clientSecret: 'tidal-secret' }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockCreateTidalClient).toHaveBeenCalledWith({
+      clientId: 'tidal-id',
+      clientSecret: 'tidal-secret',
+    })
+    const body = await res.json()
+    expect(body.message).toBe('Connected to TIDAL - API responding')
+  })
+
+  it('falls back to stored TIDAL credentials when the request omits them', async () => {
+    const app = createApp(
+      makeDeps({
+        getSettings: vi.fn(
+          async () =>
+            ({
+              ...mockSettings,
+              tidalClientId: 'stored-id',
+              tidalClientSecret: 'stored-secret',
+            }) as unknown as SettingsRow,
+        ),
+      }),
+    )
+    const res = await authedRequest(app, '/api/v1/settings/test/tidal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockCreateTidalClient).toHaveBeenCalledWith({
+      clientId: 'stored-id',
+      clientSecret: 'stored-secret',
+    })
+  })
+
+  it('returns a missing-input error when tidal credentials are incomplete', async () => {
+    const app = createApp(makeDeps())
+    const res = await authedRequest(app, '/api/v1/settings/test/tidal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientId: 'tidal-id' }),
     })
 
     expect(res.status).toBe(400)


### PR DESCRIPTION
Closes #405.

Finishes the halfway-built TIDAL search integration (plan 030). The complete, tested TIDAL client existed with zero production importers and the search catalog carried a permanently-unavailable `tidal` row (`hasTidalSearch: false` hardcoded).

## Changes

- **Settings**: new `tidal_client_id` / `tidal_client_secret` columns (migration `0040`, `IF NOT EXISTS`); secret encrypted at rest via `SENSITIVE_SETTINGS`, masked in GET responses, admin-only mutable.
- **Probe route**: `POST /api/v1/settings/test/tidal` with stored-credential fallback, matching the lidarr pattern.
- **Search source**: new `src/core/search/sources/tidal.ts` executor modeled on deezer/spotify; maps TIDAL popularity to `popularity` (0-100 score, not listeners — spotify precedent); ranked via `rankSearchMatches`.
- **Wiring**: `listSources` computes `hasTidalSearch` from stored credentials; the search closure pushes the TIDAL source when both fields are present. Parked TODO comment removed.
- **UI**: admin-only TIDAL card in Settings > Connections (client ID, masked secret, Test/Save, experimental badge). Search UI needed no change (catalog-driven).
- **i18n**: one new key (`settings.tidalDescription`) with real translations across all 15 locales; field labels and toasts reuse existing keys.
- **Tests**: +13 (source mapping/ranking, catalog availability, probe happy/fallback/missing-input, GET masking, PATCH strict-schema persistence). Two test fixtures gained the new nullable SettingsRow fields (typecheck fallout only).

`src/core/clients/tidal.ts` untouched — its swallow-errors-return-empty behavior is by design (semi-public endpoints; multi-source search degrades instead of failing).

## Verification

- `typecheck`, `lint`, `i18n:check` (15/15), `test:api-routes` (41/41): all exit 0
- Full suite: 2610 pass, 1 pre-existing pglite statement_timeout flake (untouched file, passes in isolation — tracked separately)