### PR TITLE
chore(lint): clear biome warnings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
   "files": {
     "includes": [
       "**",

--- a/src/core/providers/anthropic.ts
+++ b/src/core/providers/anthropic.ts
@@ -94,7 +94,7 @@ export class AnthropicProvider implements RecommendationProvider {
     // Fallback: some proxy deployments drop tool_use support - parse any text
     // block as a JSON array the old way.
     const firstContent = response.content[0]
-    if (!firstContent || firstContent.type !== 'text') {
+    if (firstContent?.type !== 'text') {
       throw new Error('Unexpected response format from Anthropic API')
     }
     return parseRecommendationResponse(firstContent.text)

--- a/src/db/queries/subscriptions.ts
+++ b/src/db/queries/subscriptions.ts
@@ -95,7 +95,7 @@ export async function getSubscriptionBatchStats(
   batchId: number,
 ): Promise<{ added: number } | null> {
   const batch = await getBatch(db, batchId)
-  if (!batch || !batch.stats || typeof batch.stats !== 'object') {
+  if (!batch?.stats || typeof batch.stats !== 'object') {
     return null
   }
 

--- a/src/server/routes/artists.ts
+++ b/src/server/routes/artists.ts
@@ -90,7 +90,7 @@ export function artistRoutes(deps: AppDependencies) {
     rateLimiter({ windowMs: 60_000, max: 30, keyPrefix: 'preview' }),
     async (c) => {
       const url = c.req.query('url')
-      if (!url || !url.match(/^https:\/\/cdn[st]-?preview[a-z0-9-]*\.dzcdn\.net\//)) {
+      if (!url?.match(/^https:\/\/cdn[st]-?preview[a-z0-9-]*\.dzcdn\.net\//)) {
         return c.json({ error: 'Invalid preview URL' }, 400)
       }
       try {

--- a/src/server/routes/oauth.ts
+++ b/src/server/routes/oauth.ts
@@ -115,7 +115,7 @@ export function oauthRoutes(deps: AppDependencies) {
         // Resolve userId from server-side pending token, not from the URL state param.
         // The pending token stores `pending:{userId}:{opaqueState}` and state is just the opaque part.
         const pending = await findPendingOAuthByState(deps.db, 'spotify', state)
-        if (!pending || !pending.accessToken.startsWith('pending:')) {
+        if (!pending?.accessToken.startsWith('pending:')) {
           return c.redirect('/settings?oauth_error=no_pending_auth')
         }
         const userId = pending.userId
@@ -201,7 +201,7 @@ export function oauthRoutes(deps: AppDependencies) {
       }
       case 'deezer': {
         const deezerPending = await findPendingOAuthByState(deps.db, 'deezer', state)
-        if (!deezerPending || !deezerPending.accessToken.startsWith('pending:')) {
+        if (!deezerPending?.accessToken.startsWith('pending:')) {
           return c.redirect('/settings?oauth_error=no_pending_auth')
         }
         const deezerUserId = deezerPending.userId

--- a/src/web/components/streaming-links.tsx
+++ b/src/web/components/streaming-links.tsx
@@ -74,7 +74,7 @@ type SpotifyEmbedProps = {
 
 function extractSpotifyId(url: string): { type: string; id: string } | null {
   const match = url.match(/spotify\.com\/(artist|album|track)\/([A-Za-z0-9]+)/)
-  if (!match || !match[1] || !match[2]) return null
+  if (!match?.[1] || !match[2]) return null
   return { type: match[1], id: match[2] }
 }
 

--- a/src/web/pages/dashboard.tsx
+++ b/src/web/pages/dashboard.tsx
@@ -258,7 +258,7 @@ function RecentActivity({
   data: { tracks: RecentTrackEntry[]; hasSource: boolean } | undefined
 }) {
   const { t, locale } = useI18n()
-  if (!data || !data.hasSource) return null
+  if (!data?.hasSource) return null
   return (
     <div>
       <h2 className="text-sm font-semibold text-text uppercase tracking-wide mb-3">

--- a/tests/unit/db-connect.test.ts
+++ b/tests/unit/db-connect.test.ts
@@ -30,7 +30,7 @@ describe('connectTarget', () => {
     const r = await t.db.execute(
       sql`select count(*)::int n from information_schema.tables where table_name='users'`,
     )
-    expect((r as unknown as { rows: { n: number }[] }).rows[0]!.n).toBe(1)
+    expect((r as unknown as { rows: { n: number }[] }).rows[0]?.n).toBe(1)
     await t.close()
   })
 

--- a/tests/unit/migrate-backend.test.ts
+++ b/tests/unit/migrate-backend.test.ts
@@ -6,6 +6,8 @@ import { migrateBackend } from '@/core/ops/migrate-backend'
 import * as schema from '@/db/schema'
 import { makeTestDb } from '../helpers/test-db'
 
+type TestDatabase = Awaited<ReturnType<typeof makeTestDb>>['db']
+
 // PGlite WASM cold-start + migrations can exceed the 5s default under full-suite
 // parallel contention; these tests pass in isolation. Give them headroom.
 vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 })
@@ -15,7 +17,7 @@ function tgt(name: string) {
 }
 
 // Seed a minimal but representative dataset (user + a couple stateful rows).
-async function seedFullFixtures(db: any) {
+async function seedFullFixtures(db: TestDatabase) {
   const [user] = await db
     .insert(schema.users)
     .values({ username: 'mig', passwordHash: 'x' })


### PR DESCRIPTION
## Summary

- align the Biome schema with the installed CLI
- apply equivalent optional-chain guards at all reported sites
- replace unsafe test assertions and `any` with precise fixture typing

## Verification

- `bun run lint` (zero warnings)
- `bun run typecheck`
- 95 focused tests
- full suite: 302 files passed, 4 skipped; 2,745 tests passed, 26 skipped
- `bun run i18n:check`
- `bun run check:api-docs`
- `bun run check:versions`
- Gitleaks, Semgrep, and Trivy secret scans

The first full-suite run hit the known timing-sensitive auth test timeout. The
auth file passed 13/13 in isolation, and the clean full-suite retry passed.
