### PR TITLE
docs(unraid): point installs at the CA template repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Admin tools available under Settings > Administration > Data Hygiene:
 | Docker Compose | [`deploy/docker/`](deploy/docker/) | Recommended. Includes PostgreSQL. Also on [Docker Hub](https://hub.docker.com/r/iuliandita/digarr). |
 | Helm chart | [`deploy/helm/digarr/`](deploy/helm/digarr/) | Kubernetes. Bundled PostgreSQL or bring your own. |
 | Raw k8s manifests | [`deploy/k8s/`](deploy/k8s/) | Reference manifests for advanced setups. |
-| Unraid | [`docs/guides/unraid.md`](docs/guides/unraid.md) | Add-Container template ([`deploy/unraid/digarr.xml`](deploy/unraid/digarr.xml)); CA store listing pending. Embedded PGlite by default; external PostgreSQL optional. |
+| Unraid | [`docs/guides/unraid.md`](docs/guides/unraid.md) | CA template repository ([`iuliandita/unraid-templates`](https://github.com/iuliandita/unraid-templates)) or bundled template ([`deploy/unraid/digarr.xml`](deploy/unraid/digarr.xml)); CA store listing pending. Embedded PGlite by default; external PostgreSQL optional. |
 | Synology NAS | [`docs/guides/synology.md`](docs/guides/synology.md) | DSM 7.1+ (Docker/Container Manager). SSH or GUI. |
 | Docker Desktop | [`docs/guides/docker-desktop.md`](docs/guides/docker-desktop.md) | macOS and Windows (WSL 2). |
 

--- a/docs/guides/unraid.md
+++ b/docs/guides/unraid.md
@@ -22,10 +22,24 @@ PostgreSQL, that stays fully supported via the optional Database URL field (see
 ## Step 1: Add the Digarr template
 
 Digarr is not yet published in the Community Applications store (a CA submission
-is pending). Until it lands there, use the bundled template directly -- it is the
-reliable route and uses the same XML CA would serve.
+is pending), but a dedicated CA template repository exists at
+[`iuliandita/unraid-templates`](https://github.com/iuliandita/unraid-templates).
+Adding it gives you the CA install flow today, including template updates.
 
-### Option A: User template (recommended)
+### Option A: CA template repository (recommended)
+
+1. In the Unraid web UI go to **Apps** > **Settings** (or the CA "Manage
+   template repositories" action) and add
+   `https://github.com/iuliandita/unraid-templates` to the template
+   repositories list.
+2. Search for **Digarr** under **Apps**; it appears from your added repository.
+3. Install it like any other app and fill in the configuration (see Step 2),
+   then click **Apply**.
+
+This template tracks the `latest` release tag, so **Check for Updates** on the
+Docker tab picks up new releases as they publish.
+
+### Option B: User template (manual copy)
 
 1. Copy [`deploy/unraid/digarr.xml`](../../deploy/unraid/digarr.xml) to your
    Unraid server at
@@ -40,14 +54,11 @@ reliable route and uses the same XML CA would serve.
 2. In the Unraid web UI go to **Docker** > **Add Container**.
 3. In the **Template** dropdown pick **Digarr** (it appears under your user
    templates).
-4. Fill in the configuration (see Step 3) and click **Apply**.
+4. Fill in the configuration (see Step 2) and click **Apply**.
 
-### Option B: Private template repository
-
-If you prefer CA to manage updates to the template, add the repository under
-**Apps** > **Settings** (or the CA "Manage template repositories" action) and
-point it at `https://github.com/iuliandita/digarr`. Digarr then appears in your
-CA search; install it like any other app and fill in the same fields below.
+The bundled template pins the image to the current release digest (the release
+pipeline keeps it synced), so updates mean re-copying the file; prefer Option A
+unless you want that digest pinning.
 
 ---
 
@@ -137,8 +148,10 @@ network is the simplest option).
 
 Digarr publishes multi-arch images (amd64 + arm64). To update from the Unraid
 **Docker** tab, click the container > **Check for Updates** (or **Force Update**)
-and apply. When the template repository (Option B) refreshes, the pinned digest
-moves to the newest release.
+and apply. With the CA template repository (Option A) the container tracks the
+`latest` release tag, so that is all there is to it. With the bundled template
+(Option B) the image is pinned to a release digest; re-copy the template file to
+move to a newer release.
 
 ## Notes
 


### PR DESCRIPTION
The dedicated CA template repository ([iuliandita/unraid-templates](https://github.com/iuliandita/unraid-templates)) has existed since 2026-06-29, but the Unraid guide still steered users to the manual template-copy path and pointed the repository option at the main repo instead.

- Make the CA template repository the recommended install route (Option A); it tracks `:latest` and gets CA-managed template updates.
- Keep the bundled digest-pinned template as the manual option (Option B) and explain the pinning trade-off in the Updating section.
- Update the README deployment row to mention both routes.
- Verified the CA store listing is still pending (searched the CA AppFeed 2026-07-12), so the 'listing pending' status stays.

Companion change: the upstream template repo's `digarr.xml` was stale (required PostgreSQL); updated it to the embedded-PGlite default in iuliandita/unraid-templates@b8ffda4 (#437).

Closes #438