### PR TITLE
refactor(core): consolidate media families

### DIFF
--- a/src/core/clients/subsonic-auth.ts
+++ b/src/core/clients/subsonic-auth.ts
@@ -1,0 +1,57 @@
+import { createHash, randomBytes } from 'node:crypto'
+
+export type SubsonicEnvelope<T> = {
+  'subsonic-response'?: {
+    status: string
+    version?: string
+    type?: string
+    error?: { code: number; message: string }
+  } & T
+}
+
+type SubsonicAuthOptions = {
+  username: string
+  password: string
+  salt?: string
+  extra?: Record<string, string>
+}
+
+export function buildSubsonicAuthParams({
+  username,
+  password,
+  salt = randomBytes(8).toString('hex'),
+  extra,
+}: SubsonicAuthOptions): URLSearchParams {
+  // The protocol mandates MD5 for token auth; this is not password storage.
+  const token = createHash('md5') // lgtm[js/insufficient-password-hash]
+    .update(password + salt)
+    .digest('hex')
+
+  return new URLSearchParams({
+    u: username,
+    t: token,
+    s: salt,
+    v: '1.16.1',
+    c: 'digarr',
+    f: 'json',
+    ...extra,
+  })
+}
+
+export function unwrapSubsonicResponse<T>(
+  response: SubsonicEnvelope<T>,
+  fallbackMessage?: string,
+): NonNullable<SubsonicEnvelope<T>['subsonic-response']> {
+  const body = response?.['subsonic-response']
+  if (!body || typeof body.status !== 'string') {
+    throw new Error('Malformed Subsonic response (missing subsonic-response envelope)')
+  }
+  if (body.status !== 'ok') {
+    throw new Error(
+      body.error?.message ??
+        fallbackMessage ??
+        `Subsonic error code ${body.error?.code ?? 'unknown'}`,
+    )
+  }
+  return body
+}

--- a/src/core/clients/subsonic.ts
+++ b/src/core/clients/subsonic.ts
@@ -1,8 +1,13 @@
-import { createHash, randomBytes } from 'node:crypto'
+import { randomBytes } from 'node:crypto'
 import PQueue from 'p-queue'
 import type { ServiceTestResult } from '@/core/types'
 import { errMsg } from '@/core/validation'
 import { createHttpClient } from './http'
+import {
+  buildSubsonicAuthParams,
+  type SubsonicEnvelope,
+  unwrapSubsonicResponse,
+} from './subsonic-auth'
 
 export type SubsonicArtist = {
   id: string
@@ -14,15 +19,6 @@ export type SubsonicAlbum = {
   artistId: string
   title: string
   releaseYear?: number
-}
-
-type SubsonicEnvelope<T> = {
-  'subsonic-response': {
-    status: 'ok' | 'failed'
-    version?: string
-    type?: string
-    error?: { code: number; message: string }
-  } & T
 }
 
 type RawArtist = {
@@ -68,35 +64,16 @@ export function createSubsonicClient(
     return queue.add(() => http.get<T>(path)) as Promise<T>
   }
 
-  // Subsonic token auth (protocol >= 1.13.0): the plaintext password is never
-  // sent. salt is generated once per client instance.
   const salt = options?.salt ?? randomBytes(8).toString('hex')
-  const token = createHash('md5')
-    .update(password + salt)
-    .digest('hex')
 
   function restPath(method: string, extra?: Record<string, string>): string {
-    const params = new URLSearchParams({
-      u: username,
-      t: token,
-      s: salt,
-      v: '1.16.1',
-      c: 'digarr',
-      f: 'json',
-      ...extra,
+    const params = buildSubsonicAuthParams({
+      username,
+      password,
+      salt,
+      extra,
     })
     return `/rest/${method}?${params.toString()}`
-  }
-
-  function unwrap<T>(resp: SubsonicEnvelope<T>): SubsonicEnvelope<T>['subsonic-response'] {
-    const body = resp?.['subsonic-response']
-    if (!body || typeof body.status !== 'string') {
-      throw new Error('Malformed Subsonic response (missing subsonic-response envelope)')
-    }
-    if (body.status === 'failed') {
-      throw new Error(body.error?.message ?? 'Subsonic request failed')
-    }
-    return body
   }
 
   function mapArtist(a: RawArtist): SubsonicArtist {
@@ -104,20 +81,27 @@ export function createSubsonicClient(
   }
 
   async function getStarredArtists(): Promise<SubsonicArtist[]> {
-    const body = unwrap(await get<SubsonicEnvelope<StarredBody>>(restPath('getStarred2')))
+    const body = unwrapSubsonicResponse(
+      await get<SubsonicEnvelope<StarredBody>>(restPath('getStarred2')),
+      'Subsonic request failed',
+    )
     return (body.starred2?.artist ?? []).filter((a) => a.id != null).map(mapArtist)
   }
 
   async function getAllArtists(): Promise<SubsonicArtist[]> {
-    const body = unwrap(await get<SubsonicEnvelope<ArtistsBody>>(restPath('getArtists')))
+    const body = unwrapSubsonicResponse(
+      await get<SubsonicEnvelope<ArtistsBody>>(restPath('getArtists')),
+      'Subsonic request failed',
+    )
     return (body.artists?.index?.flatMap((i) => i.artist ?? []) ?? [])
       .filter((a) => a.id != null)
       .map(mapArtist)
   }
 
   async function getAlbumsForArtist(artistId: string): Promise<SubsonicAlbum[]> {
-    const body = unwrap(
+    const body = unwrapSubsonicResponse(
       await get<SubsonicEnvelope<ArtistBody>>(restPath('getArtist', { id: artistId })),
+      'Subsonic request failed',
     )
     return (body.artist?.album ?? [])
       .filter((al) => al.id != null)
@@ -131,16 +115,15 @@ export function createSubsonicClient(
 
   async function testConnection(): Promise<ServiceTestResult> {
     try {
-      const resp = await get<SubsonicEnvelope<Record<string, never>>>(restPath('ping'))
-      const body = resp['subsonic-response']
-      if (body.status === 'ok') {
-        return {
-          success: true,
-          message: `Connected to Subsonic${body.type ? ` (${body.type})` : ''}`,
-          details: { version: body.version, type: body.type },
-        }
+      const body = unwrapSubsonicResponse(
+        await get<SubsonicEnvelope<Record<string, never>>>(restPath('ping')),
+        'Subsonic ping failed',
+      )
+      return {
+        success: true,
+        message: `Connected to Subsonic${body.type ? ` (${body.type})` : ''}`,
+        details: { version: body.version, type: body.type },
       }
-      return { success: false, message: body.error?.message ?? 'Subsonic ping failed' }
     } catch (e: unknown) {
       return { success: false, message: errMsg(e) }
     }

--- a/src/core/library/sources/emby.ts
+++ b/src/core/library/sources/emby.ts
@@ -1,5 +1,6 @@
 import type { createEmbyClient } from '@/core/clients/emby'
-import type { LibraryAlbum, LibraryArtist, LibrarySource } from './types'
+import { createJellyfinFamilyLibrarySource } from './jellyfin-family'
+import type { LibrarySource } from './types'
 
 type EmbyClient = ReturnType<typeof createEmbyClient>
 
@@ -10,37 +11,10 @@ type EmbyClient = ReturnType<typeof createEmbyClient>
  * Emby is per-user.
  */
 export function createEmbyLibrarySource(client: EmbyClient, userId: number): LibrarySource {
-  return {
+  return createJellyfinFamilyLibrarySource({
     id: 'emby',
     name: 'Emby',
-    capabilities: ['listArtists', 'listAlbums'],
+    client,
     userId,
-    mbidQuality: 'high',
-
-    async listArtists(): Promise<LibraryArtist[]> {
-      const artists = await client.getAllArtists()
-      return artists.map((a) => ({
-        sourceArtistId: a.id,
-        name: a.name,
-        mbid: a.mbid,
-        genres: a.genres,
-      }))
-    },
-
-    async listAlbums(sourceArtistId): Promise<LibraryAlbum[]> {
-      const albums = await client.getAlbumsForArtist(sourceArtistId)
-      return albums.map((album) => ({
-        sourceAlbumId: album.id,
-        sourceArtistId: album.artistId,
-        title: album.title,
-        mbid: album.mbid,
-        releaseYear: album.releaseYear,
-        primaryType: album.primaryType,
-      }))
-    },
-
-    testConnection() {
-      return client.testConnection()
-    },
-  }
+  })
 }

--- a/src/core/library/sources/jellyfin-family.ts
+++ b/src/core/library/sources/jellyfin-family.ts
@@ -1,0 +1,65 @@
+import type { ServiceTestResult } from '@/core/types'
+import type { LibraryAlbum, LibraryArtist, LibrarySource } from './types'
+
+type JellyfinFamilyLibraryClient = {
+  getAllArtists(): Promise<Array<{ id: string; name: string; mbid?: string; genres?: string[] }>>
+  getAlbumsForArtist(sourceArtistId: string): Promise<
+    Array<{
+      id: string
+      artistId: string
+      title: string
+      mbid?: string
+      releaseYear?: number
+      primaryType?: LibraryAlbum['primaryType']
+    }>
+  >
+  testConnection(): Promise<ServiceTestResult>
+}
+
+type JellyfinFamilyLibraryOptions = {
+  id: 'emby' | 'jellyfin'
+  name: 'Emby' | 'Jellyfin'
+  client: JellyfinFamilyLibraryClient
+  userId: number
+}
+
+export function createJellyfinFamilyLibrarySource({
+  id,
+  name,
+  client,
+  userId,
+}: JellyfinFamilyLibraryOptions): LibrarySource {
+  return {
+    id,
+    name,
+    capabilities: ['listArtists', 'listAlbums'],
+    userId,
+    mbidQuality: 'high',
+
+    async listArtists(): Promise<LibraryArtist[]> {
+      const artists = await client.getAllArtists()
+      return artists.map((artist) => ({
+        sourceArtistId: artist.id,
+        name: artist.name,
+        mbid: artist.mbid,
+        genres: artist.genres,
+      }))
+    },
+
+    async listAlbums(sourceArtistId): Promise<LibraryAlbum[]> {
+      const albums = await client.getAlbumsForArtist(sourceArtistId)
+      return albums.map((album) => ({
+        sourceAlbumId: album.id,
+        sourceArtistId: album.artistId,
+        title: album.title,
+        mbid: album.mbid,
+        releaseYear: album.releaseYear,
+        primaryType: album.primaryType,
+      }))
+    },
+
+    testConnection() {
+      return client.testConnection()
+    },
+  }
+}

--- a/src/core/library/sources/jellyfin.ts
+++ b/src/core/library/sources/jellyfin.ts
@@ -1,5 +1,6 @@
 import type { createJellyfinClient } from '@/core/clients/jellyfin'
-import type { LibraryAlbum, LibraryArtist, LibrarySource } from './types'
+import { createJellyfinFamilyLibrarySource } from './jellyfin-family'
+import type { LibrarySource } from './types'
 
 type JellyfinClient = ReturnType<typeof createJellyfinClient>
 
@@ -10,37 +11,10 @@ type JellyfinClient = ReturnType<typeof createJellyfinClient>
  * Jellyfin is per-user.
  */
 export function createJellyfinLibrarySource(client: JellyfinClient, userId: number): LibrarySource {
-  return {
+  return createJellyfinFamilyLibrarySource({
     id: 'jellyfin',
     name: 'Jellyfin',
-    capabilities: ['listArtists', 'listAlbums'],
+    client,
     userId,
-    mbidQuality: 'high',
-
-    async listArtists(): Promise<LibraryArtist[]> {
-      const artists = await client.getAllArtists()
-      return artists.map((a) => ({
-        sourceArtistId: a.id,
-        name: a.name,
-        mbid: a.mbid,
-        genres: a.genres,
-      }))
-    },
-
-    async listAlbums(sourceArtistId): Promise<LibraryAlbum[]> {
-      const albums = await client.getAlbumsForArtist(sourceArtistId)
-      return albums.map((album) => ({
-        sourceAlbumId: album.id,
-        sourceArtistId: album.artistId,
-        title: album.title,
-        mbid: album.mbid,
-        releaseYear: album.releaseYear,
-        primaryType: album.primaryType,
-      }))
-    },
-
-    testConnection() {
-      return client.testConnection()
-    },
-  }
+  })
 }

--- a/src/core/plugins/emby.ts
+++ b/src/core/plugins/emby.ts
@@ -1,4 +1,5 @@
 import { createEmbyClient } from '@/core/clients/emby'
+import { createJellyfinFamilySource } from './jellyfin-family'
 import type { DiscoverySource } from './types'
 
 export function createEmbySource(
@@ -9,69 +10,9 @@ export function createEmbySource(
   libraryId?: string | null,
 ): DiscoverySource {
   const client = createEmbyClient(url, apiKey, userId, { skipTlsVerify, libraryId })
-
-  return {
+  return createJellyfinFamilySource({
     id: 'emby',
     name: 'Emby',
-    capabilities: ['topArtists', 'recentListening'],
-
-    async getTopArtists(limit) {
-      const [topByPlays, favorites] = await Promise.all([
-        client.getTopArtists(limit),
-        client.getFavoriteArtists(limit),
-      ])
-
-      // Build a map from top artists keyed by name (lowercase for matching)
-      const merged = new Map<string, { name: string; playCount: number }>()
-      for (const a of topByPlays) {
-        merged.set(a.name.toLowerCase(), {
-          name: a.name,
-          playCount: a.playCount,
-        })
-      }
-
-      // Merge favorites: boost existing entries, add new ones
-      for (const fav of favorites) {
-        const key = fav.name.toLowerCase()
-        const existing = merged.get(key)
-        if (existing) {
-          // Favorite already in top list - 1.2x play count boost
-          existing.playCount = Math.round(existing.playCount * 1.2)
-        } else {
-          // New favorite not in top list - add with their play count (min 1)
-          merged.set(key, {
-            name: fav.name,
-            playCount: Math.max(fav.playCount, 1),
-          })
-        }
-      }
-
-      return Array.from(merged.values())
-        .sort((a, b) => b.playCount - a.playCount)
-        .slice(0, limit ?? 50)
-        .map((a) => ({
-          name: a.name,
-          playCount: a.playCount,
-          source: 'emby',
-        }))
-    },
-
-    async getSimilarArtists() {
-      // Emby does not provide similar artist data
-      return []
-    },
-
-    async testConnection() {
-      return client.testConnection()
-    },
-
-    async getRecentListening(limit) {
-      const tracks = await client.getRecentlyPlayed(limit)
-      return tracks.map((t) => ({
-        name: t.artistName,
-        track: t.trackName,
-        playedAt: new Date(t.datePlayed),
-      }))
-    },
-  }
+    client,
+  })
 }

--- a/src/core/plugins/jellyfin-family.ts
+++ b/src/core/plugins/jellyfin-family.ts
@@ -1,0 +1,79 @@
+import type { ServiceTestResult } from '@/core/types'
+import type { DiscoverySource } from './types'
+
+type JellyfinFamilyClient = {
+  getTopArtists(limit?: number): Promise<Array<{ name: string; playCount: number }>>
+  getFavoriteArtists(limit?: number): Promise<Array<{ name: string; playCount: number }>>
+  getRecentlyPlayed(
+    limit?: number,
+  ): Promise<Array<{ artistName: string; trackName: string; datePlayed: string }>>
+  testConnection(): Promise<ServiceTestResult>
+}
+
+type JellyfinFamilySourceOptions = {
+  id: 'emby' | 'jellyfin'
+  name: 'Emby' | 'Jellyfin'
+  client: JellyfinFamilyClient
+}
+
+export function createJellyfinFamilySource({
+  id,
+  name,
+  client,
+}: JellyfinFamilySourceOptions): DiscoverySource {
+  return {
+    id,
+    name,
+    capabilities: ['topArtists', 'recentListening'],
+
+    async getTopArtists(limit) {
+      const [topByPlays, favorites] = await Promise.all([
+        client.getTopArtists(limit),
+        client.getFavoriteArtists(limit),
+      ])
+      const merged = new Map<string, { name: string; playCount: number }>()
+
+      for (const artist of topByPlays) {
+        merged.set(artist.name.toLowerCase(), {
+          name: artist.name,
+          playCount: artist.playCount,
+        })
+      }
+
+      for (const favorite of favorites) {
+        const key = favorite.name.toLowerCase()
+        const existing = merged.get(key)
+        if (existing) {
+          existing.playCount = Math.round(existing.playCount * 1.2)
+        } else {
+          merged.set(key, {
+            name: favorite.name,
+            playCount: Math.max(favorite.playCount, 1),
+          })
+        }
+      }
+
+      return Array.from(merged.values())
+        .sort((a, b) => b.playCount - a.playCount)
+        .slice(0, limit ?? 50)
+        .map((artist) => ({ ...artist, source: id }))
+    },
+
+    async getSimilarArtists() {
+      return []
+    },
+
+    testConnection() {
+      return client.testConnection()
+    },
+
+    async getRecentListening(limit) {
+      const tracks = await client.getRecentlyPlayed(limit)
+      return tracks.map((track) => ({
+        name: track.artistName,
+        track: track.trackName,
+        playedAt: new Date(track.datePlayed),
+      }))
+    },
+  }
+}

--- a/src/core/plugins/jellyfin.ts
+++ b/src/core/plugins/jellyfin.ts
@@ -1,4 +1,5 @@
 import { createJellyfinClient } from '@/core/clients/jellyfin'
+import { createJellyfinFamilySource } from './jellyfin-family'
 import type { DiscoverySource } from './types'
 
 export function createJellyfinSource(
@@ -9,69 +10,9 @@ export function createJellyfinSource(
   libraryId?: string | null,
 ): DiscoverySource {
   const client = createJellyfinClient(url, apiKey, userId, { skipTlsVerify, libraryId })
-
-  return {
+  return createJellyfinFamilySource({
     id: 'jellyfin',
     name: 'Jellyfin',
-    capabilities: ['topArtists', 'recentListening'],
-
-    async getTopArtists(limit) {
-      const [topByPlays, favorites] = await Promise.all([
-        client.getTopArtists(limit),
-        client.getFavoriteArtists(limit),
-      ])
-
-      // Build a map from top artists keyed by name (lowercase for matching)
-      const merged = new Map<string, { name: string; playCount: number }>()
-      for (const a of topByPlays) {
-        merged.set(a.name.toLowerCase(), {
-          name: a.name,
-          playCount: a.playCount,
-        })
-      }
-
-      // Merge favorites: boost existing entries, add new ones
-      for (const fav of favorites) {
-        const key = fav.name.toLowerCase()
-        const existing = merged.get(key)
-        if (existing) {
-          // Favorite already in top list - 1.2x play count boost
-          existing.playCount = Math.round(existing.playCount * 1.2)
-        } else {
-          // New favorite not in top list - add with their play count (min 1)
-          merged.set(key, {
-            name: fav.name,
-            playCount: Math.max(fav.playCount, 1),
-          })
-        }
-      }
-
-      return Array.from(merged.values())
-        .sort((a, b) => b.playCount - a.playCount)
-        .slice(0, limit ?? 50)
-        .map((a) => ({
-          name: a.name,
-          playCount: a.playCount,
-          source: 'jellyfin',
-        }))
-    },
-
-    async getSimilarArtists() {
-      // Jellyfin does not provide similar artist data
-      return []
-    },
-
-    async testConnection() {
-      return client.testConnection()
-    },
-
-    async getRecentListening(limit) {
-      const tracks = await client.getRecentlyPlayed(limit)
-      return tracks.map((t) => ({
-        name: t.artistName,
-        track: t.trackName,
-        playedAt: new Date(t.datePlayed),
-      }))
-    },
-  }
+    client,
+  })
 }

--- a/src/core/targets/emby-playlist.ts
+++ b/src/core/targets/emby-playlist.ts
@@ -1,130 +1,17 @@
-import type { ServiceTestResult } from '@/core/types'
-import { errMsg } from '@/core/validation'
-import { pickBestTrackMatch } from './playlist-match'
-import type { DestinationTarget, PlaylistItem, PlaylistResult } from './types'
+import {
+  createJellyfinFamilyPlaylistTarget,
+  type JellyfinFamilyPlaylistConfig,
+} from './jellyfin-family-playlist'
+import type { DestinationTarget } from './types'
 
-export type EmbyPlaylistConfig = {
-  url: string
-  apiKey: string
-  userId: string
-  skipTlsVerify?: boolean
-}
-
-async function embyFetch<T>(
-  baseUrl: string,
-  apiKey: string,
-  path: string,
-  options?: { method?: string; body?: unknown; skipTlsVerify?: boolean },
-): Promise<T> {
-  const url = `${baseUrl.replace(/\/+$/, '')}${path}`
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), 10_000)
-  let res: Response
-  try {
-    res = await fetch(url, {
-      method: options?.method ?? 'GET',
-      headers: {
-        'X-Emby-Token': apiKey,
-        'Content-Type': 'application/json',
-      },
-      body: options?.body ? JSON.stringify(options.body) : undefined,
-      signal: controller.signal,
-      ...(options?.skipTlsVerify ? { tls: { rejectUnauthorized: false } } : {}),
-    })
-  } finally {
-    clearTimeout(timer)
-  }
-  if (!res.ok) {
-    throw new Error(`Emby API ${res.status}: ${await res.text()}`)
-  }
-  return res.json() as Promise<T>
-}
+export type EmbyPlaylistConfig = JellyfinFamilyPlaylistConfig
 
 export function createEmbyPlaylistTarget(
   targetId: number,
   config: EmbyPlaylistConfig,
 ): DestinationTarget {
-  return {
-    id: `emby-playlist-${targetId}`,
-    name: 'Emby Playlist',
+  return createJellyfinFamilyPlaylistTarget(targetId, config, {
     type: 'emby-playlist',
-    capabilities: ['createPlaylist'],
-
-    async createPlaylist(name: string, items: PlaylistItem[]): Promise<PlaylistResult> {
-      try {
-        const itemIds: string[] = []
-        for (const item of items) {
-          if (!item.trackName) continue
-          const params = new URLSearchParams({
-            searchTerm: `${item.artistName} ${item.trackName}`,
-            IncludeItemTypes: 'Audio',
-            Recursive: 'true',
-            Limit: '5',
-            Fields: 'Name,AlbumArtist,Artists',
-          })
-          const search = await embyFetch<{
-            Items: Array<{ Id: string; Name: string; AlbumArtist?: string; Artists?: string[] }>
-          }>(config.url, config.apiKey, `/Users/${config.userId}/Items?${params.toString()}`, {
-            skipTlsVerify: config.skipTlsVerify,
-          })
-          const matchId = pickBestTrackMatch(
-            (search.Items ?? []).map((result) => ({
-              id: result.Id,
-              title: result.Name,
-              artists: [result.AlbumArtist, ...(result.Artists ?? [])].filter(
-                (artist): artist is string => Boolean(artist),
-              ),
-            })),
-            item.artistName,
-            item.trackName,
-          )
-          if (matchId) itemIds.push(matchId)
-        }
-
-        const playlist = await embyFetch<{ Id: string }>(config.url, config.apiKey, '/Playlists', {
-          method: 'POST',
-          body: {
-            Name: name,
-            UserId: config.userId,
-            MediaType: 'Audio',
-            Ids: itemIds,
-          },
-          skipTlsVerify: config.skipTlsVerify,
-        })
-
-        return {
-          success: true,
-          targetType: 'emby-playlist',
-          targetId,
-          playlistId: playlist.Id,
-          playlistName: name,
-          itemsAdded: itemIds.length,
-        }
-      } catch (err) {
-        return {
-          success: false,
-          targetType: 'emby-playlist',
-          targetId,
-          error: errMsg(err),
-        }
-      }
-    },
-
-    async testConnection(): Promise<ServiceTestResult> {
-      try {
-        const info = await embyFetch<{ ServerName: string; Version: string }>(
-          config.url,
-          config.apiKey,
-          '/System/Info',
-          { skipTlsVerify: config.skipTlsVerify },
-        )
-        return {
-          success: true,
-          message: `Connected to Emby "${info.ServerName}" v${info.Version}`,
-        }
-      } catch (err) {
-        return { success: false, message: errMsg(err) }
-      }
-    },
-  }
+    serviceName: 'Emby',
+  })
 }

--- a/src/core/targets/jellyfin-family-playlist.ts
+++ b/src/core/targets/jellyfin-family-playlist.ts
@@ -1,0 +1,156 @@
+import type { ServiceTestResult } from '@/core/types'
+import { errMsg } from '@/core/validation'
+import { pickBestTrackMatch } from './playlist-match'
+import type { DestinationTarget, PlaylistItem, PlaylistResult, TargetType } from './types'
+
+export type JellyfinFamilyPlaylistConfig = {
+  url: string
+  apiKey: string
+  userId: string
+  skipTlsVerify?: boolean
+}
+
+type JellyfinFamilyPlaylistOptions = {
+  type: Extract<TargetType, 'emby-playlist' | 'jellyfin-playlist'>
+  serviceName: 'Emby' | 'Jellyfin'
+}
+
+async function jellyfinFamilyFetch<T>(
+  config: JellyfinFamilyPlaylistConfig,
+  serviceName: string,
+  path: string,
+  options?: { method?: string; body?: unknown },
+): Promise<T> {
+  const url = `${config.url.replace(/\/+$/, '')}${path}`
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 10_000)
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: options?.method ?? 'GET',
+      headers: {
+        'X-Emby-Token': config.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: options?.body ? JSON.stringify(options.body) : undefined,
+      signal: controller.signal,
+      ...(config.skipTlsVerify ? { tls: { rejectUnauthorized: false } } : {}),
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+  if (!response.ok) {
+    throw new Error(`${serviceName} API ${response.status}: ${await response.text()}`)
+  }
+  return (await response.json()) as T
+}
+
+export function createJellyfinFamilyPlaylistTarget(
+  targetId: number,
+  config: JellyfinFamilyPlaylistConfig,
+  { type, serviceName }: JellyfinFamilyPlaylistOptions,
+): DestinationTarget {
+  async function searchTrack(artistName: string, trackName: string): Promise<string | null> {
+    try {
+      const params = new URLSearchParams({
+        searchTerm: `${artistName} ${trackName}`,
+        IncludeItemTypes: 'Audio',
+        Recursive: 'true',
+        Limit: '5',
+        Fields: 'Name,AlbumArtist,Artists',
+      })
+      const response = await jellyfinFamilyFetch<{
+        Items: Array<{ Id: string; Name: string; AlbumArtist?: string; Artists?: string[] }>
+      }>(config, serviceName, `/Users/${config.userId}/Items?${params.toString()}`)
+
+      return pickBestTrackMatch(
+        (response.Items ?? []).map((item) => ({
+          id: item.Id,
+          title: item.Name,
+          artists: [item.AlbumArtist, ...(item.Artists ?? [])].filter((artist): artist is string =>
+            Boolean(artist),
+          ),
+        })),
+        artistName,
+        trackName,
+      )
+    } catch (error) {
+      console.warn(`[${type}] searchTrack transport error:`, {
+        artistName,
+        trackName,
+        error: errMsg(error),
+      })
+      return null
+    }
+  }
+
+  return {
+    id: `${type}-${targetId}`,
+    name: `${serviceName} Playlist`,
+    type,
+    capabilities: ['createPlaylist'],
+
+    async createPlaylist(name: string, items: PlaylistItem[]): Promise<PlaylistResult> {
+      try {
+        const itemIds: string[] = []
+        for (const item of items) {
+          if (!item.trackName) continue
+          const itemId = await searchTrack(item.artistName, item.trackName)
+          if (itemId) itemIds.push(itemId)
+        }
+
+        const playlist = await jellyfinFamilyFetch<{ Id?: string }>(
+          config,
+          serviceName,
+          '/Playlists',
+          {
+            method: 'POST',
+            body: {
+              Name: name,
+              UserId: config.userId,
+              MediaType: 'Audio',
+              Ids: itemIds,
+            },
+          },
+        )
+        const playlistId = playlist.Id
+        if (!playlistId) {
+          throw new Error(`${serviceName} did not return a playlist ID`)
+        }
+
+        return {
+          success: true,
+          targetType: type,
+          targetId,
+          playlistId,
+          playlistName: name,
+          itemsAdded: itemIds.length,
+        }
+      } catch (error) {
+        return {
+          success: false,
+          targetType: type,
+          targetId,
+          error: errMsg(error),
+        }
+      }
+    },
+
+    async testConnection(): Promise<ServiceTestResult> {
+      try {
+        const info = await jellyfinFamilyFetch<{ ServerName: string; Version: string }>(
+          config,
+          serviceName,
+          '/System/Info',
+        )
+        return {
+          success: true,
+          message: `Connected to ${serviceName} "${info.ServerName}" v${info.Version}`,
+          details: { serverName: info.ServerName, version: info.Version },
+        }
+      } catch (error) {
+        return { success: false, message: errMsg(error) }
+      }
+    },
+  }
+}

--- a/src/core/targets/jellyfin-playlist.ts
+++ b/src/core/targets/jellyfin-playlist.ts
@@ -1,165 +1,17 @@
-import type { ServiceTestResult } from '@/core/types'
-import { errMsg } from '@/core/validation'
-import { pickBestTrackMatch } from './playlist-match'
-import type { DestinationTarget, PlaylistItem, PlaylistResult } from './types'
+import {
+  createJellyfinFamilyPlaylistTarget,
+  type JellyfinFamilyPlaylistConfig,
+} from './jellyfin-family-playlist'
+import type { DestinationTarget } from './types'
 
-export type JellyfinPlaylistConfig = {
-  url: string
-  apiKey: string
-  userId: string
-  skipTlsVerify?: boolean
-}
-
-async function jellyfinFetch<T>(
-  baseUrl: string,
-  apiKey: string,
-  path: string,
-  options?: { method?: string; body?: unknown; skipTlsVerify?: boolean },
-): Promise<T> {
-  const url = `${baseUrl.replace(/\/+$/, '')}${path}`
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), 10_000)
-  let res: Response
-  try {
-    res = await fetch(url, {
-      method: options?.method ?? 'GET',
-      headers: {
-        'X-Emby-Token': apiKey,
-        'Content-Type': 'application/json',
-      },
-      body: options?.body ? JSON.stringify(options.body) : undefined,
-      signal: controller.signal,
-      ...(options?.skipTlsVerify ? { tls: { rejectUnauthorized: false } } : {}),
-    })
-  } finally {
-    clearTimeout(timer)
-  }
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(`Jellyfin API ${res.status}: ${text}`)
-  }
-  return (await res.json()) as T
-}
+export type JellyfinPlaylistConfig = JellyfinFamilyPlaylistConfig
 
 export function createJellyfinPlaylistTarget(
   targetId: number,
   config: JellyfinPlaylistConfig,
 ): DestinationTarget {
-  const { url, apiKey, userId } = config
-
-  async function searchTrack(artistName: string, trackName: string): Promise<string | null> {
-    try {
-      const params = new URLSearchParams({
-        searchTerm: `${artistName} ${trackName}`,
-        IncludeItemTypes: 'Audio',
-        Recursive: 'true',
-        Limit: '5',
-        Fields: 'Name,AlbumArtist,Artists',
-      })
-      const res = await jellyfinFetch<{
-        Items: Array<{ Id: string; Name: string; AlbumArtist?: string; Artists?: string[] }>
-      }>(url, apiKey, `/Users/${userId}/Items?${params.toString()}`)
-
-      return pickBestTrackMatch(
-        (res.Items ?? []).map((item) => ({
-          id: item.Id,
-          title: item.Name,
-          artists: [item.AlbumArtist, ...(item.Artists ?? [])].filter((artist): artist is string =>
-            Boolean(artist),
-          ),
-        })),
-        artistName,
-        trackName,
-      )
-    } catch (err) {
-      console.warn('[jellyfin-playlist] searchTrack transport error:', {
-        artistName,
-        trackName,
-        error: err instanceof Error ? err.message : String(err),
-      })
-      return null
-    }
-  }
-
-  return {
-    id: `jellyfin-playlist-${targetId}`,
-    name: 'Jellyfin Playlist',
+  return createJellyfinFamilyPlaylistTarget(targetId, config, {
     type: 'jellyfin-playlist',
-    capabilities: ['createPlaylist'],
-
-    async createPlaylist(
-      name: string,
-      items: PlaylistItem[],
-      _options?: { description?: string; public?: boolean; replace?: boolean },
-    ): Promise<PlaylistResult> {
-      try {
-        // Resolve Jellyfin item IDs for items that have a trackName
-        const itemIds: string[] = []
-        for (const item of items) {
-          if (!item.trackName) continue
-          const id = await searchTrack(item.artistName, item.trackName)
-          if (id) itemIds.push(id)
-        }
-
-        // Create the playlist
-        const playlist = await jellyfinFetch<{ Id: string; Name: string }>(
-          url,
-          apiKey,
-          '/Playlists',
-          {
-            method: 'POST',
-            body: {
-              Name: name,
-              UserId: userId,
-              MediaType: 'Audio',
-              Ids: itemIds,
-            },
-            skipTlsVerify: config.skipTlsVerify,
-          },
-        )
-
-        const playlistId = playlist.Id
-        if (!playlistId) {
-          throw new Error('Jellyfin did not return a playlist ID')
-        }
-
-        return {
-          success: true,
-          targetType: 'jellyfin-playlist',
-          targetId,
-          playlistId,
-          playlistName: name,
-          itemsAdded: itemIds.length,
-        }
-      } catch (err: unknown) {
-        return {
-          success: false,
-          targetType: 'jellyfin-playlist',
-          targetId,
-          error: errMsg(err),
-        }
-      }
-    },
-
-    async testConnection(): Promise<ServiceTestResult> {
-      try {
-        const info = await jellyfinFetch<{ ServerName: string; Version: string }>(
-          url,
-          apiKey,
-          '/System/Info',
-          { skipTlsVerify: config.skipTlsVerify },
-        )
-        return {
-          success: true,
-          message: `Connected to Jellyfin "${info.ServerName}" v${info.Version}`,
-          details: { serverName: info.ServerName, version: info.Version },
-        }
-      } catch (err: unknown) {
-        return {
-          success: false,
-          message: errMsg(err),
-        }
-      }
-    },
-  }
+    serviceName: 'Jellyfin',
+  })
 }

--- a/src/core/targets/navidrome-playlist.ts
+++ b/src/core/targets/navidrome-playlist.ts
@@ -1,4 +1,9 @@
-import { createHash, randomBytes } from 'node:crypto'
+import { redactUrlForLog } from '@/core/clients/http'
+import {
+  buildSubsonicAuthParams,
+  type SubsonicEnvelope,
+  unwrapSubsonicResponse,
+} from '@/core/clients/subsonic-auth'
 import type { ServiceTestResult } from '@/core/types'
 import { errMsg } from '@/core/validation'
 import type { DestinationTarget, PlaylistItem, PlaylistResult } from './types'
@@ -9,9 +14,6 @@ export type NavidromePlaylistConfig = {
   password: string
 }
 
-const SUBSONIC_API_VERSION = '1.16.1'
-const SUBSONIC_CLIENT = 'digarr'
-
 function buildSubsonicUrl(
   baseUrl: string,
   username: string,
@@ -20,19 +22,10 @@ function buildSubsonicUrl(
   extra?: Record<string, string>,
 ): string {
   const base = baseUrl.replace(/\/+$/, '')
-  const salt = randomBytes(8).toString('hex')
-  // Subsonic API spec mandates md5(password + salt) auth - no alternative
-  const token = createHash('md5') // lgtm[js/insufficient-password-hash]
-    .update(password + salt)
-    .digest('hex')
-  const params = new URLSearchParams({
-    u: username,
-    t: token,
-    s: salt,
-    v: SUBSONIC_API_VERSION,
-    c: SUBSONIC_CLIENT,
-    f: 'json',
-    ...extra,
+  const params = buildSubsonicAuthParams({
+    username,
+    password,
+    extra,
   })
   return `${base}/rest/${endpoint}?${params.toString()}`
 }
@@ -47,19 +40,10 @@ async function subsonicFetch<T>(url: string): Promise<T> {
     clearTimeout(timer)
   }
   if (!res.ok) {
-    throw new Error(`Subsonic HTTP ${res.status}: ${url}`)
+    throw new Error(`Subsonic HTTP ${res.status}: ${redactUrlForLog(url)}`)
   }
-  const data = (await res.json()) as {
-    'subsonic-response': {
-      status: string
-      error?: { code: number; message: string }
-    } & Record<string, unknown>
-  }
-  const root = data['subsonic-response']
-  if (root.status !== 'ok') {
-    const msg = root.error?.message ?? `Subsonic error code ${root.error?.code ?? 'unknown'}`
-    throw new Error(msg)
-  }
+  const data = (await res.json()) as SubsonicEnvelope<Record<string, unknown>>
+  const root = unwrapSubsonicResponse(data)
   return root as unknown as T
 }
 

--- a/tests/core/clients/subsonic.test.ts
+++ b/tests/core/clients/subsonic.test.ts
@@ -202,4 +202,18 @@ describe('subsonic client auth params', () => {
     expect(path).toContain(`t=${expectedToken}`)
     expect(path).not.toContain('secret')
   })
+
+  it('reuses one salt for the lifetime of a client', async () => {
+    const client = createSubsonicClient('http://nav:4533', 'admin', 'secret')
+
+    mockGet.mockResolvedValue({ 'subsonic-response': { status: 'ok' } })
+    await client.getStarredArtists()
+    await client.getAllArtists()
+
+    const salts = mockGet.mock.calls.map(([path]) =>
+      new URL(String(path), 'http://nav').searchParams.get('s'),
+    )
+    expect(salts[0]).toMatch(/^[0-9a-f]{16}$/)
+    expect(salts[1]).toBe(salts[0])
+  })
 })

--- a/tests/core/targets/emby-playlist.test.ts
+++ b/tests/core/targets/emby-playlist.test.ts
@@ -104,4 +104,76 @@ describe('createEmbyPlaylistTarget', () => {
       tls: { rejectUnauthorized: false },
     })
   })
+
+  it('skips a track when its search request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockRejectedValueOnce(new Error('search transport failed'))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ Id: 'playlist-1', Name: 'Weekly Discoveries' }),
+        }),
+    )
+
+    const target = createEmbyPlaylistTarget(9, {
+      url: 'http://emby:8096',
+      apiKey: 'key',
+      userId: 'user-1',
+    })
+
+    const result = await target.createPlaylist?.('Weekly Discoveries', [
+      { artistName: 'Boards of Canada', artistMbid: 'mbid-1', trackName: 'Roygbiv' },
+    ])
+
+    expect(result).toMatchObject({ success: true, itemsAdded: 0 })
+  })
+
+  it('fails when Emby does not return a playlist ID', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ Name: 'Weekly Discoveries' }),
+      }),
+    )
+
+    const target = createEmbyPlaylistTarget(9, {
+      url: 'http://emby:8096',
+      apiKey: 'key',
+      userId: 'user-1',
+    })
+
+    const result = await target.createPlaylist?.('Weekly Discoveries', [])
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Emby did not return a playlist ID',
+    })
+  })
+
+  it('retains the Emby response body in API errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'playlist database unavailable',
+      }),
+    )
+
+    const target = createEmbyPlaylistTarget(9, {
+      url: 'http://emby:8096',
+      apiKey: 'key',
+      userId: 'user-1',
+    })
+
+    const result = await target.createPlaylist?.('Weekly Discoveries', [])
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Emby API 500: playlist database unavailable',
+    })
+  })
 })

--- a/tests/core/targets/navidrome-playlist.test.ts
+++ b/tests/core/targets/navidrome-playlist.test.ts
@@ -90,6 +90,30 @@ describe('createNavidromePlaylistTarget()', () => {
       expect(result.success).toBe(false)
       expect(result.message).toContain('Wrong username or password')
     })
+
+    it('redacts Subsonic auth parameters from HTTP errors', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+
+      const target = createNavidromePlaylistTarget(5, CONFIG)
+      const result = await target.testConnection()
+
+      expect(result.success).toBe(false)
+      expect(result.message).not.toMatch(/[?&]t=[0-9a-f]{32}/)
+      expect(result.message).not.toMatch(/[?&]s=[0-9a-f]{16}/)
+      expect(result.message).toContain('%5BREDACTED%5D')
+    })
+
+    it('returns a clean failure for a response without a Subsonic envelope', async () => {
+      mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({ error: 'gateway' })))
+
+      const target = createNavidromePlaylistTarget(5, CONFIG)
+      const result = await target.testConnection()
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Malformed Subsonic response (missing subsonic-response envelope)',
+      })
+    })
   })
 
   describe('createPlaylist()', () => {
@@ -245,6 +269,17 @@ describe('createNavidromePlaylistTarget()', () => {
       const commentCall = calls.find((u) => u.includes('comment='))
       expect(commentCall).toBeDefined()
       expect(commentCall).toContain('Auto-generated')
+    })
+
+    it('uses a fresh auth salt for each target request', async () => {
+      const target = createNavidromePlaylistTarget(5, CONFIG)
+      await target.createPlaylist?.('Test', [
+        { artistName: 'Radiohead', artistMbid: 'mbid-rh', trackName: 'Creep' },
+      ])
+
+      const salts = mockFetch.mock.calls.map(([url]) => new URL(String(url)).searchParams.get('s'))
+      expect(salts).toHaveLength(3)
+      expect(new Set(salts).size).toBe(3)
     })
   })
 })


### PR DESCRIPTION
## Summary

- consolidate Emby and Jellyfin discovery, library, and playlist adapters behind shared family factories
- centralize Subsonic token-auth and response-envelope handling for the client and Navidrome target
- align Emby playlist error handling with Jellyfin and redact Subsonic credentials from HTTP errors

## Test plan

- `bun run lint`
- `bun run typecheck`
- `bun run test` (2,678 passed, 26 skipped)
- `bun run build`
- full review: correctness, security, slop, and docs

Refs #448
