### PR TITLE
fix(discovery): make Library Gap-Fill mode reachable

### DIFF
--- a/src/core/discovery-modes/availability.ts
+++ b/src/core/discovery-modes/availability.ts
@@ -169,6 +169,17 @@ export function evaluateDiscoveryModeAvailability(
     }
   }
 
+  if (modeId === 'gap-fill') {
+    return snapshot.hasLibrarySync
+      ? { enabled: true, fallbackUsed: false, providerPath: ['musicbrainz'] }
+      : {
+          enabled: false,
+          fallbackUsed: false,
+          providerPath: [],
+          reason: 'Sync a library first to use this mode.',
+        }
+  }
+
   return {
     enabled: false,
     fallbackUsed: false,

--- a/src/core/i18n/messages/de.ts
+++ b/src/core/i18n/messages/de.ts
@@ -733,6 +733,8 @@ export const de = {
   'discoveryMode.reason.notImplementedYet': 'Dieser Modus ist noch nicht implementiert.',
   'discoveryMode.reason.releaseRadarFallback':
     'Fallback-Anbieter werden für die Release-Entdeckung verwendet.',
+  'discoveryMode.reason.libraryRequired':
+    'Synchronisiere zuerst eine Bibliothek, um diesen Modus zu nutzen.',
   'discoveryMode.field.feed': 'Feed',
   'discoveryMode.field.artist': 'Künstler',
   'discoveryMode.field.adventurousness': 'Abenteuerlust',

--- a/src/core/i18n/messages/en.ts
+++ b/src/core/i18n/messages/en.ts
@@ -829,6 +829,7 @@ export const en = {
   'discoveryMode.reason.connectSubsonic': 'Connect Subsonic to use this mode.',
   'discoveryMode.reason.notImplementedYet': 'This mode is not implemented yet.',
   'discoveryMode.reason.releaseRadarFallback': 'Using fallback providers for release discovery.',
+  'discoveryMode.reason.libraryRequired': 'Sync a library first to use this mode.',
   'discoveryMode.field.feed': 'Feed',
   'discoveryMode.field.artist': 'Artist',
   'discoveryMode.field.adventurousness': 'Adventurousness',

--- a/src/core/i18n/messages/es.ts
+++ b/src/core/i18n/messages/es.ts
@@ -722,6 +722,7 @@ export const es = {
   'discoveryMode.reason.notImplementedYet': 'Este modo aún no está implementado.',
   'discoveryMode.reason.releaseRadarFallback':
     'Usando proveedores de respaldo para descubrir lanzamientos.',
+  'discoveryMode.reason.libraryRequired': 'Sincroniza primero una biblioteca para usar este modo.',
   'discoveryMode.field.feed': 'Feed',
   'discoveryMode.field.artist': 'Artista',
   'discoveryMode.field.adventurousness': 'Aventura',

--- a/src/core/i18n/messages/fr.ts
+++ b/src/core/i18n/messages/fr.ts
@@ -717,6 +717,8 @@ export const fr = {
   'discoveryMode.reason.notImplementedYet': "Ce mode n'est pas encore implémenté.",
   'discoveryMode.reason.releaseRadarFallback':
     'Utilisation de fournisseurs de secours pour la découverte des sorties.',
+  'discoveryMode.reason.libraryRequired':
+    'Synchronisez d’abord une bibliothèque pour utiliser ce mode.',
   'discoveryMode.field.feed': 'Flux',
   'discoveryMode.field.artist': 'Artiste',
   'discoveryMode.field.adventurousness': 'Aventure',

--- a/src/core/i18n/messages/it.ts
+++ b/src/core/i18n/messages/it.ts
@@ -721,6 +721,8 @@ export const it = {
   'discoveryMode.reason.notImplementedYet': 'Questa modalità non è ancora implementata.',
   'discoveryMode.reason.releaseRadarFallback':
     'Uso di provider di fallback per la scoperta delle uscite.',
+  'discoveryMode.reason.libraryRequired':
+    'Sincronizza prima una libreria per usare questa modalità.',
   'discoveryMode.field.feed': 'Feed',
   'discoveryMode.field.artist': 'Artista',
   'discoveryMode.field.adventurousness': 'Avventura',

--- a/src/core/i18n/messages/ja.ts
+++ b/src/core/i18n/messages/ja.ts
@@ -713,6 +713,8 @@ export const ja = {
   'discoveryMode.reason.notImplementedYet': 'このモードはまだ実装されていません。',
   'discoveryMode.reason.releaseRadarFallback':
     'リリース探索にはフォールバックプロバイダーが使われます。',
+  'discoveryMode.reason.libraryRequired':
+    'このモードを使うには、先にライブラリを同期してください。',
   'discoveryMode.field.feed': 'フィード',
   'discoveryMode.field.artist': 'アーティスト',
   'discoveryMode.field.adventurousness': '冒険度',

--- a/src/core/i18n/messages/ko.ts
+++ b/src/core/i18n/messages/ko.ts
@@ -703,6 +703,7 @@ export const ko = {
   'discoveryMode.reason.connectSubsonic': '이 모드를 사용하려면 Subsonic을 연결하세요.',
   'discoveryMode.reason.notImplementedYet': '이 모드는 아직 구현되지 않았습니다.',
   'discoveryMode.reason.releaseRadarFallback': '릴리스 탐색에는 대체 제공자가 사용됩니다.',
+  'discoveryMode.reason.libraryRequired': '이 모드를 사용하려면 먼저 라이브러리를 동기화하세요.',
   'discoveryMode.field.feed': '피드',
   'discoveryMode.field.artist': '아티스트',
   'discoveryMode.field.adventurousness': '모험성',

--- a/src/core/i18n/messages/nl.ts
+++ b/src/core/i18n/messages/nl.ts
@@ -724,6 +724,8 @@ export const nl = {
   'discoveryMode.reason.notImplementedYet': 'Deze modus is nog niet geïmplementeerd.',
   'discoveryMode.reason.releaseRadarFallback':
     'Fallbackproviders worden gebruikt voor release-ontdekking.',
+  'discoveryMode.reason.libraryRequired':
+    'Synchroniseer eerst een bibliotheek om deze modus te gebruiken.',
   'discoveryMode.field.feed': 'Feed',
   'discoveryMode.field.artist': 'Artiest',
   'discoveryMode.field.adventurousness': 'Avontuurlijkheid',

--- a/src/core/i18n/messages/pl.ts
+++ b/src/core/i18n/messages/pl.ts
@@ -727,6 +727,7 @@ export const pl = {
   'discoveryMode.reason.connectSubsonic': 'Połącz Subsonic, aby użyć tego trybu.',
   'discoveryMode.reason.notImplementedYet': 'Ten tryb nie jest jeszcze zaimplementowany.',
   'discoveryMode.reason.releaseRadarFallback': 'Do odkrywania wydan używane sa źródła zapasowe.',
+  'discoveryMode.reason.libraryRequired': 'Najpierw zsynchronizuj bibliotekę, aby użyć tego trybu.',
   'discoveryMode.field.feed': 'Feed',
   'discoveryMode.field.artist': 'Artysta',
   'discoveryMode.field.adventurousness': 'Odwaznosc',

--- a/src/core/i18n/messages/pt-BR.ts
+++ b/src/core/i18n/messages/pt-BR.ts
@@ -725,6 +725,7 @@ export const ptBR = {
   'discoveryMode.reason.notImplementedYet': 'Este modo ainda não foi implementado.',
   'discoveryMode.reason.releaseRadarFallback':
     'Usando provedores de fallback para descobrir lançamentos.',
+  'discoveryMode.reason.libraryRequired': 'Sincronize primeiro uma biblioteca para usar este modo.',
   'discoveryMode.field.feed': 'Feed',
   'discoveryMode.field.artist': 'Artista',
   'discoveryMode.field.adventurousness': 'Aventura',

--- a/src/core/i18n/messages/ro.ts
+++ b/src/core/i18n/messages/ro.ts
@@ -725,6 +725,8 @@ export const ro = {
   'discoveryMode.reason.notImplementedYet': 'Acest mod nu este încă implementat.',
   'discoveryMode.reason.releaseRadarFallback':
     'Se folosesc furnizori de rezervă pentru descoperirea lansărilor.',
+  'discoveryMode.reason.libraryRequired':
+    'Sincronizează mai întâi o bibliotecă pentru a folosi acest mod.',
   'discoveryMode.field.feed': 'Flux',
   'discoveryMode.field.artist': 'Artist',
   'discoveryMode.field.adventurousness': 'Aventurism',

--- a/src/core/i18n/messages/ru.ts
+++ b/src/core/i18n/messages/ru.ts
@@ -734,6 +734,8 @@ export const ru = {
   'discoveryMode.reason.notImplementedYet': 'Этот режим ещё не реализован.',
   'discoveryMode.reason.releaseRadarFallback':
     'Для поиска релизов используются резервные провайдеры.',
+  'discoveryMode.reason.libraryRequired':
+    'Сначала синхронизируйте библиотеку, чтобы использовать этот режим.',
   'discoveryMode.field.feed': 'Лента',
   'discoveryMode.field.artist': 'Исполнитель',
   'discoveryMode.field.adventurousness': 'Авантюризм',

--- a/src/core/i18n/messages/tr.ts
+++ b/src/core/i18n/messages/tr.ts
@@ -721,6 +721,7 @@ export const tr = {
   'discoveryMode.reason.connectSubsonic': "Bu modu kullanmak için Subsonic'i bağlayın.",
   'discoveryMode.reason.notImplementedYet': 'Bu mod henüz uygulanmadı.',
   'discoveryMode.reason.releaseRadarFallback': 'Yayin kesfi için yedek saglayicilar kullaniliyor.',
+  'discoveryMode.reason.libraryRequired': 'Bu modu kullanmak için önce bir kütüphaneyi eşitleyin.',
   'discoveryMode.field.feed': 'Feed',
   'discoveryMode.field.artist': 'Sanatci',
   'discoveryMode.field.adventurousness': 'Maceraperestlik',

--- a/src/core/i18n/messages/uk.ts
+++ b/src/core/i18n/messages/uk.ts
@@ -728,6 +728,8 @@ export const uk = {
   'discoveryMode.reason.notImplementedYet': 'Цей режим ще не реалізовано.',
   'discoveryMode.reason.releaseRadarFallback':
     'Для пошуку релізів використовуються резервні постачальники.',
+  'discoveryMode.reason.libraryRequired':
+    'Спочатку синхронізуйте бібліотеку, щоб використовувати цей режим.',
   'discoveryMode.field.feed': 'Стрічка',
   'discoveryMode.field.artist': 'Виконавець',
   'discoveryMode.field.adventurousness': 'Авантюризм',

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -666,6 +666,7 @@ export const zhCN = {
   'discoveryMode.reason.connectSubsonic': '连接 Subsonic 以使用此模式。',
   'discoveryMode.reason.notImplementedYet': '此模式尚未实现。',
   'discoveryMode.reason.releaseRadarFallback': '正在使用后备提供方来发现新发行。',
+  'discoveryMode.reason.libraryRequired': '请先同步音乐库以使用此模式。',
   'discoveryMode.field.feed': '订阅源',
   'discoveryMode.field.artist': '艺术家',
   'discoveryMode.field.adventurousness': '探索程度',

--- a/src/web/lib/discovery-i18n.ts
+++ b/src/web/lib/discovery-i18n.ts
@@ -38,6 +38,7 @@ const REASON_KEY_ALIASES: Record<string, MessageKey> = {
   'Using fallback providers for release discovery.': 'discoveryMode.reason.releaseRadarFallback',
   'This mode is not implemented yet.': 'discoveryMode.notImplementedYet',
   'This mode is not shipped yet.': 'discoveryMode.notShippedYet',
+  'Sync a library first to use this mode.': 'discoveryMode.reason.libraryRequired',
 }
 
 function normalizeModeId(modeId: string): string {

--- a/tests/core/discovery-modes/availability.test.ts
+++ b/tests/core/discovery-modes/availability.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { evaluateDiscoveryModeAvailability } from '@/core/discovery-modes/availability'
+import {
+  EMPTY_DISCOVERY_SNAPSHOT,
+  evaluateDiscoveryModeAvailability,
+} from '@/core/discovery-modes/availability'
+import { createDefaultDiscoveryModeRegistry } from '@/core/discovery-modes/registry'
 
 describe('evaluateDiscoveryModeAvailability', () => {
   it('disables strict ListenBrainz mode when the connection is missing', () => {
@@ -159,5 +163,43 @@ describe('evaluateDiscoveryModeAvailability', () => {
       providerPath: [],
     })
     expect(result.reason).toBe('Connect Discogs to use this mode.')
+  })
+
+  it('enables gap-fill (MusicBrainz) when a library has been synced', () => {
+    const result = evaluateDiscoveryModeAvailability('gap-fill', {
+      ...EMPTY_DISCOVERY_SNAPSHOT,
+      hasLibrarySync: true,
+    })
+
+    expect(result).toMatchObject({
+      enabled: true,
+      fallbackUsed: false,
+      providerPath: ['musicbrainz'],
+    })
+  })
+
+  it('reports gap-fill mode unavailable when no library has been synced', () => {
+    const result = evaluateDiscoveryModeAvailability('gap-fill', EMPTY_DISCOVERY_SNAPSHOT)
+
+    expect(result).toMatchObject({
+      enabled: false,
+      fallbackUsed: false,
+      providerPath: [],
+      reason: 'Sync a library first to use this mode.',
+    })
+  })
+
+  it('never falls through to the not-shipped-yet reason for a registered mode', () => {
+    const allTrueSnapshot = Object.fromEntries(
+      Object.keys(EMPTY_DISCOVERY_SNAPSHOT).map((key) => [key, true]),
+    ) as typeof EMPTY_DISCOVERY_SNAPSHOT
+
+    const registry = createDefaultDiscoveryModeRegistry()
+    for (const mode of registry.list()) {
+      const result = evaluateDiscoveryModeAvailability(mode.id, allTrueSnapshot)
+      expect(result.reason, `mode '${mode.id}' fell through to the default reason`).not.toBe(
+        'This mode is not shipped yet.',
+      )
+    }
   })
 })


### PR DESCRIPTION
## What

Gap-Fill discovery mode shipped in v1.2.0 (PR #243) as album-discovery Producer A -- registered, implemented, tested, translated across 15 locales -- but was never wired into `evaluateDiscoveryModeAvailability`. It fell through to `'This mode is not shipped yet.'`, so the UI greyed it out, the run route returned 400, and the subscription runner threw. Users could never run a feature the CHANGELOG and README advertise.

## Fix

One availability branch, gated on the already-populated `hasLibrarySync` snapshot flag (no snapshot-builder change needed -- both sites at `src/index.ts` already populate it):

- `src/core/discovery-modes/availability.ts` -- gap-fill branch (`strict` + `providerPath: ['musicbrainz']`).
- `discoveryMode.reason.libraryRequired` i18n key across all 15 locales (real translations).
- `src/web/lib/discovery-i18n.ts` -- frontend reason alias.
- `tests/core/discovery-modes/availability.test.ts` -- +3 cases: gap-fill enabled/disabled, plus a **registry-parity guard** that fails if any registered mode lacks an availability branch (prevents the next instance of this bug class).

## Verification

typecheck 0, lint 0 (9 pre-existing warns), i18n 15/15, discovery-mode tests 95 pass (parity guard covers the full registry), full suite 2616 pass (the one failure is the tracked pglite `statement_timeout` flake #418 -- 6/6 in isolation).

Closes the P1 "shipped-but-dead gap-fill" bug.