### PR TITLE
fix(i18n): translate connect-reasons for the four newest discovery modes

### DIFF
--- a/src/web/lib/discovery-i18n.ts
+++ b/src/web/lib/discovery-i18n.ts
@@ -35,6 +35,10 @@ const REASON_KEY_ALIASES: Record<string, MessageKey> = {
   'Connect ListenBrainz or Last.fm to use this mode.':
     'discoveryMode.reason.connectListenBrainzOrLastfm',
   'Connect Discogs to use this mode.': 'discoveryMode.reason.connectDiscogs',
+  'Connect Last.fm to use this mode.': 'discoveryMode.reason.connectLastfm',
+  'Connect Deezer to use this mode.': 'discoveryMode.reason.connectDeezer',
+  'Connect Spotify to use this mode.': 'discoveryMode.reason.connectSpotify',
+  'Connect Subsonic to use this mode.': 'discoveryMode.reason.connectSubsonic',
   'Using fallback providers for release discovery.': 'discoveryMode.reason.releaseRadarFallback',
   'This mode is not implemented yet.': 'discoveryMode.notImplementedYet',
   'This mode is not shipped yet.': 'discoveryMode.notShippedYet',

--- a/tests/web/lib/discovery-i18n.test.ts
+++ b/tests/web/lib/discovery-i18n.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import {
+  EMPTY_DISCOVERY_SNAPSHOT,
+  evaluateDiscoveryModeAvailability,
+} from '@/core/discovery-modes/availability'
+import { createDefaultDiscoveryModeRegistry } from '@/core/discovery-modes/registry'
 import { translateDiscoveryReason } from '@/web/lib/discovery-i18n'
 
 describe('translateDiscoveryReason', () => {
@@ -7,5 +12,35 @@ describe('translateDiscoveryReason', () => {
     const t = (key: string) => key
 
     expect(translateDiscoveryReason(t, reason)).toBe(reason)
+  })
+
+  it('maps the connect reasons of the four newest modes to i18n keys', () => {
+    const t = (key: string) => `T:${key}`
+
+    expect(translateDiscoveryReason(t, 'Connect Last.fm to use this mode.')).toBe(
+      'T:discoveryMode.reason.connectLastfm',
+    )
+    expect(translateDiscoveryReason(t, 'Connect Deezer to use this mode.')).toBe(
+      'T:discoveryMode.reason.connectDeezer',
+    )
+    expect(translateDiscoveryReason(t, 'Connect Spotify to use this mode.')).toBe(
+      'T:discoveryMode.reason.connectSpotify',
+    )
+    expect(translateDiscoveryReason(t, 'Connect Subsonic to use this mode.')).toBe(
+      'T:discoveryMode.reason.connectSubsonic',
+    )
+  })
+
+  it('every registered mode disabled-reason has an i18n alias', () => {
+    const t = (key: string) => `T:${key}`
+
+    for (const mode of createDefaultDiscoveryModeRegistry().list()) {
+      const result = evaluateDiscoveryModeAvailability(mode.id, EMPTY_DISCOVERY_SNAPSHOT)
+      if (result.reason) {
+        expect(translateDiscoveryReason(t, result.reason), `mode ${mode.id}`).not.toBe(
+          result.reason,
+        )
+      }
+    }
   })
 })


### PR DESCRIPTION
## Summary

The four newest discovery modes (Charts, Deezer Flow, Spotify Saved Albums, Subsonic Starred) shipped their `discoveryMode.reason.connect*` strings in all 15 locales, but `REASON_KEY_ALIASES` in `src/web/lib/discovery-i18n.ts` never got entries for their backend reason literals. The translations were dead code: every non-English user saw the English "Connect X to use this mode." line on the Discovery Modes page.

- Add the four missing alias entries (literals copied byte-for-byte from `availability.ts`; keys already exist in every locale, enforced by the `MessageKey` type).
- Add a per-literal mapping test with a marker translator.
- Add a registry-wide parity test: every registered mode's disabled-reason under the all-false snapshot must be translatable. This has regressed four modes in a row; the guard fails by mode name on the fifth.

Complements the existing branch-presence guard in `tests/core/discovery-modes/availability.test.ts` (that one asserts a mode has an availability branch; this one asserts the branch's reason is translatable).

No backend or locale changes.

## Test plan

- `bun run test tests/web/lib/discovery-i18n.test.ts` (3 tests)
- Parity guard spot-checked: removing the Deezer alias fails the test naming `mode deezer-flow`
- `bun run typecheck`, `bun run lint`, full suite green locally (2629 tests)

Fixes #417
