### PR TITLE
fix(security): redact AI source errors in discovery pipeline

### DIFF
--- a/src/core/pipeline/discover.ts
+++ b/src/core/pipeline/discover.ts
@@ -204,7 +204,7 @@ export async function discover(
         })
       }
     } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err)
+      const detail = redactSecrets(err instanceof Error ? err.message : String(err))
       console.warn(`[discover] AI source failed: ${detail}`)
       options.onSourceFailure?.('ai', detail)
     }

--- a/tests/core/pipeline/discover.test.ts
+++ b/tests/core/pipeline/discover.test.ts
@@ -174,6 +174,26 @@ describe('discover()', () => {
     warn.mockRestore()
   })
 
+  it('redacts credential-shaped substrings from an AI source failure before it reaches onSourceFailure', async () => {
+    const lb = makeLb()
+    const ai = {
+      getRecommendations: vi
+        .fn()
+        .mockRejectedValue(new Error('AI request failed: ?api_key=abc123secret')),
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const onSourceFailure = vi.fn()
+
+    await discover(profile, { listeningSources: [lb], ai }, 10, undefined, 0, { onSourceFailure })
+
+    const aiCall = onSourceFailure.mock.calls.find((call) => call[0] === 'ai')
+    expect(aiCall).toBeDefined()
+    const lastError = aiCall?.[1]
+    expect(lastError).toContain('[redacted]')
+    expect(lastError).not.toContain('abc123secret')
+    warn.mockRestore()
+  })
+
   it('respects topArtistsLimit - skips artists beyond the limit', async () => {
     const lb = makeLb()
     // Limit to 1 artist, so only Radiohead's similar artists should be fetched


### PR DESCRIPTION
Closes #415.

The AI-source failure path in `discover()` passed the raw `err.message` to both `console.warn` and `options.onSourceFailure`, which the orchestrator persists into job `sourceResults.ai.error` and surfaces in an SSE progress warning. An AI provider error embedding a key (e.g. a 401 body echoing `?api_key=...`) reached job records and the UI verbatim.

Plan 028 already redacted the listening-source path; this closes the AI-path gap it deferred.

## Change
- `src/core/pipeline/discover.ts`: wrap the AI-path `detail` with `redactSecrets(...)` at capture, so both the log line and `onSourceFailure` get the redacted value.
- `tests/core/pipeline/discover.test.ts`: regression test asserting an AI failure message containing `?api_key=...` reaches `onSourceFailure('ai', ...)` with `[redacted]` and without the secret.

## Verification
- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run test` — full suite green (2627 passed)