### PR TITLE
fix(library): retry unmonitored fix per artist when bulk call fails

### DIFF
--- a/src/core/library/health.ts
+++ b/src/core/library/health.ts
@@ -192,17 +192,19 @@ export class LibraryHealthService {
 
     if (checkId === 'unmonitored') {
       const ids = items.map((i) => i.artistId).filter((id) => id > 0)
-      if (ids.length > 0) {
-        try {
-          await this.deps.lidarrClient.setArtistsMonitored(ids, true)
-          progress.completed = ids.length
-        } catch (err: unknown) {
-          progress.failed = ids.length
-          progress.errors.push(errMsg(err))
-        }
+      if (ids.length === 0) {
+        progress.status = 'completed'
+        return progress
       }
-      progress.status = progress.failed === 0 ? 'completed' : 'failed'
-      return progress
+      try {
+        await this.deps.lidarrClient.setArtistsMonitored(ids, true)
+        progress.completed = ids.length
+        progress.status = 'completed'
+        return progress
+      } catch {
+        // bulk editor rejects the whole batch as a unit -- fall through to the
+        // per-artist queue to attribute failures and fix what still can be
+      }
     }
 
     const queue = new PQueue({ concurrency: 1, interval: 1000, intervalCap: 1 })
@@ -434,6 +436,10 @@ export class LibraryHealthService {
 
   private async applyFix(checkId: HealthCheckId, item: HealthCheckItem): Promise<void> {
     switch (checkId) {
+      case 'unmonitored':
+        await this.deps.lidarrClient.setArtistsMonitored([item.artistId], true)
+        break
+
       case 'missing-metadata':
       case 'genre-gaps':
         await this.deps.lidarrClient.triggerCommand('RefreshArtist', { artistId: item.artistId })

--- a/tests/core/library/health.test.ts
+++ b/tests/core/library/health.test.ts
@@ -716,7 +716,7 @@ describe('LibraryHealthService', () => {
       expect(progress).toMatchObject({ total: 3, completed: 3, failed: 0, status: 'completed' })
     })
 
-    it('records a single batch error when the bulk unmonitored call fails', async () => {
+    it('falls back to per-artist calls when the bulk unmonitored call fails', async () => {
       const unmonitoredArtists = [
         { ...ARTIST_RADIOHEAD, monitored: false },
         { ...ARTIST_PORTISHEAD, monitored: false },
@@ -729,12 +729,55 @@ describe('LibraryHealthService', () => {
 
       const progress = await service.fixCheck('unmonitored')
 
-      expect(mocks.setArtistsMonitored).toHaveBeenCalledTimes(1)
-      expect(progress.completed).toBe(0)
-      expect(progress.failed).toBe(3)
-      expect(progress.status).toBe('failed')
+      expect(mocks.setArtistsMonitored).toHaveBeenCalledTimes(4)
+      expect(mocks.setArtistsMonitored).toHaveBeenNthCalledWith(
+        1,
+        [ARTIST_RADIOHEAD.id, ARTIST_PORTISHEAD.id, ARTIST_BJORK.id],
+        true,
+      )
+      expect(mocks.setArtistsMonitored).toHaveBeenNthCalledWith(2, [ARTIST_RADIOHEAD.id], true)
+      expect(mocks.setArtistsMonitored).toHaveBeenNthCalledWith(3, [ARTIST_PORTISHEAD.id], true)
+      expect(mocks.setArtistsMonitored).toHaveBeenNthCalledWith(4, [ARTIST_BJORK.id], true)
+      expect(progress).toMatchObject({ total: 3, completed: 0, failed: 3, status: 'failed' })
+      expect(progress.errors).toHaveLength(3)
+      expect(progress.errors).toEqual([
+        `${ARTIST_RADIOHEAD.artistName}: Lidarr down`,
+        `${ARTIST_PORTISHEAD.artistName}: Lidarr down`,
+        `${ARTIST_BJORK.artistName}: Lidarr down`,
+      ])
+    })
+
+    it('recovers healthy artists and names the culprit when one item poisons the bulk call', async () => {
+      const unmonitoredArtists = [
+        { ...ARTIST_RADIOHEAD, monitored: false },
+        { ...ARTIST_PORTISHEAD, monitored: false },
+        ARTIST_BJORK,
+      ]
+      mocks.getArtists.mockResolvedValue(unmonitoredArtists)
+      mocks.cacheGetAll.mockResolvedValue([])
+      await service.runChecks()
+      mocks.setArtistsMonitored.mockImplementation((ids: number[]) => {
+        if (ids.length > 1 || ids[0] === ARTIST_PORTISHEAD.id) {
+          return Promise.reject(new Error('artist not found'))
+        }
+        return Promise.resolve([])
+      })
+
+      const progress = await service.fixCheck('unmonitored')
+
+      expect(mocks.setArtistsMonitored).toHaveBeenCalledTimes(4)
+      expect(mocks.setArtistsMonitored).toHaveBeenNthCalledWith(
+        1,
+        [ARTIST_RADIOHEAD.id, ARTIST_PORTISHEAD.id, ARTIST_BJORK.id],
+        true,
+      )
+      expect(mocks.setArtistsMonitored).toHaveBeenNthCalledWith(2, [ARTIST_RADIOHEAD.id], true)
+      expect(mocks.setArtistsMonitored).toHaveBeenNthCalledWith(3, [ARTIST_PORTISHEAD.id], true)
+      expect(mocks.setArtistsMonitored).toHaveBeenNthCalledWith(4, [ARTIST_BJORK.id], true)
+      expect(progress).toMatchObject({ total: 3, completed: 2, failed: 1, status: 'failed' })
       expect(progress.errors).toHaveLength(1)
-      expect(progress.errors[0]).toContain('Lidarr down')
+      expect(progress.errors[0]).toContain(ARTIST_PORTISHEAD.artistName)
+      expect(progress.errors[0]).toContain('artist not found')
     })
 
     it('still queues one triggerCommand call per item for missing-albums (non-bulk path unchanged)', async () => {


### PR DESCRIPTION
## Summary
- keep the bulk unmonitored happy path as a single Lidarr editor call
- fall back to the existing per-artist queue only when the bulk call fails
- add regression coverage for full outage attribution and one poison artist with partial recovery

Closes #414

## Verification
- bun run typecheck
- bun run lint (passes with 9 pre-existing warnings)
- bun run test tests/core/library/
- bun run test tests/db/pglite-integration.test.ts

Note: local full-suite reruns hit the tracked pglite hook timeout from #418; the pglite file passes in isolation.