### PR TITLE
refactor(api): centralize route guards

### DIFF
--- a/src/server/helpers/problem.ts
+++ b/src/server/helpers/problem.ts
@@ -39,3 +39,7 @@ export function problem(
     'content-type': 'application/problem+json',
   })
 }
+
+export function notFoundProblem(c: Context, type: string, title: string, code: string) {
+  return problem(c, type, title, 404, undefined, undefined, code)
+}

--- a/src/server/routes/album-blocks.ts
+++ b/src/server/routes/album-blocks.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import type { BlockedAlbumRow } from '@/db/queries/album-blocks'
 import { problem } from '@/server/helpers/problem'
+import { requireUser } from '@/server/helpers/require-user'
 import type { HonoEnv } from '@/server/types'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -14,18 +15,9 @@ export function albumBlocksRoutes(deps: AlbumBlocksRouteDeps) {
   const router = new Hono<HonoEnv>()
 
   router.get('/api/v1/album-blocks', async (c) => {
-    const userId = c.get('userId')
-    if (typeof userId !== 'number') {
-      return problem(
-        c,
-        'unauthorized',
-        'Unauthorized',
-        401,
-        undefined,
-        undefined,
-        'errors.auth.unauthorized',
-      )
-    }
+    const auth = requireUser(c)
+    if (!auth.ok) return auth.response
+    const { userId } = auth
     const items = await deps.listAlbumBlocks(userId)
     return c.json({
       items: items.map((item) => ({ ...item, blockedAt: item.blockedAt.toISOString() })),
@@ -33,18 +25,9 @@ export function albumBlocksRoutes(deps: AlbumBlocksRouteDeps) {
   })
 
   router.delete('/api/v1/album-blocks/:releaseGroupMbid', async (c) => {
-    const userId = c.get('userId')
-    if (typeof userId !== 'number') {
-      return problem(
-        c,
-        'unauthorized',
-        'Unauthorized',
-        401,
-        undefined,
-        undefined,
-        'errors.auth.unauthorized',
-      )
-    }
+    const auth = requireUser(c)
+    if (!auth.ok) return auth.response
+    const { userId } = auth
     const releaseGroupMbid = c.req.param('releaseGroupMbid')
     if (!UUID_RE.test(releaseGroupMbid)) {
       return problem(

--- a/src/server/routes/artist-blocks.ts
+++ b/src/server/routes/artist-blocks.ts
@@ -6,6 +6,7 @@ import type { BlockedArtistRow, ListBlocksCursor } from '@/db/queries/artist-blo
 import { type Cursor, decodeCursor, encodeCursor } from '@/server/helpers/pagination-cursor'
 import { parseOptionalClampedInt, parsePositiveIntParam } from '@/server/helpers/parse-int-clamp'
 import { problem } from '@/server/helpers/problem'
+import { requireUser } from '@/server/helpers/require-user'
 import { zJson } from '@/server/schemas/validator'
 import type { HonoEnv } from '@/server/types'
 
@@ -54,18 +55,9 @@ export function artistBlocksRoutes(deps: ArtistBlocksRouteDeps) {
   const router = new Hono<HonoEnv>()
 
   router.get('/api/v1/artist-blocks', async (c) => {
-    const userId = c.get('userId')
-    if (typeof userId !== 'number') {
-      return problem(
-        c,
-        'unauthorized',
-        'Unauthorized',
-        401,
-        undefined,
-        undefined,
-        'errors.auth.unauthorized',
-      )
-    }
+    const auth = requireUser(c)
+    if (!auth.ok) return auth.response
+    const { userId } = auth
     const limit = parseOptionalClampedInt(c.req.query('limit'), { min: 1, max: 200, default: 50 })
     if (limit == null) {
       return problem(
@@ -97,18 +89,9 @@ export function artistBlocksRoutes(deps: ArtistBlocksRouteDeps) {
   })
 
   router.delete('/api/v1/artist-blocks/:artistId', async (c) => {
-    const userId = c.get('userId')
-    if (typeof userId !== 'number') {
-      return problem(
-        c,
-        'unauthorized',
-        'Unauthorized',
-        401,
-        undefined,
-        undefined,
-        'errors.auth.unauthorized',
-      )
-    }
+    const auth = requireUser(c)
+    if (!auth.ok) return auth.response
+    const { userId } = auth
     const artistId = parsePositiveIntParam(c.req.param('artistId'))
     if (artistId == null) {
       return problem(
@@ -126,18 +109,9 @@ export function artistBlocksRoutes(deps: ArtistBlocksRouteDeps) {
   })
 
   router.post('/api/v1/artist-blocks', zJson(createBlockSchema), async (c) => {
-    const userId = c.get('userId')
-    if (typeof userId !== 'number') {
-      return problem(
-        c,
-        'unauthorized',
-        'Unauthorized',
-        401,
-        undefined,
-        undefined,
-        'errors.auth.unauthorized',
-      )
-    }
+    const auth = requireUser(c)
+    if (!auth.ok) return auth.response
+    const { userId } = auth
     const body = c.req.valid('json')
     await deps.addArtistBlock({
       userId,

--- a/src/server/routes/playlists.ts
+++ b/src/server/routes/playlists.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import {
   exportPlaylistToCsv,
   exportPlaylistToJson,
@@ -21,7 +21,7 @@ import { mergePreferences, type PlaylistConfig } from '@/db/schema'
 import { notAuthenticated } from '@/server/helpers/auth-problems'
 import { readPagination } from '@/server/helpers/pagination'
 import { encodeCursor } from '@/server/helpers/pagination-cursor'
-import { problem } from '@/server/helpers/problem'
+import { notFoundProblem } from '@/server/helpers/problem'
 import {
   createPlaylistSchema,
   playlistExportFormatParamSchema,
@@ -65,6 +65,22 @@ function sanitizeFilename(value: string): string {
 export function playlistRoutes(deps: PlaylistDeps) {
   const router = new Hono<HonoEnv>()
   const { db } = deps
+
+  const loadOwnedPlaylist = async (c: Context<HonoEnv>, id: number, userId: number) => {
+    const result = await getPlaylistWithTracks(db, id)
+    if (!result || result.playlist.userId !== userId) {
+      return {
+        ok: false as const,
+        response: notFoundProblem(
+          c,
+          'playlist-not-found',
+          'Playlist not found',
+          'errors.playlist.notFound',
+        ),
+      }
+    }
+    return { ok: true as const, result }
+  }
 
   // GET /api/v1/playlists/scheduler - must be registered before :id route
   router.get('/api/v1/playlists/scheduler', async (c) => {
@@ -144,29 +160,10 @@ export function playlistRoutes(deps: PlaylistDeps) {
 
     const { id } = c.req.valid('param')
 
-    const result = await getPlaylistWithTracks(db, id)
-    if (!result)
-      return problem(
-        c,
-        'playlist-not-found',
-        'Playlist not found',
-        404,
-        undefined,
-        undefined,
-        'errors.playlist.notFound',
-      )
-    if (result.playlist.userId !== userId)
-      return problem(
-        c,
-        'playlist-not-found',
-        'Playlist not found',
-        404,
-        undefined,
-        undefined,
-        'errors.playlist.notFound',
-      )
+    const loaded = await loadOwnedPlaylist(c, id, userId)
+    if (!loaded.ok) return loaded.response
 
-    return c.json(result)
+    return c.json(loaded.result)
   })
 
   // GET /api/v1/playlists/:id/export/:format
@@ -181,27 +178,9 @@ export function playlistRoutes(deps: PlaylistDeps) {
       const exporter = PLAYLIST_EXPORTERS[format]
       const contentType = PLAYLIST_EXPORT_CONTENT_TYPES[format]
 
-      const result = await getPlaylistWithTracks(db, id)
-      if (!result)
-        return problem(
-          c,
-          'playlist-not-found',
-          'Playlist not found',
-          404,
-          undefined,
-          undefined,
-          'errors.playlist.notFound',
-        )
-      if (result.playlist.userId !== userId)
-        return problem(
-          c,
-          'playlist-not-found',
-          'Playlist not found',
-          404,
-          undefined,
-          undefined,
-          'errors.playlist.notFound',
-        )
+      const loaded = await loadOwnedPlaylist(c, id, userId)
+      if (!loaded.ok) return loaded.response
+      const result = loaded.result
 
       const tracks = result.tracks.slice().sort((a, b) => a.position - b.position)
       const filename = sanitizeFilename(result.playlist.name) || `playlist-${id}`
@@ -226,27 +205,8 @@ export function playlistRoutes(deps: PlaylistDeps) {
       if (!userId) return notAuthenticated(c)
 
       const { id } = c.req.valid('param')
-      const existing = await getPlaylistWithTracks(db, id)
-      if (!existing)
-        return problem(
-          c,
-          'playlist-not-found',
-          'Playlist not found',
-          404,
-          undefined,
-          undefined,
-          'errors.playlist.notFound',
-        )
-      if (existing.playlist.userId !== userId)
-        return problem(
-          c,
-          'playlist-not-found',
-          'Playlist not found',
-          404,
-          undefined,
-          undefined,
-          'errors.playlist.notFound',
-        )
+      const loaded = await loadOwnedPlaylist(c, id, userId)
+      if (!loaded.ok) return loaded.response
 
       const body = c.req.valid('json')
       await updatePlaylist(db, id, body as Record<string, unknown>)
@@ -262,27 +222,8 @@ export function playlistRoutes(deps: PlaylistDeps) {
 
     const { id } = c.req.valid('param')
 
-    const result = await getPlaylistWithTracks(db, id)
-    if (!result)
-      return problem(
-        c,
-        'playlist-not-found',
-        'Playlist not found',
-        404,
-        undefined,
-        undefined,
-        'errors.playlist.notFound',
-      )
-    if (result.playlist.userId !== userId)
-      return problem(
-        c,
-        'playlist-not-found',
-        'Playlist not found',
-        404,
-        undefined,
-        undefined,
-        'errors.playlist.notFound',
-      )
+    const loaded = await loadOwnedPlaylist(c, id, userId)
+    if (!loaded.ok) return loaded.response
 
     await deletePlaylist(db, id)
     await deps.restartPlaylistScheduler()
@@ -296,27 +237,8 @@ export function playlistRoutes(deps: PlaylistDeps) {
 
     const { id } = c.req.valid('param')
 
-    const result = await getPlaylistWithTracks(db, id)
-    if (!result)
-      return problem(
-        c,
-        'playlist-not-found',
-        'Playlist not found',
-        404,
-        undefined,
-        undefined,
-        'errors.playlist.notFound',
-      )
-    if (result.playlist.userId !== userId)
-      return problem(
-        c,
-        'playlist-not-found',
-        'Playlist not found',
-        404,
-        undefined,
-        undefined,
-        'errors.playlist.notFound',
-      )
+    const loaded = await loadOwnedPlaylist(c, id, userId)
+    if (!loaded.ok) return loaded.response
 
     // Fire-and-forget
     Promise.resolve()

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import { createDeezerUserClient } from '@/core/clients/deezer-user'
 import { resolveDeezerToken } from '@/core/deezer-auth'
 import {
@@ -15,7 +15,7 @@ import { notAuthenticated } from '@/server/helpers/auth-problems'
 import { readPagination } from '@/server/helpers/pagination'
 import { encodeCursor } from '@/server/helpers/pagination-cursor'
 import { parsePositiveIntParam } from '@/server/helpers/parse-int-clamp'
-import { problem } from '@/server/helpers/problem'
+import { notFoundProblem } from '@/server/helpers/problem'
 import { resolveRequestMessages } from '@/server/locale'
 import {
   bulkToggleSchema,
@@ -117,6 +117,22 @@ async function resolveDiscoveryModeSourceConfig(
 
 export function subscriptionRoutes(deps: AppDependencies) {
   const router = new Hono<HonoEnv>()
+
+  const loadOwnedSubscription = async (c: Context<HonoEnv>, id: number, userId: number) => {
+    const subscription = await deps.subscriptionQueries.getSubscription(id)
+    if (!subscription || subscription.userId !== userId) {
+      return {
+        ok: false as const,
+        response: notFoundProblem(
+          c,
+          'subscription-not-found',
+          'Subscription not found',
+          'errors.subscription.notFound',
+        ),
+      }
+    }
+    return { ok: true as const, subscription }
+  }
 
   router.get('/api/v1/subscriptions/adapter-types', (c) => {
     return c.json({
@@ -699,29 +715,9 @@ export function subscriptionRoutes(deps: AppDependencies) {
       }
 
       const { id } = c.req.valid('param')
-      const existing = await deps.subscriptionQueries.getSubscription(id)
-      if (!existing) {
-        return problem(
-          c,
-          'subscription-not-found',
-          'Subscription not found',
-          404,
-          undefined,
-          undefined,
-          'errors.subscription.notFound',
-        )
-      }
-      if (existing.userId !== userId) {
-        return problem(
-          c,
-          'subscription-not-found',
-          'Subscription not found',
-          404,
-          undefined,
-          undefined,
-          'errors.subscription.notFound',
-        )
-      }
+      const loaded = await loadOwnedSubscription(c, id, userId)
+      if (!loaded.ok) return loaded.response
+      const existing = loaded.subscription
 
       const body = c.req.valid('json')
       const update: Record<string, unknown> = { ...body, action: 'add_to_recommendations' }
@@ -767,29 +763,8 @@ export function subscriptionRoutes(deps: AppDependencies) {
       return notAuthenticated(c)
     }
     const { id } = c.req.valid('param')
-    const existing = await deps.subscriptionQueries.getSubscription(id)
-    if (!existing) {
-      return problem(
-        c,
-        'subscription-not-found',
-        'Subscription not found',
-        404,
-        undefined,
-        undefined,
-        'errors.subscription.notFound',
-      )
-    }
-    if (existing.userId !== userId) {
-      return problem(
-        c,
-        'subscription-not-found',
-        'Subscription not found',
-        404,
-        undefined,
-        undefined,
-        'errors.subscription.notFound',
-      )
-    }
+    const loaded = await loadOwnedSubscription(c, id, userId)
+    if (!loaded.ok) return loaded.response
     await deps.subscriptionQueries.deleteSubscription(id)
     deps.scheduler.remove(`subscription-${id}`)
     return c.body(null, 204)
@@ -802,29 +777,8 @@ export function subscriptionRoutes(deps: AppDependencies) {
     }
 
     const { id } = c.req.valid('param')
-    const existing = await deps.subscriptionQueries.getSubscription(id)
-    if (!existing) {
-      return problem(
-        c,
-        'subscription-not-found',
-        'Subscription not found',
-        404,
-        undefined,
-        undefined,
-        'errors.subscription.notFound',
-      )
-    }
-    if (existing.userId !== userId) {
-      return problem(
-        c,
-        'subscription-not-found',
-        'Subscription not found',
-        404,
-        undefined,
-        undefined,
-        'errors.subscription.notFound',
-      )
-    }
+    const loaded = await loadOwnedSubscription(c, id, userId)
+    if (!loaded.ok) return loaded.response
 
     try {
       await deps.runSubscription(id)
@@ -860,29 +814,8 @@ export function subscriptionRoutes(deps: AppDependencies) {
 
     const id = parsePositiveIntParam(c.req.param('id'))
     if (id == null) return c.json({ error: 'Invalid subscription ID' }, 400)
-    const existing = await deps.subscriptionQueries.getSubscription(id)
-    if (!existing) {
-      return problem(
-        c,
-        'subscription-not-found',
-        'Subscription not found',
-        404,
-        undefined,
-        undefined,
-        'errors.subscription.notFound',
-      )
-    }
-    if (existing.userId !== userId) {
-      return problem(
-        c,
-        'subscription-not-found',
-        'Subscription not found',
-        404,
-        undefined,
-        undefined,
-        'errors.subscription.notFound',
-      )
-    }
+    const loaded = await loadOwnedSubscription(c, id, userId)
+    if (!loaded.ok) return loaded.response
 
     const runs = await deps.jobQueries.getJobsForSubscription(id)
     return c.json(runs)

--- a/src/server/routes/targets.ts
+++ b/src/server/routes/targets.ts
@@ -1,10 +1,10 @@
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import type { ServiceTestResult } from '@/core/types'
 import type { TargetInsert, TargetRow, TargetUpdate } from '@/db/queries/targets'
 import { notAuthenticated } from '@/server/helpers/auth-problems'
 import { readPagination } from '@/server/helpers/pagination'
 import { type Cursor, encodeCursor } from '@/server/helpers/pagination-cursor'
-import { problem } from '@/server/helpers/problem'
+import { notFoundProblem } from '@/server/helpers/problem'
 import { adminGuard } from '@/server/middleware/admin-guard'
 import {
   createTargetSchema,
@@ -32,6 +32,22 @@ type TargetDeps = {
 
 export function targetRoutes(deps: TargetDeps) {
   const router = new Hono<HonoEnv>()
+
+  const loadOwnedTarget = async (c: Context<HonoEnv>, id: number, userId: number) => {
+    const target = await deps.targetQueries.getTarget(id)
+    if (!target || target.userId !== userId) {
+      return {
+        ok: false as const,
+        response: notFoundProblem(
+          c,
+          'target-not-found',
+          'Target not found',
+          'errors.target.notFound',
+        ),
+      }
+    }
+    return { ok: true as const, target }
+  }
 
   // Admins see every target (with masked configs); each row carries `owned: true`
   // when it belongs to the caller. Non-admins see ONLY their own targets -- other
@@ -102,18 +118,8 @@ export function targetRoutes(deps: TargetDeps) {
       if (!userId) return notAuthenticated(c)
 
       const { id } = c.req.valid('param')
-      const target = await deps.targetQueries.getTarget(id)
-      if (!target || target.userId !== userId) {
-        return problem(
-          c,
-          'target-not-found',
-          'Target not found',
-          404,
-          undefined,
-          undefined,
-          'errors.target.notFound',
-        )
-      }
+      const loaded = await loadOwnedTarget(c, id, userId)
+      if (!loaded.ok) return loaded.response
 
       const allowed: TargetUpdate = c.req.valid('json')
       await deps.targetQueries.updateTarget(id, allowed)
@@ -130,18 +136,8 @@ export function targetRoutes(deps: TargetDeps) {
       if (!userId) return notAuthenticated(c)
 
       const { id } = c.req.valid('param')
-      const target = await deps.targetQueries.getTarget(id)
-      if (!target || target.userId !== userId) {
-        return problem(
-          c,
-          'target-not-found',
-          'Target not found',
-          404,
-          undefined,
-          undefined,
-          'errors.target.notFound',
-        )
-      }
+      const loaded = await loadOwnedTarget(c, id, userId)
+      if (!loaded.ok) return loaded.response
 
       await deps.targetQueries.deleteTarget(id)
       return c.body(null, 204)
@@ -153,18 +149,9 @@ export function targetRoutes(deps: TargetDeps) {
     if (!userId) return notAuthenticated(c)
 
     const { id } = c.req.valid('param')
-    const target = await deps.targetQueries.getTarget(id)
-    if (!target || target.userId !== userId) {
-      return problem(
-        c,
-        'target-not-found',
-        'Target not found',
-        404,
-        undefined,
-        undefined,
-        'errors.target.notFound',
-      )
-    }
+    const loaded = await loadOwnedTarget(c, id, userId)
+    if (!loaded.ok) return loaded.response
+    const target = loaded.target
 
     const result = await deps.testTargetConnection(target.type, target.config)
     return c.json(result)

--- a/src/server/routes/test-seed.ts
+++ b/src/server/routes/test-seed.ts
@@ -2,7 +2,7 @@ import { and, eq, inArray } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { artists, recommendationBatches, recommendations } from '@/db/schema'
 import type { AppDependencies } from '@/server'
-import { notAuthenticated } from '@/server/helpers/auth-problems'
+import { requireUser } from '@/server/helpers/require-user'
 import type { HonoEnv } from '@/server/types'
 
 // Fixed, deterministic seed set. UUIDs are stable so re-seeding upserts the same
@@ -63,8 +63,9 @@ export function testSeedRoutes(deps: AppDependencies) {
   // Seed a fixed set of pending recommendations (and their artists) for the
   // authenticated user so browser tests have something to approve/reject.
   router.post('/api/v1/test/seed-recommendations', async (c) => {
-    const userId = c.get('userId')
-    if (typeof userId !== 'number') return notAuthenticated(c)
+    const auth = requireUser(c)
+    if (!auth.ok) return auth.response
+    const { userId } = auth
 
     const db = deps.db
     const now = new Date()

--- a/tests/server/helpers/problem.test.ts
+++ b/tests/server/helpers/problem.test.ts
@@ -3,7 +3,7 @@
 import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import { describe, expect, it } from 'vitest'
-import { problem } from '@/server/helpers/problem'
+import { notFoundProblem, problem } from '@/server/helpers/problem'
 
 describe('problem helper', () => {
   it('returns RFC 9457 envelope with application/problem+json', async () => {
@@ -40,6 +40,23 @@ describe('problem helper', () => {
     const res = await app.request('/boom')
     const body = (await res.json()) as { retryAfter?: number }
     expect(body.retryAfter).toBe(42)
+  })
+
+  it('returns a coded 404 without placeholder arguments', async () => {
+    const app = new Hono()
+    app.get('/missing', (c) =>
+      notFoundProblem(c, 'widget-not-found', 'Widget not found', 'errors.widget.notFound'),
+    )
+
+    const res = await app.request('/missing')
+    expect(res.status).toBe(404)
+    expect(res.headers.get('content-type')).toContain('application/problem+json')
+    expect(await res.json()).toEqual({
+      type: '/problems/widget-not-found',
+      title: 'Widget not found',
+      status: 404,
+      code: 'errors.widget.notFound',
+    })
   })
 })
 

--- a/tests/server/routes/album-blocks.test.ts
+++ b/tests/server/routes/album-blocks.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment node
 
+import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { clearAllSessions, createSession } from '@/core/sessions'
 import type { BlockedAlbumRow } from '@/db/queries/album-blocks'
 import { createApp } from '@/server'
+import { albumBlocksRoutes } from '@/server/routes/album-blocks'
+import type { HonoEnv } from '@/server/types'
 import { makeDeps } from '../../helpers/test-app'
 
 const SESSION_TOKEN = 'album-blocks-token'
@@ -45,6 +48,21 @@ describe('GET /api/v1/album-blocks', () => {
     const app = createApp(makeDeps())
     const res = await app.request('/api/v1/album-blocks')
     expect(res.status).toBe(401)
+  })
+
+  it('returns the canonical auth problem when mounted directly', async () => {
+    const app = new Hono<HonoEnv>()
+    app.route('/', albumBlocksRoutes(makeDeps()))
+
+    const res = await app.request('/api/v1/album-blocks')
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toBe('Bearer realm="digarr"')
+    expect(await res.json()).toEqual({
+      type: '/problems/not-authenticated',
+      title: 'Not authenticated',
+      status: 401,
+      code: 'errors.auth.notAuthenticated',
+    })
   })
 })
 

--- a/tests/server/routes/artist-blocks.test.ts
+++ b/tests/server/routes/artist-blocks.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment node
 
+import { Hono } from 'hono'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { clearAllSessions, createSession } from '@/core/sessions'
 import type { BlockedArtistRow } from '@/db/queries/artist-blocks'
 import { createApp } from '@/server'
+import { artistBlocksRoutes } from '@/server/routes/artist-blocks'
+import type { HonoEnv } from '@/server/types'
 import { makeDeps } from '../../helpers/test-app'
 
 const SESSION_TOKEN = 'artist-blocks-token'
@@ -67,6 +70,21 @@ describe('GET /api/v1/artist-blocks', () => {
     const app = createApp(makeDeps())
     const res = await app.request('/api/v1/artist-blocks')
     expect(res.status).toBe(401)
+  })
+
+  it('returns the canonical auth problem when mounted directly', async () => {
+    const app = new Hono<HonoEnv>()
+    app.route('/', artistBlocksRoutes(makeDeps()))
+
+    const res = await app.request('/api/v1/artist-blocks')
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toBe('Bearer realm="digarr"')
+    expect(await res.json()).toEqual({
+      type: '/problems/not-authenticated',
+      title: 'Not authenticated',
+      status: 401,
+      code: 'errors.auth.notAuthenticated',
+    })
   })
 })
 

--- a/tests/server/routes/playlists.test.ts
+++ b/tests/server/routes/playlists.test.ts
@@ -258,6 +258,17 @@ describe('GET /api/v1/playlists/:id', () => {
     const res = await app.request('/api/v1/playlists/9999')
     expect(res.status).toBe(404)
   })
+
+  it('returns the same hidden 404 body for missing and cross-user playlists', async () => {
+    const missing = await createTestApp(makeDeps(), USER_ID).request('/api/v1/playlists/9999')
+    const crossUser = await createTestApp(makeDeps(), 999).request('/api/v1/playlists/1')
+
+    expect(missing.status).toBe(404)
+    expect(crossUser.status).toBe(404)
+    expect(missing.headers.get('content-type')).toContain('application/problem+json')
+    expect(crossUser.headers.get('content-type')).toContain('application/problem+json')
+    expect(await crossUser.text()).toBe(await missing.text())
+  })
 })
 
 describe('GET /api/v1/playlists/:id/export/:format', () => {

--- a/tests/server/routes/subscriptions.test.ts
+++ b/tests/server/routes/subscriptions.test.ts
@@ -686,6 +686,21 @@ describe('DELETE /api/v1/subscriptions/:id', () => {
     const res = await app.request('/api/v1/subscriptions/999', { method: 'DELETE' })
     expect(res.status).toBe(404)
   })
+
+  it('returns the same hidden 404 body for missing and cross-user subscriptions', async () => {
+    const missing = await createTestApp(makeDeps(), USER_ID).request('/api/v1/subscriptions/999', {
+      method: 'DELETE',
+    })
+    const crossUser = await createTestApp(makeDeps(), 99).request('/api/v1/subscriptions/1', {
+      method: 'DELETE',
+    })
+
+    expect(missing.status).toBe(404)
+    expect(crossUser.status).toBe(404)
+    expect(missing.headers.get('content-type')).toContain('application/problem+json')
+    expect(crossUser.headers.get('content-type')).toContain('application/problem+json')
+    expect(await crossUser.text()).toBe(await missing.text())
+  })
 })
 
 describe('POST /api/v1/subscriptions/:id/run', () => {

--- a/tests/server/routes/targets.test.ts
+++ b/tests/server/routes/targets.test.ts
@@ -185,6 +185,21 @@ describe('target routes', () => {
     expect(res.status).toBe(404)
   })
 
+  it('returns the same hidden 404 body for missing and cross-user targets', async () => {
+    mockDeps.targetQueries.getTarget.mockImplementation(async (id: number) =>
+      id === 1 ? { id: 1, userId: 1, type: 'lidarr' } : null,
+    )
+
+    const missing = await createTestApp(1).request('/api/v1/targets/999', { method: 'DELETE' })
+    const crossUser = await createTestApp(2).request('/api/v1/targets/1', { method: 'DELETE' })
+
+    expect(missing.status).toBe(404)
+    expect(crossUser.status).toBe(404)
+    expect(missing.headers.get('content-type')).toContain('application/problem+json')
+    expect(crossUser.headers.get('content-type')).toContain('application/problem+json')
+    expect(await crossUser.text()).toBe(await missing.text())
+  })
+
   it('POST /api/v1/targets/:id/test tests connection', async () => {
     mockDeps.targetQueries.getTarget.mockResolvedValue({
       id: 1,


### PR DESCRIPTION
## Summary

- centralize owned playlist, subscription, and target lookup guards
- preserve byte-identical hidden 404 responses for missing and cross-user resources
- canonicalize audited direct-route authentication failures through `requireUser`

## Test plan

- `bun run lint`
- `bun run typecheck`
- `bun run test` (2,671 passed, 26 skipped)
- `bun run build`
- full review: correctness, security, slop, and docs

Refs #448
