### PR TITLE
perf(ops): bound backend migration memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Releases that have been promoted to the `:stable` Docker channel carry a `(stabl
 
 - **Genre backfill for non-Spotify listening sources.** Discovery-only scans now use genre metadata already returned by Plex, Jellyfin, Emby, and Discogs, then fill remaining gaps from synchronized library rows and the artist cache. After the foreground scan finishes, a maintenance-aware background warmer enriches at most 10 artists through the existing MusicBrainz rate gate, with optional Last.fm top-tag fallback and 180-day negative caching. Ambiguous name-only matches are skipped. Dashboard and Settings show covered and pending listening artists, translated across all 15 shipped locales.
 
+### Changed
+
+- **Database backend migration now copies and verifies one table at a time.** The admin migration tool no longer holds whole-source and whole-target backup objects in application memory. It keeps the consistent read-only source transaction and atomic target transaction, restores in bounded chunks, and reports the same count/content verification result while the working set follows the largest individual table.
+
 ## v1.12.0 - 2026-07-05
 
 AI provider problems are now visible everywhere they matter, plus a batch of Lidarr, library-sync, and OIDC fixes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,10 +51,14 @@ default to external PostgreSQL; PGlite is opt-in there (Helm
 **In-app backend migration.** Admins can switch between PGlite and external
 PostgreSQL through Settings -> Administration -> Migrate Database Backend without
 stopping the server or writing SQL. The tool (`src/core/ops/migrate-backend.ts`)
-takes a consistent read-only snapshot of the source inside a `REPEATABLE READ
-READ ONLY` transaction, runs schema migrations on the target, restores the
-snapshot atomically, then verifies every table by row count and SHA-256 content
-hash before returning a `MigrationReport`. During the copy, `maintenanceMiddleware`
+runs schema migrations on the target, then opens a consistent source view inside
+a `REPEATABLE READ READ ONLY` transaction and copies the restore registry in
+foreign key order inside one target transaction. Each table is selected, restored in
+chunks, and verified by row count and SHA-256 content hash before the next table
+is loaded. The process does not retain whole-source or whole-target backup
+objects, so its working set follows the largest individual table instead of the
+whole database. A write failure rolls back the target copy transaction before a
+`MigrationReport` is returned. During the copy, `maintenanceMiddleware`
 blocks all write methods (`POST/PUT/PATCH/DELETE`) on non-migration routes,
 returning `503 Maintenance in progress`; reads pass through. Background
 schedulers check the same flag (`isMaintenance()` in `src/core/ops/maintenance.ts`)

--- a/docs/guides/switching-backends.md
+++ b/docs/guides/switching-backends.md
@@ -83,24 +83,32 @@ Click **Migrate**. The operation:
 
 1. Freezes writes on all non-migration routes and pauses background scheduler
    ticks (maintenance lock).
-2. Takes a consistent, read-only snapshot of the source database inside a
-   `REPEATABLE READ READ ONLY` transaction.
-3. Runs schema migrations on the target (creates all tables).
-4. Restores the snapshot atomically into the target.
-5. Verifies every table by row count and SHA-256 content hash.
+2. Runs schema migrations on the target (creates all tables).
+3. Opens a consistent `REPEATABLE READ READ ONLY` transaction on the source.
+4. Copies tables in foreign-key order inside one target transaction, using
+   bounded insert chunks.
+5. Verifies each table by row count and SHA-256 content hash before loading the
+   next table.
 6. Releases the maintenance lock.
 
 The source database is **never modified**. If anything goes wrong, the target is
-left in a partial state and the source is intact; retry after fixing the
+copy transaction rolls back. Target schema migrations and, during an overwrite,
+the intentional session/rate-limit clear remain outside that transaction. A
+verification mismatch keeps the copied target for inspection but returns a
+failed report, so do not switch the application to it. Retry after fixing the
 underlying problem.
+
+The migration does not build whole-database source and target snapshots in
+application memory. Its working set follows the largest table being copied and
+verified, rather than the size of the full database.
 
 Progress is shown inline. On a large library the copy may take a minute or two.
 
 ### 5. Read the report
 
-On success, the panel shows a table of tables migrated and their row counts, plus
-a summary of what was excluded (see below). Any mismatches between source and
-target counts appear here with details.
+On success, the panel shows every migrated table and its row count, plus a
+summary of what was excluded (see below). Count and same-count content mismatches
+appear in the failed report with details.
 
 ### 6. Set the env var and restart
 

--- a/src/core/ops/backup.ts
+++ b/src/core/ops/backup.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { getTableColumns, getTableName, sql } from 'drizzle-orm'
@@ -73,6 +74,18 @@ type BackupTable =
   | typeof targets
   | typeof users
 
+export type DatabaseCopyMismatch = {
+  table: string
+  source: number
+  target: number
+  contentDiffers?: boolean
+}
+
+export type DatabaseCopyResult = {
+  tablesRestored: Record<string, number>
+  mismatches: DatabaseCopyMismatch[]
+}
+
 function getAppVersion(): string {
   try {
     const pkg = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf-8'))
@@ -87,6 +100,25 @@ async function selectAll(
   table: BackupTable,
 ): Promise<Record<string, unknown>[]> {
   return db.select().from(table as AnyPgTable) as unknown as Record<string, unknown>[]
+}
+
+function canonical(value: unknown): unknown {
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'bigint') return value.toString()
+  if (Array.isArray(value)) return value.map(canonical)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value as Record<string, unknown>)
+        .sort()
+        .map((key) => [key, canonical((value as Record<string, unknown>)[key])]),
+    )
+  }
+  return value
+}
+
+function tableHash(rows: Record<string, unknown>[]): string {
+  const canonicalRows = rows.map((row) => JSON.stringify(canonical(row))).sort()
+  return createHash('sha256').update(canonicalRows.join('\n')).digest('hex')
 }
 
 export async function createBackup(
@@ -320,6 +352,48 @@ const RESTORE_ORDER = [
 export const BACKUP_TABLE_BY_KEY = Object.fromEntries(
   RESTORE_ORDER.map((spec) => [spec.key as keyof BackupData, spec.table]),
 ) as Partial<Record<keyof BackupData, AnyPgTable>>
+
+export async function copyDatabaseTables(
+  source: Pick<OpsDb, 'select'>,
+  target: OpsDb,
+): Promise<DatabaseCopyResult> {
+  const tablesRestored: Record<string, number> = {}
+  const mismatches: DatabaseCopyMismatch[] = []
+
+  await target.transaction(async (tx) => {
+    for (const spec of [...RESTORE_ORDER].reverse()) {
+      await spec.clear(tx)
+    }
+
+    for (const spec of RESTORE_ORDER) {
+      const sourceRows = await selectAll(source, spec.table)
+      await spec.restore(tx, sourceRows)
+      await spec.resetSequence(tx)
+      tablesRestored[spec.key] = sourceRows.length
+
+      const countResult = await tx.execute(
+        sql`select count(*)::int n from ${sql.identifier(getTableName(spec.table))}`,
+      )
+      const targetCount = (countResult as unknown as { rows: { n: number }[] }).rows[0]?.n ?? 0
+      if (targetCount !== sourceRows.length) {
+        mismatches.push({ table: spec.key, source: sourceRows.length, target: targetCount })
+        continue
+      }
+
+      const targetRows = await selectAll(tx, spec.table)
+      if (tableHash(sourceRows) !== tableHash(targetRows)) {
+        mismatches.push({
+          table: spec.key,
+          source: sourceRows.length,
+          target: targetCount,
+          contentDiffers: true,
+        })
+      }
+    }
+  })
+
+  return { tablesRestored, mismatches }
+}
 
 function detectEncryptionMismatch(backup: BackupFile): { mismatch: boolean; fields: string[] } {
   const currentFp = getKeyFingerprint()

--- a/src/core/ops/migrate-backend.ts
+++ b/src/core/ops/migrate-backend.ts
@@ -1,9 +1,7 @@
-import { createHash } from 'node:crypto'
-import { getTableName, sql } from 'drizzle-orm'
-import type { AnyPgTable } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
 import type { Database } from '@/db'
 import { backendFingerprint, connectTarget, type MigrationTargetSpec } from '@/db/connect'
-import { BACKUP_TABLE_BY_KEY, createBackup, restoreBackup } from './backup'
+import { copyDatabaseTables } from './backup'
 
 /** A known precondition failure (not a crash). `code` lets the HTTP layer map it
  *  to a meaningful status. Messages never contain credentials. */
@@ -49,26 +47,6 @@ function envHint(target: MigrationTargetSpec): string {
     return `Unset DATABASE_URL/DB_HOST and set DB_PATH=${target.path}, then restart.`
   }
   return 'Set DATABASE_URL to the PostgreSQL connection string you entered above, then restart.'
-}
-
-function canonical(v: unknown): unknown {
-  if (v instanceof Date) return v.toISOString()
-  if (typeof v === 'bigint') return v.toString() // JSON.stringify can't serialize BigInt
-  if (Array.isArray(v)) return v.map(canonical)
-  if (v && typeof v === 'object') {
-    return Object.fromEntries(
-      Object.keys(v as Record<string, unknown>)
-        .sort()
-        .map((k) => [k, canonical((v as Record<string, unknown>)[k])]),
-    )
-  }
-  return v
-}
-
-function tableHash(rows: Record<string, unknown>[]): string {
-  const canon = rows.map((r) => JSON.stringify(canonical(r)))
-  canon.sort()
-  return createHash('sha256').update(canon.join('\n')).digest('hex')
 }
 
 export async function migrateBackend(input: MigrateBackendInput): Promise<MigrationReport> {
@@ -130,61 +108,24 @@ export async function migrateBackend(input: MigrateBackendInput): Promise<Migrat
       )
     }
 
-    const backup = await sourceDb.transaction(async (tx) => {
+    const copy = await sourceDb.transaction(async (tx) => {
       await tx.execute(sql`set transaction isolation level repeatable read read only`)
-      return createBackup(tx, { includeCaches: true, full: true })
+      return copyDatabaseTables(tx, conn.db)
     })
 
-    const restore = await restoreBackup(conn.db, backup, {})
-    if (restore.encryptionMismatch) {
-      // Unreachable here (same-process key fingerprint always matches); kept because
-      // restoreBackup is shared with file-based restore where a mismatch is real.
-      throw new MigrateBackendError(
-        'encryption_mismatch',
-        'Cannot migrate: the source data was encrypted with a different key than the current DIGARR_ENCRYPTION_KEY. Set the same encryption key before migrating.',
-      )
-    }
-
-    const targetBackup = await createBackup(conn.db, { includeCaches: true, full: true })
-    const mismatches: MigrationReport['mismatches'] = []
-    for (const [key, rows] of Object.entries(backup.data)) {
-      if (!Array.isArray(rows)) continue
-      const table = BACKUP_TABLE_BY_KEY[key as keyof typeof BACKUP_TABLE_BY_KEY]
-      if (!table) continue
-      const got = await conn.db.execute(
-        sql`select count(*)::int n from ${sql.identifier(getTableName(table as AnyPgTable))}`,
-      )
-      const targetCount = (got as unknown as { rows: { n: number }[] }).rows[0]?.n ?? 0
-      if (targetCount !== rows.length) {
-        mismatches.push({ table: key, source: rows.length, target: targetCount })
-        continue
-      }
-      const tgtRows =
-        (targetBackup.data[key as keyof typeof targetBackup.data] as Record<string, unknown>[]) ??
-        []
-      if (tableHash(rows) !== tableHash(tgtRows)) {
-        mismatches.push({
-          table: key,
-          source: rows.length,
-          target: targetCount,
-          contentDiffers: true,
-        })
-      }
-    }
-
-    const verified = mismatches.length === 0
+    const verified = copy.mismatches.length === 0
     // A count mismatch leaves content unchecked, so contentVerified must require
     // verified too — otherwise a missing table reports intact content.
-    const contentVerified = verified && !mismatches.some((m) => m.contentDiffers)
+    const contentVerified = verified && !copy.mismatches.some((m) => m.contentDiffers)
     return {
       ok: verified,
       verified,
       contentVerified,
       targetBackend: conn.backend,
       targetDescription: conn.describe(),
-      tablesMigrated: restore.tablesRestored,
+      tablesMigrated: copy.tablesRestored,
       excludedTables: [...EXCLUDED_TABLES],
-      mismatches,
+      mismatches: copy.mismatches,
       targetEnvHint: envHint(target),
     }
   } finally {

--- a/tests/unit/migrate-backend-failure.test.ts
+++ b/tests/unit/migrate-backend-failure.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { sql } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as schema from '@/db/schema'
 import { makeTestDb } from '../helpers/test-db'
@@ -9,17 +10,20 @@ import { makeTestDb } from '../helpers/test-db'
 // parallel contention; these failure paths still spin up a real target.
 vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 })
 
-// Keep createBackup + BACKUP_TABLE_BY_KEY real (the verification loop and the
-// source snapshot rely on them); override only restoreBackup so we can simulate
-// a target that diverges from the source after the copy, or a restore that
-// blows up mid-flight.
+const copyDatabaseTables = vi.hoisted(() => vi.fn())
+
 vi.mock('@/core/ops/backup', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/core/ops/backup')>()
-  return { ...actual, restoreBackup: vi.fn() }
+  return {
+    ...actual,
+    copyDatabaseTables,
+    createBackup: vi.fn(actual.createBackup),
+    restoreBackup: vi.fn(actual.restoreBackup),
+  }
 })
 
 const { migrateBackend } = await import('@/core/ops/migrate-backend')
-const { restoreBackup } = await import('@/core/ops/backup')
+const { createBackup, restoreBackup } = await import('@/core/ops/backup')
 
 function tgt(name: string) {
   return join(process.env.DIGARR_MIGRATE_DATA_ROOT as string, name)
@@ -28,27 +32,55 @@ function tgt(name: string) {
 describe('migrateBackend failure paths', () => {
   beforeEach(() => {
     process.env.DIGARR_MIGRATE_DATA_ROOT = mkdtempSync(join(tmpdir(), 'digarr-migfail-'))
-    vi.mocked(restoreBackup).mockReset()
+    copyDatabaseTables.mockReset()
+    vi.mocked(createBackup).mockClear()
+    vi.mocked(restoreBackup).mockClear()
   })
   afterEach(() => {
     delete process.env.DIGARR_MIGRATE_DATA_ROOT
   })
 
-  it('reports ok:false with mismatches when the target is missing rows after restore', async () => {
+  it('delegates the copy from a repeatable-read, read-only source transaction', async () => {
     const src = await makeTestDb()
     try {
       await src.db.insert(schema.users).values({ username: 'mig', passwordHash: 'x' })
-      await src.db
-        .insert(schema.genres)
-        .values({ name: 'Synthwave', slug: 'synthwave', source: 'manual' })
+      copyDatabaseTables.mockImplementation(async (sourceTx) => {
+        const isolation = await sourceTx.execute(sql`show transaction_isolation`)
+        const readOnly = await sourceTx.execute(sql`show transaction_read_only`)
+        expect(
+          (isolation as unknown as { rows: { transaction_isolation: string }[] }).rows[0]
+            ?.transaction_isolation,
+        ).toBe('repeatable read')
+        expect(
+          (readOnly as unknown as { rows: { transaction_read_only: string }[] }).rows[0]
+            ?.transaction_read_only,
+        ).toBe('on')
+        return { tablesRestored: { users: 1 }, mismatches: [] }
+      })
 
-      // No-op restore: the freshly created target stays empty, so the post-copy
-      // verification must detect the row-count mismatch and refuse to claim success.
-      vi.mocked(restoreBackup).mockResolvedValue({
-        tablesRestored: {},
-        warnings: [],
-        encryptionMismatch: false,
-        affectedEncryptedFields: [],
+      const report = await migrateBackend({
+        sourceDb: src.db as never,
+        target: { backend: 'pglite', path: tgt('delegated') },
+        isPipelineRunning: () => false,
+      })
+
+      expect(copyDatabaseTables).toHaveBeenCalledOnce()
+      expect(createBackup).not.toHaveBeenCalled()
+      expect(restoreBackup).not.toHaveBeenCalled()
+      expect(report.tablesMigrated).toEqual({ users: 1 })
+      expect(report.verified).toBe(true)
+    } finally {
+      await src.close()
+    }
+  })
+
+  it('reports ok:false when the table copy reports a mismatch', async () => {
+    const src = await makeTestDb()
+    try {
+      await src.db.insert(schema.users).values({ username: 'mig', passwordHash: 'x' })
+      copyDatabaseTables.mockResolvedValue({
+        tablesRestored: { users: 1 },
+        mismatches: [{ table: 'users', source: 1, target: 1, contentDiffers: true }],
       })
 
       const report = await migrateBackend({
@@ -60,19 +92,19 @@ describe('migrateBackend failure paths', () => {
       expect(report.ok).toBe(false)
       expect(report.verified).toBe(false)
       expect(report.contentVerified).toBe(false)
-      expect(report.mismatches.length).toBeGreaterThan(0)
-      const users = report.mismatches.find((m) => m.table === 'users')
-      expect(users).toMatchObject({ source: 1, target: 0 })
+      expect(report.mismatches).toEqual([
+        { table: 'users', source: 1, target: 1, contentDiffers: true },
+      ])
     } finally {
       await src.close()
     }
   })
 
-  it('rejects (no silent ok:true) when restoreBackup throws mid-restore', async () => {
+  it('rejects when the table copy throws mid-transaction', async () => {
     const src = await makeTestDb()
     try {
       await src.db.insert(schema.users).values({ username: 'mig', passwordHash: 'x' })
-      vi.mocked(restoreBackup).mockRejectedValue(new Error('constraint violation mid-restore'))
+      copyDatabaseTables.mockRejectedValue(new Error('constraint violation mid-copy'))
 
       await expect(
         migrateBackend({
@@ -80,7 +112,7 @@ describe('migrateBackend failure paths', () => {
           target: { backend: 'pglite', path: tgt('throw') },
           isPipelineRunning: () => false,
         }),
-      ).rejects.toThrow(/constraint violation mid-restore/)
+      ).rejects.toThrow(/constraint violation mid-copy/)
     } finally {
       await src.close()
     }

--- a/tests/unit/migrate-backend.test.ts
+++ b/tests/unit/migrate-backend.test.ts
@@ -1,7 +1,9 @@
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { sql } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BACKUP_TABLE_BY_KEY, copyDatabaseTables } from '@/core/ops/backup'
 import { migrateBackend } from '@/core/ops/migrate-backend'
 import * as schema from '@/db/schema'
 import { makeTestDb } from '../helpers/test-db'
@@ -22,9 +24,58 @@ async function seedFullFixtures(db: TestDatabase) {
     .insert(schema.users)
     .values({ username: 'mig', passwordHash: 'x' })
     .returning()
+  if (!user) throw new Error('user insert failed')
   await db.insert(schema.settings).values({ setupComplete: true })
   await db.insert(schema.genres).values({ name: 'Synthwave', slug: 'synthwave', source: 'manual' })
-  return user
+  const [artist] = await db
+    .insert(schema.artists)
+    .values({ mbid: '00000000-0000-0000-0000-000000000001', name: 'Migration Artist' })
+    .returning()
+  if (!artist) throw new Error('artist insert failed')
+  await db.insert(schema.artistBlocks).values({ userId: user.id, artistId: artist.id })
+  const [playlist] = await db
+    .insert(schema.playlists)
+    .values({ userId: user.id, name: 'Migration Playlist', strategy: 'weekly_digest' })
+    .returning()
+  if (!playlist) throw new Error('playlist insert failed')
+  await db.insert(schema.playlistTracks).values({
+    playlistId: playlist.id,
+    artistName: artist.name,
+    trackName: 'Migration Track',
+    position: 1,
+  })
+  await db.insert(schema.libraryArtists).values({
+    userId: user.id,
+    source: 'lidarr',
+    sourceArtistId: 'migration-artist',
+    name: artist.name,
+    nameNormalized: 'migration artist',
+  })
+  await db.insert(schema.recordingArtistCache).values({
+    recordingMbid: '00000000-0000-0000-0000-000000000002',
+    artistMbid: artist.mbid,
+    artistName: artist.name,
+  })
+  return { user, artist, playlist }
+}
+
+async function installUserTrigger(db: TestDatabase, name: string, body: string) {
+  await db.execute(
+    sql.raw(`
+    CREATE FUNCTION ${name}() RETURNS trigger AS $$
+    BEGIN
+      ${body}
+    END;
+    $$ LANGUAGE plpgsql
+  `),
+  )
+  await db.execute(
+    sql.raw(`
+    CREATE TRIGGER ${name}
+    BEFORE INSERT ON users
+    FOR EACH ROW EXECUTE FUNCTION ${name}()
+  `),
+  )
 }
 
 describe('migrateBackend', () => {
@@ -59,10 +110,90 @@ describe('migrateBackend', () => {
     expect(report.verified).toBe(true)
     expect(report.contentVerified).toBe(true)
     expect(report.tablesMigrated.users).toBeGreaterThan(0)
+    expect(Object.keys(report.tablesMigrated).sort()).toEqual(
+      Object.keys(BACKUP_TABLE_BY_KEY).sort(),
+    )
     expect(report.excludedTables).toEqual(['sessions', 'rateLimitBuckets'])
     expect(report.mismatches).toEqual([])
     expect(report.targetEnvHint).toMatch(/DB_PATH=/)
     await src.close()
+  })
+
+  it('reports a row-count mismatch from the copied table', async () => {
+    const src = await makeTestDb()
+    const target = await makeTestDb()
+    try {
+      await src.db.insert(schema.users).values({ username: 'mig', passwordHash: 'x' })
+      await installUserTrigger(target.db, 'skip_migrated_user', 'RETURN NULL;')
+
+      const result = await copyDatabaseTables(src.db as never, target.db as never)
+
+      expect(result.mismatches).toContainEqual({ table: 'users', source: 1, target: 0 })
+    } finally {
+      await src.close()
+      await target.close()
+    }
+  })
+
+  it('reports a content mismatch when row counts agree', async () => {
+    const src = await makeTestDb()
+    const target = await makeTestDb()
+    try {
+      await src.db.insert(schema.users).values({ username: 'mig', passwordHash: 'x' })
+      await installUserTrigger(
+        target.db,
+        'mutate_migrated_user',
+        "NEW.username := NEW.username || '-changed'; RETURN NEW;",
+      )
+
+      const result = await copyDatabaseTables(src.db as never, target.db as never)
+
+      expect(result.mismatches).toContainEqual({
+        table: 'users',
+        source: 1,
+        target: 1,
+        contentDiffers: true,
+      })
+    } finally {
+      await src.close()
+      await target.close()
+    }
+  })
+
+  it('rolls back the target when a later table fails to restore', async () => {
+    const src = await makeTestDb()
+    const target = await makeTestDb()
+    try {
+      await src.db.insert(schema.users).values({ username: 'copied', passwordHash: 'x' })
+      await target.db.insert(schema.users).values({ username: 'survivor', passwordHash: 'x' })
+      const failingSource = {
+        select: () => ({
+          from: async (table: unknown) => {
+            if (table === schema.slskdJobs) {
+              return [
+                {
+                  id: 1,
+                  userId: 999,
+                  targetId: 999,
+                  sourceType: 'recommendation',
+                  workKey: 'invalid-job',
+                  artistMbid: '00000000-0000-0000-0000-000000000003',
+                  artistName: 'Invalid Artist',
+                  releaseTitle: 'Invalid Release',
+                },
+              ]
+            }
+            return src.db.select().from(table as never)
+          },
+        }),
+      }
+
+      await expect(copyDatabaseTables(failingSource as never, target.db as never)).rejects.toThrow()
+      expect(await target.db.select().from(schema.users)).toMatchObject([{ username: 'survivor' }])
+    } finally {
+      await src.close()
+      await target.close()
+    }
   })
 
   it('refuses a non-empty target without overwrite, succeeds with overwrite', async () => {


### PR DESCRIPTION
## Summary

- replace whole-database source/target backup objects with table-scoped copy and verification
- preserve the repeatable-read source view and single atomic target transaction
- reuse the existing foreign-key registry, conflict targets, sequence resets, genre ordering, and chunked writes
- document the real runtime order, rollback boundary, mismatch behavior, and largest-table memory bound

## Tests

- TDD red/green coverage for delegation, count mismatch, content mismatch, and late-table rollback
- `bun run lint`
- `bun run typecheck`
- full suite: 303 files passed, 4 skipped; 2,765 tests passed, 26 skipped
- `bun run build`
- `bun run i18n:check`
- `bun run check:api-docs`
- `bun run check:versions`
- Gitleaks, Semgrep, and Trivy secret scans

`sessions` and `rateLimitBuckets` remain intentionally excluded. File-based
backup/restore behavior is unchanged.
