### PR TITLE
refactor(web): dedupe API request helpers

### DIFF
--- a/src/web/lib/api.ts
+++ b/src/web/lib/api.ts
@@ -88,15 +88,21 @@ function translateErrorCode(code: string): string | null {
 // Fired when any fetchApi call gets 401 - AuthGate listens and shows login
 export const AUTH_EXPIRED_EVENT = 'digarr:auth-expired'
 
+function getAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'X-Digarr-Locale': getRequestLocale(),
+  }
+  const token = getStoredToken()
+  if (token) headers.Authorization = `Bearer ${token}`
+  return headers
+}
+
 async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
-  const headers: Record<string, string> = {}
-  headers['X-Digarr-Locale'] = getRequestLocale()
+  const headers = getAuthHeaders()
   // Skip Content-Type for FormData - browser sets it with the correct boundary
   if (!(options?.body instanceof FormData)) {
     headers['Content-Type'] = 'application/json'
   }
-  const token = getStoredToken()
-  if (token) headers.Authorization = `Bearer ${token}`
 
   const { headers: extraHeaders, ...restOptions } = options ?? {}
   const res = await fetch(`${BASE}${path}`, {
@@ -119,6 +125,14 @@ async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
     return undefined as T
   }
   return res.json() as Promise<T>
+}
+
+function authedRawFetch(path: string, options?: RequestInit): Promise<Response> {
+  const { headers: extraHeaders, ...restOptions } = options ?? {}
+  return fetch(`${BASE}${path}`, {
+    ...restOptions,
+    headers: { ...getAuthHeaders(), ...(extraHeaders as Record<string, string>) },
+  })
 }
 
 // Auth
@@ -707,13 +721,7 @@ export async function exportRecommendations(
   if (params?.status) query.set('status', params.status)
   if (params?.batchId) query.set('batchId', String(params.batchId))
   const qs = query.toString() ? `?${query}` : ''
-  const token = getStoredToken()
-  const response = await fetch(`${BASE}/exports/${format}${qs}`, {
-    headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      'X-Digarr-Locale': getRequestLocale(),
-    },
-  })
+  const response = await authedRawFetch(`/exports/${format}${qs}`)
   if (!response.ok) throw new Error('Export failed')
   await downloadResponseBlob(
     response,
@@ -892,32 +900,21 @@ export const deleteSubscriptionApi = (id: number) =>
 export const triggerSubscriptionRun = (id: number) =>
   fetchApi<{ message: string }>(`/subscriptions/${id}/run`, { method: 'POST' })
 
-export const importSpotifyLikedSongs = () =>
-  fetchApi<{ message: string; subscriptionId: number; created: boolean }>(
-    '/subscriptions/import/spotify-liked-songs',
-    { method: 'POST' },
-  )
+type SubscriptionImportResult = { message: string; subscriptionId: number; created: boolean }
+
+const postImport = (path: string) => fetchApi<SubscriptionImportResult>(path, { method: 'POST' })
+
+export const importSpotifyLikedSongs = () => postImport('/subscriptions/import/spotify-liked-songs')
 
 export const importSpotifyPlaylist = (playlistId: string) =>
-  fetchApi<{ message: string; subscriptionId: number; created: boolean }>(
-    '/subscriptions/import/spotify-playlist',
-    {
-      method: 'POST',
-      body: JSON.stringify({ playlistId }),
-    },
-  )
+  fetchApi<SubscriptionImportResult>('/subscriptions/import/spotify-playlist', {
+    method: 'POST',
+    body: JSON.stringify({ playlistId }),
+  })
 
-export const importDeezerFavorites = () =>
-  fetchApi<{ message: string; subscriptionId: number; created: boolean }>(
-    '/subscriptions/import/deezer-favorites',
-    { method: 'POST' },
-  )
+export const importDeezerFavorites = () => postImport('/subscriptions/import/deezer-favorites')
 
-export const importDeezerFollowed = () =>
-  fetchApi<{ message: string; subscriptionId: number; created: boolean }>(
-    '/subscriptions/import/deezer-followed',
-    { method: 'POST' },
-  )
+export const importDeezerFollowed = () => postImport('/subscriptions/import/deezer-followed')
 
 export const importCsvFile = async (file: File) => {
   const formData = new FormData()
@@ -1041,13 +1038,7 @@ export async function exportPlaylistApi(
   id: number,
   format: 'json' | 'csv' | 'm3u' | 'xspf',
 ): Promise<void> {
-  const token = getStoredToken()
-  const response = await fetch(`${BASE}/playlists/${id}/export/${format}`, {
-    headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      'X-Digarr-Locale': getRequestLocale(),
-    },
-  })
+  const response = await authedRawFetch(`/playlists/${id}/export/${format}`)
   if (!response.ok) throw new Error('Playlist export failed')
   await downloadResponseBlob(response, `playlist-${id}.${format}`)
 }
@@ -1066,15 +1057,8 @@ export const getArtistTopTracks = (artistId: number) =>
 // ── Admin: Backup & Restore ────────────────────
 
 export async function downloadBackup(includeCaches = false): Promise<void> {
-  const token = getStoredToken()
   const qs = includeCaches ? '?includeCaches=true' : ''
-  const res = await fetch(`${BASE}/admin/backup${qs}`, {
-    method: 'POST',
-    headers: {
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      'X-Digarr-Locale': getRequestLocale(),
-    },
-  })
+  const res = await authedRawFetch(`/admin/backup${qs}`, { method: 'POST' })
   if (!res.ok) throw new ApiError(res.status, await res.json().catch(() => ({})))
   await downloadResponseBlob(res, 'digarr-backup.json')
 }

--- a/tests/web/lib/api.test.ts
+++ b/tests/web/lib/api.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ApiError,
+  downloadBackup,
+  exportPlaylistApi,
+  exportRecommendations,
+  importDeezerFavorites,
+  importDeezerFollowed,
+  importSpotifyLikedSongs,
+  setStoredToken,
+} from '@/web/lib/api'
+import { setStoredLocale } from '@/web/lib/locale-storage'
+
+const fetchMock = vi.fn()
+let clickedAnchor: HTMLAnchorElement | null = null
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>()
+  return {
+    get length() {
+      return values.size
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  }
+}
+
+function successfulDownload(filename?: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(
+      filename ? { 'content-disposition': `attachment; filename="${filename}"` } : {},
+    ),
+    blob: vi.fn().mockResolvedValue(new Blob(['content'])),
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+  vi.stubGlobal('localStorage', memoryStorage())
+  setStoredToken('session-token')
+  setStoredLocale('de')
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    value: vi.fn(() => 'blob:test'),
+  })
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    value: vi.fn(),
+  })
+  clickedAnchor = null
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+    this: HTMLAnchorElement,
+  ) {
+    clickedAnchor = this
+  })
+})
+
+describe('authenticated downloads', () => {
+  it('sends the stored token and locale for every raw download', async () => {
+    fetchMock.mockResolvedValue(successfulDownload())
+
+    await exportRecommendations('csv', { status: 'approved', batchId: 4 })
+    await exportPlaylistApi(7, 'm3u')
+    await downloadBackup(true)
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/v1/exports/csv?status=approved&batchId=4',
+      '/api/v1/playlists/7/export/m3u',
+      '/api/v1/admin/backup?includeCaches=true',
+    ])
+    for (const [, init] of fetchMock.mock.calls as Array<[string, RequestInit]>) {
+      const headers = new Headers(init.headers)
+      expect(headers.get('Authorization')).toBe('Bearer session-token')
+      expect(headers.get('X-Digarr-Locale')).toBe('de')
+    }
+    expect(fetchMock.mock.calls[0]?.[1]?.method).toBeUndefined()
+    expect(fetchMock.mock.calls[1]?.[1]?.method).toBeUndefined()
+    expect(fetchMock.mock.calls[2]?.[1]?.method).toBe('POST')
+  })
+
+  it('uses the response filename when one is provided', async () => {
+    fetchMock.mockResolvedValueOnce(successfulDownload('server-backup.json'))
+
+    await downloadBackup()
+
+    expect(clickedAnchor?.download).toBe('server-backup.json')
+  })
+
+  it('preserves each download function error shape', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        json: vi.fn().mockResolvedValue({ title: 'Backup failed' }),
+      })
+
+    await expect(exportRecommendations('json')).rejects.toThrow('Export failed')
+    await expect(exportPlaylistApi(7, 'json')).rejects.toThrow('Playlist export failed')
+    const backupError = await downloadBackup().catch((error: unknown) => error)
+    expect(backupError).toBeInstanceOf(ApiError)
+    expect(backupError).toMatchObject({
+      status: 422,
+      message: 'Backup failed',
+    })
+  })
+})
+
+describe('subscription imports', () => {
+  it('posts the three no-body imports and preserves their response shape', async () => {
+    const responses = [
+      { message: 'spotify', subscriptionId: 1, created: true },
+      { message: 'favorites', subscriptionId: 2, created: false },
+      { message: 'followed', subscriptionId: 3, created: true },
+    ]
+    for (const response of responses) {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(response),
+      })
+    }
+
+    await expect(importSpotifyLikedSongs()).resolves.toEqual(responses[0])
+    await expect(importDeezerFavorites()).resolves.toEqual(responses[1])
+    await expect(importDeezerFollowed()).resolves.toEqual(responses[2])
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/v1/subscriptions/import/spotify-liked-songs',
+      '/api/v1/subscriptions/import/deezer-favorites',
+      '/api/v1/subscriptions/import/deezer-followed',
+    ])
+    for (const [, init] of fetchMock.mock.calls as Array<[string, RequestInit]>) {
+      expect(init.method).toBe('POST')
+      expect(init.body).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- centralize token and locale headers for JSON and raw-response API requests
- share the three identical no-body subscription import POST wrappers
- add focused coverage for export, backup, and import request contracts

## Test plan

- `bun run lint`
- `bun run typecheck`
- `bun run test` (2,682 passed, 26 skipped)
- `bun run build`
- full review: correctness, security, slop, and docs

Refs #448
