### PR TITLE
docs: cover audition queue, digest bookmark, and Deezer scope drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ Search across Spotify, Deezer, MusicBrainz, TIDAL, and Bandcamp in one pass. Dig
 - **Multilingual UI:** 15 shipped locales, saved user language preference, localized auth/setup/high-traffic pages, and locale-aware AI reasoning
 - **Top tracks:** Deezer 30-second previews on recommendation cards with MusicBrainz fallback
 - **Decade filtering:** filter recommendations by era, from the 60s through the 20s+
-- **Music previews:** Spotify embeds, Deezer clips, and YouTube on recommendation cards
+- **Music previews:** Spotify embeds, Deezer clips, and YouTube on recommendation cards, plus an Audition queue on Discover that plays pending previews back-to-back in score order with previous/next controls in the global preview bar
 - **OIDC/SSO and multi-user:** per-user queues, sources, scoring weights, and target configs
 - **Swipe-to-approve** on mobile, card-stack mode on desktop
-- **Webhook notifications:** Discord, Slack, ntfy, Gotify, or any HTTP endpoint -- per-batch, plus an optional scheduled digest (a periodic activity roll-up on a cron schedule)
+- **Webhook notifications:** Discord, Slack, ntfy, Gotify, or any HTTP endpoint -- per-batch, plus an optional scheduled digest (a periodic activity roll-up on a cron schedule that survives restarts without double-reporting or dropping a window)
 - **15 color themes:** editor classics plus streaming-service-inspired *arr themes, in dark and light variants
 - **Export:** JSON, CSV, M3U, and XSPF
 - **Self-hosted:** a single container that runs alongside your existing *arr stack

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,7 +116,7 @@ Async IIFE in `src/index.ts`:
 10. Subscription scheduler
 11. Playlist scheduler
 12. `startStuckDetector()` - cron every 5 min
-13. `startDigestNotifier()` - cron driving the scheduled notification digest; no-ops when `digestCron` is unset. `restartDigestNotifier()` re-arms it at runtime when the cron preference changes, so a settings save applies without a restart
+13. `startDigestNotifier()` - cron driving the scheduled notification digest; no-ops when `digestCron` is unset. `restartDigestNotifier()` re-arms it at runtime when the cron preference changes, so a settings save applies without a restart. Each send covers the window since a persisted last-sent bookmark (advanced only after a successful send, so delivery is at-least-once and restarts or downtime neither double-report nor drop a window); ticks are skipped during maintenance
 
 ## Album-level discovery
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,7 +64,7 @@ Ideas we're considering. If any of these matter to you, open an issue or discuss
 Good ideas with no timeline yet.
 
 - Taste DNA / shareable profile
-- Audition playlists ("try before you add")
+- Audition playlists ("try before you add") -- the artist-level audition queue is shipped (see Shipped Highlights); a track-level playlist variant is still open
 - Interactive API docs (Swagger/Scalar UI)
 
 ## Experiments
@@ -89,6 +89,8 @@ Low confidence. Would build only with real demand.
 For release-by-release detail, see [CHANGELOG.md](../CHANGELOG.md).
 Release reminder: after publishing a new app image, run `bun scripts/sync-deploy-digests.ts <tag>` -- it rewrites the pinned digests and version tags across the k8s/Helm/Unraid deploy files plus the example pins in the compose files and README.
 
+- Audition queue for continuous preview playback: an Audition button on the Discover toolbar queues the loaded pending recommendations that have previews, in score order; the global preview bar gains previous/next and position controls, and playback auto-advances when a Deezer clip ends or after a 30-second timer for Spotify/YouTube embeds. Preview-less items are skipped, and playing anything else or stopping deactivates the queue. Artist-level v1 ("try before you add"); browsers may block embed autoplay, in which case the timer still advances past silent items. Full i18n across 15 locales
+- The scheduled notification digest now persists a last-sent bookmark, so restarts or downtime no longer double-report or drop a window; delivery is at-least-once
 - AI provider failures are now first-class observable (v1.12.0): a dead provider surfaces in scan progress warnings, job history records the real provider error, connection-test failures show the upstream message, and saving AI settings re-probes the persisted config. Provider hardening landed alongside: shared LLM output parsing for OpenAI/Gemini, secret redaction in error snippets, and Ollama model validation in test connection
 - Zero-external-database operation shipped in v1.11.0: embedded PGlite backend (no separate PostgreSQL container), an admin-gated in-app migration tool between PGlite and PostgreSQL with verified atomic copy, a Subsonic (Navidrome/Airsonic/Gonic) listening + library source, self-service account email, and an OIDC account-takeover fix (subject-only identity matching, GHSA-w643-583p-vm6m)
 - Album-level discovery substrate shipped in v1.0.0: albums are a first-class recommendation unit (`kind` discriminator on recommendations, `album_blocks` forever-block layer, album scoring modifier, `addAlbum` single-album Lidarr approval, kind filter + Albums nav on Discover, full i18n across 15 locales). All three producers now populate it with `kind='album'` recommendations: the release-radar new-release producer (v1.1.0) for new releases from tracked artists, Library Gap-Fill (v1.2.0) for the studio albums you are missing from those tracked artists, and net-new album discovery (v1.3.0) for a specific album the AI suggests by a new-to-you artist, gated behind a default-off toggle. Release-radar now surfaces all new releases per artist in a single scan.


### PR DESCRIPTION
## Summary

Docs sweep for the three changes shipped to develop since v1.12.0:

- **README**: Music previews bullet now mentions the Audition queue (#436); the webhook-notifications digest parenthetical notes it survives restarts without double-reporting or dropping a window (#440).
- **docs/ROADMAP.md**: two Shipped Highlights entries (audition queue with auto-advance mechanics and the embed-autoplay caveat; digest last-sent bookmark with at-least-once delivery); the Future "Audition playlists" item is annotated rather than removed -- the artist-level queue shipped, a track-level playlist variant stays open.
- **docs/ARCHITECTURE.md**: boot-order entry for `startDigestNotifier` extended with the persisted bookmark semantics and the maintenance-tick skip.

The Deezer `manage_library` scope drop (#441) has no tracked doc covering OAuth scopes, so it is intentionally not documented anywhere -- nothing invented.

No CHANGELOG edits (sections are created at release-bump time). Follow-up for the next release: recapture `docs/screenshots/discover.png` (`bun scripts/capture-screenshots.ts`) -- the Discover toolbar and preview bar changed materially.

## Test plan

- `bun run check:versions` pass (README pins untouched)
- `bun run typecheck` 0, `bun run lint` 0 errors
