### PR TITLE
fix(oauth): stop requesting unused Deezer manage_library scope

### DIFF
--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -18,7 +18,7 @@ const SPOTIFY_SCOPES =
 
 const DEEZER_AUTH_URL = 'https://connect.deezer.com/oauth/auth.php'
 const DEEZER_TOKEN_URL = 'https://connect.deezer.com/oauth/access_token.php'
-const DEEZER_SCOPES = 'basic_access,email,listening_history,manage_library'
+const DEEZER_SCOPES = 'basic_access,email,listening_history'
 
 export function oauthRoutes(deps: AppDependencies) {
   const router = new Hono<HonoEnv>()


### PR DESCRIPTION
## Summary

Removes `manage_library` from the Deezer OAuth scope request. The scope has had zero consumers since the OAuth flow shipped -- every Deezer code path is read-only (flow recommendations, previews, top tracks) -- and the planned playlist-push target that would have used it is externally blocked: Deezer has closed new API app registration, so the feature would only ever serve grandfathered apps.

- One-line change to `DEEZER_SCOPES`; `basic_access,email,listening_history` kept.
- Existing connections unaffected: Deezer permissions are fixed at consent time, stored tokens keep their grant, and no code gates on the stored scopes string.
- Deliberate trade-off: re-adding the scope later would require per-user reconnect. Accepted, since the platform no longer admits new write-capable apps anyway.
- `listening_history` deliberately not dropped: the flow-recommendations endpoint's permission requirement could not be verified while Deezer's docs portal is down.

## Test plan

- `bun run test tests/server/routes/oauth-deezer.test.ts` 17/17 (stored-token fixture with the old scopes string still passes -- represents a pre-drop consent)
- `bun run test tests/server/` 616/616
- `bun run typecheck` 0, `bun run lint` 0 errors
