### PR TITLE
test(core): cover shared runtime branches

### DIFF
--- a/tests/core/discovery-modes/runtime.test.ts
+++ b/tests/core/discovery-modes/runtime.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DiscoveryModeRequest } from '@/core/discovery-modes/request'
+
+const { db, mockGetUserConnections, mockResolveDeezerToken, mockResolveSpotifyToken } = vi.hoisted(
+  () => ({
+    db: { kind: 'test-db' },
+    mockGetUserConnections: vi.fn(),
+    mockResolveDeezerToken: vi.fn(),
+    mockResolveSpotifyToken: vi.fn(),
+  }),
+)
+
+vi.mock('@/db', () => ({ db }))
+vi.mock('@/db/queries/users', () => ({ getUserConnections: mockGetUserConnections }))
+vi.mock('@/core/spotify-auth', () => ({ resolveSpotifyToken: mockResolveSpotifyToken }))
+vi.mock('@/core/deezer-auth', () => ({ resolveDeezerToken: mockResolveDeezerToken }))
+
+import {
+  getDiscoveryModeConnections,
+  getDiscoveryModeDeezerToken,
+  getDiscoveryModeSpotifyToken,
+  getNormalizedLimit,
+  getProviderPath,
+  normalizeDiscoveryName,
+  parseSeeds,
+} from '@/core/discovery-modes/modes/runtime'
+
+function request(
+  normalizedSettings: Record<string, unknown>,
+  providerPath: unknown = [],
+): DiscoveryModeRequest {
+  return {
+    modeId: 'charts',
+    triggerType: 'manual',
+    settingsMode: 'advanced',
+    userId: 7,
+    rawUserSettings: normalizedSettings,
+    normalizedSettings,
+    providerContext: { providerPath },
+    fallbackPolicy: 'allow-fallback',
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('discovery mode runtime helpers', () => {
+  it('normalizes finite limits and falls back for invalid values', () => {
+    expect(getNormalizedLimit(request({}), 25)).toBe(25)
+    expect(getNormalizedLimit(request({ limit: 12.9 }), 25)).toBe(12)
+    expect(getNormalizedLimit(request({ limit: 0 }), 25)).toBe(1)
+    expect(getNormalizedLimit(request({ limit: 500 }), 25, 100)).toBe(100)
+    expect(getNormalizedLimit(request({ limit: 'not-a-number' }), 25)).toBe(25)
+    expect(getNormalizedLimit(request({ limit: Number.POSITIVE_INFINITY }), 25)).toBe(25)
+  })
+
+  it('keeps only string entries from provider paths', () => {
+    expect(getProviderPath(request({}, ['lastfm', 42, null, 'musicbrainz']))).toEqual([
+      'lastfm',
+      'musicbrainz',
+    ])
+    expect(getProviderPath(request({}, 'lastfm'))).toEqual([])
+  })
+
+  it('normalizes discovery names for comparison', () => {
+    expect(normalizeDiscoveryName('  Boards Of Canada  ')).toBe('boards of canada')
+  })
+
+  it('parses string and object seed formats while dropping blank or malformed entries', () => {
+    expect(parseSeeds(' Radiohead, , Portishead ')).toEqual([
+      { name: 'Radiohead' },
+      { name: 'Portishead' },
+    ])
+    expect(
+      parseSeeds([
+        '  Bjork ',
+        { name: ' Massive Attack ', mbid: 'artist-mbid' },
+        { name: 'Air', mbid: 42 },
+        { name: ' ' },
+        { title: 'wrong shape' },
+        null,
+      ]),
+    ).toEqual([
+      { name: 'Bjork' },
+      { name: 'Massive Attack', mbid: 'artist-mbid' },
+      { name: 'Air', mbid: undefined },
+    ])
+    expect(parseSeeds({ name: 'not-an-array' })).toEqual([])
+  })
+
+  it('delegates connection lookup with the requested user ID', async () => {
+    const connections = { listenbrainzUsername: 'listener' }
+    mockGetUserConnections.mockResolvedValue(connections)
+
+    await expect(getDiscoveryModeConnections(7)).resolves.toBe(connections)
+    expect(mockGetUserConnections).toHaveBeenCalledWith(db, 7)
+  })
+
+  it('returns resolved provider tokens', async () => {
+    mockResolveSpotifyToken.mockResolvedValue('spotify-token')
+    mockResolveDeezerToken.mockResolvedValue('deezer-token')
+
+    await expect(getDiscoveryModeSpotifyToken(7)).resolves.toBe('spotify-token')
+    await expect(getDiscoveryModeDeezerToken(7)).resolves.toBe('deezer-token')
+    expect(mockResolveSpotifyToken).toHaveBeenCalledWith(db, 7)
+    expect(mockResolveDeezerToken).toHaveBeenCalledWith(db, 7)
+  })
+
+  it('returns null when provider token resolution fails', async () => {
+    mockResolveSpotifyToken.mockRejectedValue(new Error('missing Spotify token'))
+    mockResolveDeezerToken.mockRejectedValue(new Error('missing Deezer token'))
+
+    await expect(getDiscoveryModeSpotifyToken(7)).resolves.toBeNull()
+    await expect(getDiscoveryModeDeezerToken(7)).resolves.toBeNull()
+  })
+})

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -46,6 +46,24 @@ const { mockCreateEmbyClient } = vi.hoisted(() => ({
   })),
 }))
 
+const { mockCreatePlexClient } = vi.hoisted(() => ({
+  mockCreatePlexClient: vi.fn(() => ({
+    testConnection: vi.fn(async () => ({
+      success: true,
+      message: 'Connected to Plex',
+    })),
+  })),
+}))
+
+const { mockCreateJellyfinClient } = vi.hoisted(() => ({
+  mockCreateJellyfinClient: vi.fn(() => ({
+    testConnection: vi.fn(async () => ({
+      success: true,
+      message: 'Connected to Jellyfin',
+    })),
+  })),
+}))
+
 const { mockCreateSubsonicClient } = vi.hoisted(() => ({
   mockCreateSubsonicClient: vi.fn(() => ({
     testConnection: vi.fn(async () => ({
@@ -112,6 +130,14 @@ vi.mock('@/core/clients/lastfm', () => ({
 
 vi.mock('@/core/clients/emby', () => ({
   createEmbyClient: mockCreateEmbyClient,
+}))
+
+vi.mock('@/core/clients/plex', () => ({
+  createPlexClient: mockCreatePlexClient,
+}))
+
+vi.mock('@/core/clients/jellyfin', () => ({
+  createJellyfinClient: mockCreateJellyfinClient,
 }))
 
 vi.mock('@/core/clients/subsonic', () => ({
@@ -841,6 +867,96 @@ describe('POST /api/v1/settings/test/:service', () => {
     expect(mockCreateEmbyClient).toHaveBeenCalledWith('http://127.0.0.1:8096', 'key', 'user-1', {
       skipTlsVerify: false,
       libraryId: null,
+    })
+  })
+
+  it.each([
+    ['explicit', { sectionId: 'music-1' }, 'music-1'],
+    ['empty', { sectionId: '' }, ''],
+    ['omitted', {}, 'stored-music'],
+  ])('passes the %s Plex library selection to the client', async (_case, selection, expected) => {
+    mockCreatePlexClient.mockClear()
+    mockGetUserConnections.mockResolvedValueOnce({
+      ...defaultUserConnections,
+      plexSectionId: 'stored-music',
+    })
+    const app = createApp(makeDeps())
+
+    const res = await authedRequest(app, '/api/v1/settings/test/plex', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'http://plex:32400',
+        token: 'plex-token',
+        ...selection,
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockCreatePlexClient).toHaveBeenCalledWith('http://plex:32400', 'plex-token', {
+      sectionId: expected,
+    })
+  })
+
+  it.each([
+    ['explicit', { libraryId: 'music-1' }, 'music-1'],
+    ['empty', { libraryId: '' }, ''],
+    ['omitted', {}, 'stored-music'],
+  ])('passes the %s Jellyfin library selection to the client', async (_case, selection, expected) => {
+    mockCreateJellyfinClient.mockClear()
+    mockGetUserConnections.mockResolvedValueOnce({
+      ...defaultUserConnections,
+      jellyfinLibraryId: 'stored-music',
+    })
+    const app = createApp(makeDeps())
+
+    const res = await authedRequest(app, '/api/v1/settings/test/jellyfin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'http://jellyfin:8096',
+        apiKey: 'jellyfin-key',
+        userId: 'user-1',
+        ...selection,
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockCreateJellyfinClient).toHaveBeenCalledWith(
+      'http://jellyfin:8096',
+      'jellyfin-key',
+      'user-1',
+      { skipTlsVerify: false, libraryId: expected },
+    )
+  })
+
+  it.each([
+    ['explicit', { libraryId: 'music-1' }, 'music-1'],
+    ['empty', { libraryId: '' }, ''],
+    ['omitted', {}, 'stored-music'],
+  ])('passes the %s Emby library selection to the client', async (_case, selection, expected) => {
+    mockCreateEmbyClient.mockClear()
+    mockGetUserConnections.mockResolvedValueOnce({
+      ...defaultUserConnections,
+      embyLibraryId: 'stored-music',
+    })
+    const app = createApp(makeDeps())
+
+    const res = await authedRequest(app, '/api/v1/settings/test/emby', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'http://emby:8096',
+        apiKey: 'emby-key',
+        userId: 'user-1',
+        ...selection,
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockCreateEmbyClient).toHaveBeenCalledWith('http://emby:8096', 'emby-key', 'user-1', {
+      skipTlsVerify: false,
+      libraryId: expected,
     })
   })
 


### PR DESCRIPTION
## Summary

- cover explicit, empty, and omitted library selections for Plex, Jellyfin, and Emby probes
- directly test discovery runtime limits, provider paths, name/seed normalization, connection lookup, and token fallbacks
- keep production behavior unchanged

## Test plan

- `bun run test tests/core/discovery-modes/runtime.test.ts tests/server/routes/settings.test.ts` (64 passed)
- `bun run typecheck`
- `bun run lint` (only the nine pre-existing warnings handled separately)
- `bun run test` (303 files passed, 4 skipped; 2761 tests passed, 26 skipped)
- staged secret/static scans and full review
