### PR TITLE
docs(unraid): Digarr is live in the Community Applications store

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Admin tools available under Settings > Administration > Data Hygiene:
 | Docker Compose | [`deploy/docker/`](deploy/docker/) | Recommended. Includes PostgreSQL. Also on [Docker Hub](https://hub.docker.com/r/iuliandita/digarr). |
 | Helm chart | [`deploy/helm/digarr/`](deploy/helm/digarr/) | Kubernetes. Bundled PostgreSQL or bring your own. |
 | Raw k8s manifests | [`deploy/k8s/`](deploy/k8s/) | Reference manifests for advanced setups. |
-| Unraid | [`docs/guides/unraid.md`](docs/guides/unraid.md) | CA template repository ([`iuliandita/unraid-templates`](https://github.com/iuliandita/unraid-templates)) or bundled template ([`deploy/unraid/digarr.xml`](deploy/unraid/digarr.xml)); CA store listing pending. Embedded PGlite by default; external PostgreSQL optional. |
+| Unraid | [`docs/guides/unraid.md`](docs/guides/unraid.md) | In the Community Applications store (search "Digarr"); bundled template ([`deploy/unraid/digarr.xml`](deploy/unraid/digarr.xml)) as manual fallback. Embedded PGlite by default; external PostgreSQL optional. |
 | Synology NAS | [`docs/guides/synology.md`](docs/guides/synology.md) | DSM 7.1+ (Docker/Container Manager). SSH or GUI. |
 | Docker Desktop | [`docs/guides/docker-desktop.md`](docs/guides/docker-desktop.md) | macOS and Windows (WSL 2). |
 

--- a/docs/guides/unraid.md
+++ b/docs/guides/unraid.md
@@ -21,23 +21,17 @@ PostgreSQL, that stays fully supported via the optional Database URL field (see
 
 ## Step 1: Add the Digarr template
 
-Digarr is not yet published in the Community Applications store (a CA submission
-is pending), but a dedicated CA template repository exists at
-[`iuliandita/unraid-templates`](https://github.com/iuliandita/unraid-templates).
-Adding it gives you the CA install flow today, including template updates.
+Digarr is published in the Community Applications store via the Selfhosters
+repository, so a plain Apps search is all you need.
 
-### Option A: CA template repository (recommended)
+### Option A: Community Applications store (recommended)
 
-1. In the Unraid web UI go to **Apps** > **Settings** (or the CA "Manage
-   template repositories" action) and add
-   `https://github.com/iuliandita/unraid-templates` to the template
-   repositories list.
-2. Search for **Digarr** under **Apps**; it appears from your added repository.
-3. Install it like any other app and fill in the configuration (see Step 2),
-   then click **Apply**.
+1. In the Unraid web UI go to **Apps** and search for **Digarr**.
+2. Click **Install** and fill in the configuration (see Step 2), then click
+   **Apply**.
 
-This template tracks the `latest` release tag, so **Check for Updates** on the
-Docker tab picks up new releases as they publish.
+The store template tracks the `latest` release tag, so **Check for Updates** on
+the Docker tab picks up new releases as they publish.
 
 ### Option B: User template (manual copy)
 
@@ -148,7 +142,7 @@ network is the simplest option).
 
 Digarr publishes multi-arch images (amd64 + arm64). To update from the Unraid
 **Docker** tab, click the container > **Check for Updates** (or **Force Update**)
-and apply. With the CA template repository (Option A) the container tracks the
+and apply. With the CA store template (Option A) the container tracks the
 `latest` release tag, so that is all there is to it. With the bundled template
 (Option B) the image is pinned to a release digest; re-copy the template file to
 move to a newer release.


### PR DESCRIPTION
Correction to #446: verified against the CA application feed that Digarr has been served from the Selfhosters repository since selfhosters/unRAID-CA-templates#658 merged on 2026-06-29. The 'CA store listing pending' status and the custom template-repository install route were both stale.

- Recommended install path is now a plain **Apps** search for Digarr.
- Bundled digest-pinned template stays as the manual fallback (Option B).
- README deployment row updated to match.

The store still serves the pre-PGlite description (separate PostgreSQL required); selfhosters/unRAID-CA-templates#681 updates it to the embedded-database default.