### PR TITLE
test(db): give the pglite statement_timeout test a boot-sized timeout

### DIFF
--- a/tests/db/pglite-integration.test.ts
+++ b/tests/db/pglite-integration.test.ts
@@ -42,7 +42,7 @@ describe('pglite backend contract', () => {
     await applyPgliteStatementTimeout(client)
     const res = await client.query<{ statement_timeout: string }>('SHOW statement_timeout')
     expect(res.rows[0]?.statement_timeout).toBe('30s')
-  })
+  }, 20_000)
 
   it('round-trips a backup on pglite', async () => {
     await db.execute(sql`INSERT INTO settings (id) VALUES (1) ON CONFLICT (id) DO NOTHING`)


### PR DESCRIPTION
## Summary

`tests/db/pglite-integration.test.ts > caps queries with a 30s statement_timeout` boots a second in-memory PGlite instance inside the test body. Instance boot is CPU-heavy; under full-suite parallel load it can exceed vitest's 5s default timeout (fails in `bun run test`, always passes standalone). Observed repeatedly across recent PR runs.

Give that one test a local 20s budget (`it(name, fn, 20_000)`). Observed worst case under load was ~6.1s; 20s covers slower machines without masking a genuine hang for long. Deliberately not a global `testTimeout` bump, which would hide real hangs across the other 2600+ tests.

## Test plan

- `bun run test tests/db/pglite-integration.test.ts` (6 pass)
- `bun run test tests/db/` (152 pass)
- `bun run typecheck`, `bun run lint`

Fixes #418
