### PR TITLE
refactor(targets): share safe HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Releases that have been promoted to the `:stable` Docker channel carry a `(stabl
 ### Changed
 
 - **Database backend migration now copies and verifies one table at a time.** The admin migration tool no longer holds whole-source and whole-target backup objects in application memory. It keeps the consistent read-only source transaction and atomic target transaction, restores in bounded chunks, and reports the same count/content verification result while the working set follows the largest individual table.
+- **Playlist targets now share one safe HTTP transport policy.** Jellyfin, Emby, Plex, and Navidrome playlist requests use the shared timeout, TLS, JSON parsing, response-body error, and credential-redaction path. Read-only requests and best-effort metadata updates may retry; duplicate-producing playlist creation and song-add requests make exactly one attempt, including Subsonic's GET-shaped mutation endpoints.
 
 ## v1.12.0 - 2026-07-05
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,11 +148,12 @@ Albums are a first-class recommendation unit. Key additions:
 ## Key invariants
 
 - Config precedence: DB settings (single row, `id=1`) override env vars. Per-user credentials live on the `users` table; global settings are the fallback.
-- Provider and metadata reads normally go through `createHttpClient()` in
-  `src/core/clients/http.ts` for timeout, retry/backoff, redaction, and optional
-  TLS-skip behavior. Playlist targets currently keep target-specific fetch
-  wrappers because create/mutate requests cannot inherit generic retries until
-  an idempotency or reconciliation policy exists (tracked in issue #453).
+- Provider, metadata, and playlist-target requests go through
+  `createHttpClient()` in `src/core/clients/http.ts` for timeout, retry/backoff,
+  JSON parsing, response-body errors, redaction, and optional TLS-skip behavior.
+  Read-only calls retain the client retry default. Duplicate-producing playlist
+  creation and song-add calls pass `retries: 0`; this classification is based on
+  endpoint semantics because Subsonic mutations use GET-shaped endpoints.
 - Field-level encryption uses AES-256-GCM with HKDF-derived keys (`src/core/crypto.ts`). Encrypted DB values are prefixed `enc:v1:`. Legacy SHA-256 decryption is retained as a read-path fallback for pre-migration values.
 - Tests run in Node.js (vitest), not Bun. `Bun.serve()`, `Bun.file()` and similar Bun-only APIs are unavailable in tests; password hashing uses `node:crypto` `scrypt`.
 - Migrations are idempotent. Drizzle generates bare DDL, so every generated migration must add `IF NOT EXISTS` / `IF EXISTS` clauses by hand.

--- a/src/core/clients/http.ts
+++ b/src/core/clients/http.ts
@@ -33,6 +33,10 @@ type HttpClientConfig = {
   onRequest?: (method: string, url: string) => void
 }
 
+export type HttpRequestOptions = {
+  retries?: number
+}
+
 export function createHttpClient(config: HttpClientConfig) {
   const {
     baseUrl,
@@ -45,11 +49,17 @@ export function createHttpClient(config: HttpClientConfig) {
     onRequest,
   } = config
 
-  async function send(method: string, path: string, body?: unknown): Promise<Response> {
+  async function send(
+    method: string,
+    path: string,
+    body?: unknown,
+    options: HttpRequestOptions = {},
+  ): Promise<Response> {
     const url = `${baseUrl}${path}`
+    const maxRetries = options.retries ?? retries
     onRequest?.(method, url)
 
-    for (let attempt = 0; attempt <= retries; attempt++) {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
       const controller = new AbortController()
       const timer = setTimeout(() => controller.abort(), timeout)
 
@@ -90,29 +100,34 @@ export function createHttpClient(config: HttpClientConfig) {
         if (res.status >= 400 && res.status < 500) {
           throw new HttpError(res.status, errorBody, url)
         }
-        if (attempt >= retries) {
+        if (attempt >= maxRetries) {
           throw new HttpError(res.status, errorBody, url)
         }
       } catch (err: unknown) {
         clearTimeout(timer)
         if (err instanceof HttpError) {
-          if (err.status >= 500 && attempt < retries) {
+          if (err.status >= 500 && attempt < maxRetries) {
             await sleep(2 ** attempt * 500)
             continue
           }
           throw err
         }
-        if (attempt >= retries) throw err
+        if (attempt >= maxRetries) throw err
         await sleep(2 ** attempt * 500)
       }
     }
 
-    throw new Error(`Request failed after ${retries} retries: ${method} ${redactUrlForLog(url)}`)
+    throw new Error(`Request failed after ${maxRetries} retries: ${method} ${redactUrlForLog(url)}`)
   }
 
-  async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  async function request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    options: HttpRequestOptions = {},
+  ): Promise<T> {
     const url = `${baseUrl}${path}`
-    const res = await send(method, path, body)
+    const res = await send(method, path, body, options)
     const text = await res.text()
     if (!text) {
       throw new HttpError(res.status, 'Expected JSON response body', url)
@@ -124,15 +139,24 @@ export function createHttpClient(config: HttpClientConfig) {
     }
   }
 
-  async function requestVoid(method: string, path: string, body?: unknown): Promise<void> {
-    await send(method, path, body)
+  async function requestVoid(
+    method: string,
+    path: string,
+    body?: unknown,
+    options: HttpRequestOptions = {},
+  ): Promise<void> {
+    await send(method, path, body, options)
   }
 
   return {
-    get: <T>(path: string) => request<T>('GET', path),
-    post: <T>(path: string, body?: unknown) => request<T>('POST', path, body),
-    put: <T>(path: string, body?: unknown) => request<T>('PUT', path, body),
-    delete: (path: string) => requestVoid('DELETE', path),
+    get: <T>(path: string, options?: HttpRequestOptions) =>
+      request<T>('GET', path, undefined, options),
+    post: <T>(path: string, body?: unknown, options?: HttpRequestOptions) =>
+      request<T>('POST', path, body, options),
+    put: <T>(path: string, body?: unknown, options?: HttpRequestOptions) =>
+      request<T>('PUT', path, body, options),
+    delete: (path: string, options?: HttpRequestOptions) =>
+      requestVoid('DELETE', path, undefined, options),
   }
 }
 

--- a/src/core/targets/jellyfin-family-playlist.ts
+++ b/src/core/targets/jellyfin-family-playlist.ts
@@ -1,3 +1,4 @@
+import { createHttpClient, HttpError } from '@/core/clients/http'
 import type { ServiceTestResult } from '@/core/types'
 import { errMsg } from '@/core/validation'
 import { pickBestTrackMatch } from './playlist-match'
@@ -15,41 +16,43 @@ type JellyfinFamilyPlaylistOptions = {
   serviceName: 'Emby' | 'Jellyfin'
 }
 
-async function jellyfinFamilyFetch<T>(
-  config: JellyfinFamilyPlaylistConfig,
-  serviceName: string,
-  path: string,
-  options?: { method?: string; body?: unknown },
-): Promise<T> {
-  const url = `${config.url.replace(/\/+$/, '')}${path}`
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), 10_000)
-  let response: Response
-  try {
-    response = await fetch(url, {
-      method: options?.method ?? 'GET',
-      headers: {
-        'X-Emby-Token': config.apiKey,
-        'Content-Type': 'application/json',
-      },
-      body: options?.body ? JSON.stringify(options.body) : undefined,
-      signal: controller.signal,
-      ...(config.skipTlsVerify ? { tls: { rejectUnauthorized: false } } : {}),
-    })
-  } finally {
-    clearTimeout(timer)
-  }
-  if (!response.ok) {
-    throw new Error(`${serviceName} API ${response.status}: ${await response.text()}`)
-  }
-  return (await response.json()) as T
-}
-
 export function createJellyfinFamilyPlaylistTarget(
   targetId: number,
   config: JellyfinFamilyPlaylistConfig,
   { type, serviceName }: JellyfinFamilyPlaylistOptions,
 ): DestinationTarget {
+  const client = createHttpClient({
+    baseUrl: config.url.replace(/\/+$/, ''),
+    headers: { 'X-Emby-Token': config.apiKey },
+    timeout: 10_000,
+    skipTlsVerify: config.skipTlsVerify,
+  })
+
+  function rethrowProviderError(error: unknown): never {
+    if (error instanceof HttpError) {
+      throw new Error(
+        `${serviceName} API ${error.status}: ${error.body.replaceAll(config.apiKey, '[REDACTED]')}`,
+      )
+    }
+    throw error
+  }
+
+  async function get<T>(path: string): Promise<T> {
+    try {
+      return await client.get<T>(path)
+    } catch (error) {
+      rethrowProviderError(error)
+    }
+  }
+
+  async function postOnce<T>(path: string, body: unknown): Promise<T> {
+    try {
+      return await client.post<T>(path, body, { retries: 0 })
+    } catch (error) {
+      rethrowProviderError(error)
+    }
+  }
+
   async function searchTrack(artistName: string, trackName: string): Promise<string | null> {
     try {
       const params = new URLSearchParams({
@@ -59,9 +62,9 @@ export function createJellyfinFamilyPlaylistTarget(
         Limit: '5',
         Fields: 'Name,AlbumArtist,Artists',
       })
-      const response = await jellyfinFamilyFetch<{
+      const response = await get<{
         Items: Array<{ Id: string; Name: string; AlbumArtist?: string; Artists?: string[] }>
-      }>(config, serviceName, `/Users/${config.userId}/Items?${params.toString()}`)
+      }>(`/Users/${config.userId}/Items?${params.toString()}`)
 
       return pickBestTrackMatch(
         (response.Items ?? []).map((item) => ({
@@ -75,7 +78,8 @@ export function createJellyfinFamilyPlaylistTarget(
         trackName,
       )
     } catch (error) {
-      console.warn(`[${type}] searchTrack transport error:`, {
+      console.warn('playlist search transport error', {
+        type,
         artistName,
         trackName,
         error: errMsg(error),
@@ -99,20 +103,12 @@ export function createJellyfinFamilyPlaylistTarget(
           if (itemId) itemIds.push(itemId)
         }
 
-        const playlist = await jellyfinFamilyFetch<{ Id?: string }>(
-          config,
-          serviceName,
-          '/Playlists',
-          {
-            method: 'POST',
-            body: {
-              Name: name,
-              UserId: config.userId,
-              MediaType: 'Audio',
-              Ids: itemIds,
-            },
-          },
-        )
+        const playlist = await postOnce<{ Id?: string }>('/Playlists', {
+          Name: name,
+          UserId: config.userId,
+          MediaType: 'Audio',
+          Ids: itemIds,
+        })
         const playlistId = playlist.Id
         if (!playlistId) {
           throw new Error(`${serviceName} did not return a playlist ID`)
@@ -138,11 +134,7 @@ export function createJellyfinFamilyPlaylistTarget(
 
     async testConnection(): Promise<ServiceTestResult> {
       try {
-        const info = await jellyfinFamilyFetch<{ ServerName: string; Version: string }>(
-          config,
-          serviceName,
-          '/System/Info',
-        )
+        const info = await get<{ ServerName: string; Version: string }>('/System/Info')
         return {
           success: true,
           message: `Connected to ${serviceName} "${info.ServerName}" v${info.Version}`,

--- a/src/core/targets/navidrome-playlist.ts
+++ b/src/core/targets/navidrome-playlist.ts
@@ -1,4 +1,4 @@
-import { redactUrlForLog } from '@/core/clients/http'
+import { createHttpClient, HttpError, type HttpRequestOptions } from '@/core/clients/http'
 import {
   buildSubsonicAuthParams,
   type SubsonicEnvelope,
@@ -14,37 +14,28 @@ export type NavidromePlaylistConfig = {
   password: string
 }
 
-function buildSubsonicUrl(
-  baseUrl: string,
+function buildSubsonicPath(
   username: string,
   password: string,
   endpoint: string,
   extra?: Record<string, string>,
 ): string {
-  const base = baseUrl.replace(/\/+$/, '')
   const params = buildSubsonicAuthParams({
     username,
     password,
     extra,
   })
-  return `${base}/rest/${endpoint}?${params.toString()}`
+  return `/rest/${endpoint}?${params.toString()}`
 }
 
-async function subsonicFetch<T>(url: string): Promise<T> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), 10_000)
-  let res: Response
-  try {
-    res = await fetch(url, { signal: controller.signal })
-  } finally {
-    clearTimeout(timer)
+function redactSubsonicAuthValues(text: string, path: string): string {
+  const params = new URL(path, 'http://subsonic.invalid').searchParams
+  let redacted = text
+  for (const key of ['t', 's']) {
+    const value = params.get(key)
+    if (value) redacted = redacted.replaceAll(value, '[REDACTED]')
   }
-  if (!res.ok) {
-    throw new Error(`Subsonic HTTP ${res.status}: ${redactUrlForLog(url)}`)
-  }
-  const data = (await res.json()) as SubsonicEnvelope<Record<string, unknown>>
-  const root = unwrapSubsonicResponse(data)
-  return root as unknown as T
+  return redacted
 }
 
 export function createNavidromePlaylistTarget(
@@ -52,15 +43,32 @@ export function createNavidromePlaylistTarget(
   config: NavidromePlaylistConfig,
 ): DestinationTarget {
   const { url, username, password } = config
+  const client = createHttpClient({ baseUrl: url.replace(/\/+$/, ''), timeout: 10_000 })
 
-  function apiUrl(endpoint: string, extra?: Record<string, string>): string {
-    return buildSubsonicUrl(url, username, password, endpoint, extra)
+  function apiPath(endpoint: string, extra?: Record<string, string>): string {
+    return buildSubsonicPath(username, password, endpoint, extra)
+  }
+
+  async function subsonicFetch<T>(path: string, options?: HttpRequestOptions): Promise<T> {
+    let data: SubsonicEnvelope<Record<string, unknown>>
+    try {
+      data = await client.get<SubsonicEnvelope<Record<string, unknown>>>(path, options)
+    } catch (error) {
+      if (error instanceof HttpError) {
+        throw new Error(
+          `Subsonic HTTP ${error.status}: ${redactSubsonicAuthValues(error.body, path)}`,
+        )
+      }
+      throw error
+    }
+    const root = unwrapSubsonicResponse(data)
+    return root as unknown as T
   }
 
   async function searchTrack(artistName: string, trackName: string): Promise<string | null> {
     try {
       const query = `${artistName} ${trackName}`
-      const searchUrl = apiUrl('search3', {
+      const searchPath = apiPath('search3', {
         query,
         songCount: '5',
         artistCount: '0',
@@ -68,7 +76,7 @@ export function createNavidromePlaylistTarget(
       })
       const res = await subsonicFetch<{
         searchResult3?: { song?: Array<{ id: string; title: string; artist: string }> }
-      }>(searchUrl)
+      }>(searchPath)
 
       const songs = res.searchResult3?.song ?? []
       if (songs.length === 0) return null
@@ -106,10 +114,10 @@ export function createNavidromePlaylistTarget(
         }
 
         // Create the playlist
-        const createUrl = apiUrl('createPlaylist', { name })
+        const createPath = apiPath('createPlaylist', { name })
         const created = await subsonicFetch<{
           playlist: { id: string; name: string }
-        }>(createUrl)
+        }>(createPath, { retries: 0 })
 
         const playlistId = created.playlist?.id
         if (!playlistId) {
@@ -122,16 +130,16 @@ export function createNavidromePlaylistTarget(
           songIds.forEach((id, i) => {
             updateParams[`songIdToAdd[${i}]`] = id
           })
-          const updateUrl = apiUrl('updatePlaylist', updateParams)
-          await subsonicFetch(updateUrl)
+          const updatePath = apiPath('updatePlaylist', updateParams)
+          await subsonicFetch(updatePath, { retries: 0 })
         }
 
         if (options?.description) {
-          const commentUrl = apiUrl('updatePlaylist', {
+          const commentPath = apiPath('updatePlaylist', {
             playlistId,
             comment: options.description,
           })
-          await subsonicFetch(commentUrl).catch(() => {
+          await subsonicFetch(commentPath).catch(() => {
             // Best-effort: description update is not critical
           })
         }
@@ -156,8 +164,8 @@ export function createNavidromePlaylistTarget(
 
     async testConnection(): Promise<ServiceTestResult> {
       try {
-        const pingUrl = apiUrl('ping')
-        await subsonicFetch(pingUrl)
+        const pingPath = apiPath('ping')
+        await subsonicFetch(pingPath)
         return {
           success: true,
           message: `Connected to Navidrome as ${username}`,

--- a/src/core/targets/plex-playlist.ts
+++ b/src/core/targets/plex-playlist.ts
@@ -1,3 +1,4 @@
+import { createHttpClient, HttpError } from '@/core/clients/http'
 import type { ServiceTestResult } from '@/core/types'
 import { errMsg } from '@/core/validation'
 import { pickBestTrackMatch } from './playlist-match'
@@ -28,46 +29,44 @@ type PlexPlaylistCreateResponse = {
   }
 }
 
-async function plexFetch<T>(
-  baseUrl: string,
-  token: string,
-  path: string,
-  options?: { method?: string; body?: URLSearchParams },
-): Promise<T> {
-  const url = `${baseUrl.replace(/\/+$/, '')}${path}`
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), 10_000)
-  let res: Response
-  try {
-    res = await fetch(url, {
-      method: options?.method ?? 'GET',
-      headers: {
-        'X-Plex-Token': token,
-        Accept: 'application/json',
-      },
-      body: options?.body,
-      signal: controller.signal,
-    })
-  } finally {
-    clearTimeout(timer)
-  }
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(`Plex API ${res.status}: ${text}`)
-  }
-  return (await res.json()) as T
-}
-
 export function createPlexPlaylistTarget(
   targetId: number,
   config: PlexPlaylistConfig,
 ): DestinationTarget {
   const { url, token } = config
+  const client = createHttpClient({
+    baseUrl: url.replace(/\/+$/, ''),
+    headers: { 'X-Plex-Token': token, Accept: 'application/json' },
+    timeout: 10_000,
+  })
+
+  function rethrowPlexError(error: unknown): never {
+    if (error instanceof HttpError) {
+      throw new Error(`Plex API ${error.status}: ${error.body.replaceAll(token, '[REDACTED]')}`)
+    }
+    throw error
+  }
+
+  async function get<T>(path: string): Promise<T> {
+    try {
+      return await client.get<T>(path)
+    } catch (error) {
+      rethrowPlexError(error)
+    }
+  }
+
+  async function postOnce<T>(path: string): Promise<T> {
+    try {
+      return await client.post<T>(path, undefined, { retries: 0 })
+    } catch (error) {
+      rethrowPlexError(error)
+    }
+  }
 
   async function getMusicMachineId(): Promise<string> {
-    const res = await plexFetch<{
+    const res = await get<{
       MediaContainer: { machineIdentifier: string }
-    }>(url, token, '/')
+    }>('/')
     return res.MediaContainer.machineIdentifier
   }
 
@@ -77,11 +76,7 @@ export function createPlexPlaylistTarget(
         query: `${artistName} ${trackName}`,
         limit: '5',
       })
-      const res = await plexFetch<PlexHubSearchResponse>(
-        url,
-        token,
-        `/hubs/search?${params.toString()}`,
-      )
+      const res = await get<PlexHubSearchResponse>(`/hubs/search?${params.toString()}`)
 
       const hubs = res.MediaContainer.Hub ?? []
       const trackHub = hubs.find((h) => h.type === 'track')
@@ -132,12 +127,7 @@ export function createPlexPlaylistTarget(
         const uriParam = uris.map((u) => `uri=${encodeURIComponent(u)}`).join('&')
         const qs = uris.length > 0 ? `${baseParams.toString()}&${uriParam}` : baseParams.toString()
 
-        const created = await plexFetch<PlexPlaylistCreateResponse>(
-          url,
-          token,
-          `/playlists?${qs}`,
-          { method: 'POST' },
-        )
+        const created = await postOnce<PlexPlaylistCreateResponse>(`/playlists?${qs}`)
 
         const playlist = created.MediaContainer.Metadata?.[0]
         if (!playlist) {
@@ -164,9 +154,9 @@ export function createPlexPlaylistTarget(
 
     async testConnection(): Promise<ServiceTestResult> {
       try {
-        const res = await plexFetch<{
+        const res = await get<{
           MediaContainer: { friendlyName?: string; version?: string; machineIdentifier: string }
-        }>(url, token, '/')
+        }>('/')
         const info = res.MediaContainer
         const label = info.friendlyName ?? info.machineIdentifier
         return {

--- a/tests/core/clients/http.test.ts
+++ b/tests/core/clients/http.test.ts
@@ -235,6 +235,28 @@ describe('createHttpClient', () => {
       // retries=2: initial attempt + 2 retries = 3 total
       expect(after - before).toBe(3)
     }, 20_000)
+
+    it('allows a POST to disable retries without changing the client default', async () => {
+      const path = '/flaky/post-no-retry'
+      const before = serverHits.get(path) ?? 0
+      const client = createHttpClient({ baseUrl, retries: 3 })
+
+      await client.post(`${path}?fails=99`, { name: 'once' }, { retries: 0 }).catch(() => null)
+
+      const after = serverHits.get(path) ?? 0
+      expect(after - before).toBe(1)
+    }, 20_000)
+
+    it('allows a GET-shaped mutation to disable retries', async () => {
+      const path = '/flaky/get-mutation-no-retry'
+      const before = serverHits.get(path) ?? 0
+      const client = createHttpClient({ baseUrl, retries: 3 })
+
+      await client.get(`${path}?fails=99`, { retries: 0 }).catch(() => null)
+
+      const after = serverHits.get(path) ?? 0
+      expect(after - before).toBe(1)
+    }, 20_000)
   })
 
   describe('timeout', () => {

--- a/tests/core/targets/emby-playlist.test.ts
+++ b/tests/core/targets/emby-playlist.test.ts
@@ -3,6 +3,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createEmbyPlaylistTarget } from '@/core/targets/emby-playlist'
 
+function ok(body: unknown): Response {
+  return new Response(JSON.stringify(body))
+}
+
 describe('createEmbyPlaylistTarget', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -13,16 +17,10 @@ describe('createEmbyPlaylistTarget', () => {
       'fetch',
       vi
         .fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            Items: [{ Id: 'track-1', Name: 'Roygbiv', AlbumArtist: 'Boards of Canada' }],
-          }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ Id: 'playlist-1', Name: 'Weekly Discoveries' }),
-        }),
+        .mockResolvedValueOnce(
+          ok({ Items: [{ Id: 'track-1', Name: 'Roygbiv', AlbumArtist: 'Boards of Canada' }] }),
+        )
+        .mockResolvedValueOnce(ok({ Id: 'playlist-1', Name: 'Weekly Discoveries' })),
     )
 
     const target = createEmbyPlaylistTarget(9, {
@@ -46,19 +44,15 @@ describe('createEmbyPlaylistTarget', () => {
   it('prefers an exact title+artist match instead of the first near-match', async () => {
     const fetchMock = vi.fn()
     fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      .mockResolvedValueOnce(
+        ok({
           Items: [
             { Id: 'partial', Name: 'Roygbiv (Live)', AlbumArtist: 'Boards of Canada' },
             { Id: 'exact', Name: 'Roygbiv', AlbumArtist: 'Boards of Canada' },
           ],
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ Id: 'playlist-1', Name: 'Weekly Discoveries' }),
-      })
+      )
+      .mockResolvedValueOnce(ok({ Id: 'playlist-1', Name: 'Weekly Discoveries' }))
     vi.stubGlobal('fetch', fetchMock)
 
     const target = createEmbyPlaylistTarget(9, {
@@ -80,14 +74,8 @@ describe('createEmbyPlaylistTarget', () => {
   it('passes Bun TLS skip options when configured', async () => {
     const fetchMock = vi.fn()
     fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ Items: [] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ Id: 'playlist-1', Name: 'Weekly Discoveries' }),
-      })
+      .mockResolvedValueOnce(ok({ Items: [] }))
+      .mockResolvedValueOnce(ok({ Id: 'playlist-1', Name: 'Weekly Discoveries' }))
     vi.stubGlobal('fetch', fetchMock)
 
     const target = createEmbyPlaylistTarget(9, {
@@ -108,13 +96,12 @@ describe('createEmbyPlaylistTarget', () => {
   it('skips a track when its search request fails', async () => {
     vi.stubGlobal(
       'fetch',
-      vi
-        .fn()
-        .mockRejectedValueOnce(new Error('search transport failed'))
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ Id: 'playlist-1', Name: 'Weekly Discoveries' }),
-        }),
+      vi.fn().mockImplementation((url: string | URL | Request, init?: RequestInit) => {
+        if (String(url).includes('/Items') && (!init?.method || init.method === 'GET')) {
+          return Promise.reject(new Error('search transport failed'))
+        }
+        return Promise.resolve(ok({ Id: 'playlist-1', Name: 'Weekly Discoveries' }))
+      }),
     )
 
     const target = createEmbyPlaylistTarget(9, {
@@ -131,13 +118,7 @@ describe('createEmbyPlaylistTarget', () => {
   })
 
   it('fails when Emby does not return a playlist ID', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ Name: 'Weekly Discoveries' }),
-      }),
-    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(ok({ Name: 'Weekly Discoveries' })))
 
     const target = createEmbyPlaylistTarget(9, {
       url: 'http://emby:8096',
@@ -154,14 +135,12 @@ describe('createEmbyPlaylistTarget', () => {
   })
 
   it('retains the Emby response body in API errors', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce({
-        ok: false,
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response('playlist database unavailable', {
         status: 500,
-        text: async () => 'playlist database unavailable',
       }),
     )
+    vi.stubGlobal('fetch', fetchMock)
 
     const target = createEmbyPlaylistTarget(9, {
       url: 'http://emby:8096',
@@ -174,6 +153,24 @@ describe('createEmbyPlaylistTarget', () => {
     expect(result).toMatchObject({
       success: false,
       error: 'Emby API 500: playlist database unavailable',
+    })
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('returns a provider-shaped error for malformed JSON', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(new Response('not-json')))
+
+    const target = createEmbyPlaylistTarget(9, {
+      url: 'http://emby:8096',
+      apiKey: 'key',
+      userId: 'user-1',
+    })
+
+    const result = await target.createPlaylist?.('Weekly Discoveries', [])
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Emby API 200: Invalid JSON: not-json',
     })
   })
 })

--- a/tests/core/targets/jellyfin-playlist.test.ts
+++ b/tests/core/targets/jellyfin-playlist.test.ts
@@ -48,7 +48,7 @@ describe('createJellyfinPlaylistTarget()', () => {
       await target.testConnection()
 
       const opts = mockFetch.mock.calls[0]?.[1] as RequestInit
-      expect(opts.headers).toEqual(expect.objectContaining({ 'X-Emby-Token': 'jf-api-key' }))
+      expect(new Headers(opts.headers).get('X-Emby-Token')).toBe('jf-api-key')
     })
 
     it('passes Bun TLS skip options when configured', async () => {
@@ -65,7 +65,7 @@ describe('createJellyfinPlaylistTarget()', () => {
     })
 
     it('returns failure when server is unreachable', async () => {
-      mockFetch.mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
+      mockFetch.mockRejectedValue(new Error('connect ECONNREFUSED'))
 
       const target = createJellyfinPlaylistTarget(7, CONFIG)
       const result = await target.testConnection()
@@ -185,6 +185,55 @@ describe('createJellyfinPlaylistTarget()', () => {
 
       expect(result?.success).toBe(false)
       expect(result?.error).toContain('500')
+      expect(result?.error).toContain('Error')
+      expect(
+        mockFetch.mock.calls.filter(
+          ([url, init]) =>
+            String(url).includes('/Playlists') &&
+            (init as RequestInit | undefined)?.method === 'POST',
+        ),
+      ).toHaveLength(1)
+    })
+
+    it('returns a provider-shaped error for malformed JSON', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('not-json'))
+
+      const target = createJellyfinPlaylistTarget(7, CONFIG)
+      const result = await target.createPlaylist?.('Bad JSON', [])
+
+      expect(result).toMatchObject({
+        success: false,
+        error: 'Jellyfin API 200: Invalid JSON: not-json',
+      })
+    })
+
+    it('redacts the API key if an upstream error body echoes it', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(`apiKey=${CONFIG.apiKey}`, {
+          status: 500,
+        }),
+      )
+
+      const target = createJellyfinPlaylistTarget(7, CONFIG)
+      const result = await target.createPlaylist?.('Echoed Credential', [])
+
+      expect(result).toMatchObject({
+        success: false,
+        error: 'Jellyfin API 500: apiKey=[REDACTED]',
+      })
+      expect(result?.error).not.toContain(CONFIG.apiKey)
+    })
+
+    it('returns a provider-shaped error for an empty JSON response', async () => {
+      mockFetch.mockResolvedValueOnce(new Response(''))
+
+      const target = createJellyfinPlaylistTarget(7, CONFIG)
+      const result = await target.createPlaylist?.('Empty Response', [])
+
+      expect(result).toMatchObject({
+        success: false,
+        error: 'Jellyfin API 200: Expected JSON response body',
+      })
     })
 
     it('prefers exact artist+title match in search results', async () => {

--- a/tests/core/targets/navidrome-playlist.test.ts
+++ b/tests/core/targets/navidrome-playlist.test.ts
@@ -72,7 +72,7 @@ describe('createNavidromePlaylistTarget()', () => {
     })
 
     it('returns failure when server is unreachable', async () => {
-      mockFetch.mockImplementationOnce(() => networkError())
+      mockFetch.mockImplementation(() => networkError())
 
       const target = createNavidromePlaylistTarget(5, CONFIG)
       const result = await target.testConnection()
@@ -100,7 +100,7 @@ describe('createNavidromePlaylistTarget()', () => {
       expect(result.success).toBe(false)
       expect(result.message).not.toMatch(/[?&]t=[0-9a-f]{32}/)
       expect(result.message).not.toMatch(/[?&]s=[0-9a-f]{16}/)
-      expect(result.message).toContain('%5BREDACTED%5D')
+      expect(result.message).toBe('Subsonic HTTP 401: Unauthorized')
     })
 
     it('returns a clean failure for a response without a Subsonic envelope', async () => {
@@ -112,6 +112,30 @@ describe('createNavidromePlaylistTarget()', () => {
       expect(result).toEqual({
         success: false,
         message: 'Malformed Subsonic response (missing subsonic-response envelope)',
+      })
+    })
+
+    it('retries a read-only ping when the server recovers', async () => {
+      mockFetch
+        .mockResolvedValueOnce(new Response('temporary outage', { status: 500 }))
+        .mockResolvedValueOnce(okResponse({}))
+
+      const target = createNavidromePlaylistTarget(5, CONFIG)
+      const result = await target.testConnection()
+
+      expect(result.success).toBe(true)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns a provider-shaped error for malformed JSON', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('not-json'))
+
+      const target = createNavidromePlaylistTarget(5, CONFIG)
+      const result = await target.testConnection()
+
+      expect(result).toEqual({
+        success: false,
+        message: 'Subsonic HTTP 200: Invalid JSON: not-json',
       })
     })
   })
@@ -221,6 +245,85 @@ describe('createNavidromePlaylistTarget()', () => {
 
       expect(result?.success).toBe(false)
       expect(result?.error).toContain('Requested data was not found')
+    })
+
+    it('makes one create request and redacts echoed auth values from the body', async () => {
+      let token = ''
+      let salt = ''
+      mockFetch.mockImplementation(async (url: string | URL | Request) => {
+        const parsed = new URL(String(url))
+        if (parsed.pathname.includes('/rest/createPlaylist')) {
+          token = parsed.searchParams.get('t') ?? ''
+          salt = parsed.searchParams.get('s') ?? ''
+          return new Response(`failed t=${token}&s=${salt}`, { status: 500 })
+        }
+        return okResponse({})
+      })
+
+      const target = createNavidromePlaylistTarget(5, CONFIG)
+      const result = await target.createPlaylist?.('Bad Playlist', [])
+
+      expect(result).toMatchObject({
+        success: false,
+        error: 'Subsonic HTTP 500: failed t=[REDACTED]&s=[REDACTED]',
+      })
+      expect(result?.error).not.toContain(token)
+      expect(result?.error).not.toContain(salt)
+      expect(
+        mockFetch.mock.calls.filter(([url]) => String(url).includes('/rest/createPlaylist')),
+      ).toHaveLength(1)
+    })
+
+    it('makes one song-add request when updatePlaylist returns 500', async () => {
+      mockFetch.mockImplementation(async (url: string | URL | Request) => {
+        const value = String(url)
+        if (value.includes('/rest/search3')) {
+          return okResponse({
+            searchResult3: { song: [{ id: 'song-1', title: 'Creep', artist: 'Radiohead' }] },
+          })
+        }
+        if (value.includes('/rest/createPlaylist')) {
+          return okResponse({ playlist: { id: 'pl-42', name: 'Test' } })
+        }
+        if (value.includes('songIdToAdd')) {
+          return new Response('song update unavailable', { status: 500 })
+        }
+        return okResponse({})
+      })
+
+      const target = createNavidromePlaylistTarget(5, CONFIG)
+      const result = await target.createPlaylist?.('Test', [
+        { artistName: 'Radiohead', artistMbid: 'mbid-rh', trackName: 'Creep' },
+      ])
+
+      expect(result).toMatchObject({
+        success: false,
+        error: 'Subsonic HTTP 500: song update unavailable',
+      })
+      expect(
+        mockFetch.mock.calls.filter(([url]) => String(url).includes('songIdToAdd')),
+      ).toHaveLength(1)
+    })
+
+    it('retries a best-effort comment update', async () => {
+      let commentAttempts = 0
+      mockFetch.mockImplementation(async (url: string | URL | Request) => {
+        const value = String(url)
+        if (value.includes('/rest/createPlaylist')) {
+          return okResponse({ playlist: { id: 'pl-42', name: 'Test' } })
+        }
+        if (value.includes('comment=')) {
+          commentAttempts += 1
+          if (commentAttempts === 1) return new Response('temporary outage', { status: 500 })
+        }
+        return okResponse({})
+      })
+
+      const target = createNavidromePlaylistTarget(5, CONFIG)
+      const result = await target.createPlaylist?.('Test', [], { description: 'Description' })
+
+      expect(result?.success).toBe(true)
+      expect(commentAttempts).toBe(2)
     })
 
     it('prefers exact title+artist match over first search result', async () => {

--- a/tests/core/targets/plex-playlist.test.ts
+++ b/tests/core/targets/plex-playlist.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createPlexPlaylistTarget } from '@/core/targets/plex-playlist'
+
+const CONFIG = {
+  url: 'http://plex:32400/',
+  token: 'plex-secret-token',
+}
+
+function ok(body: unknown): Response {
+  return new Response(JSON.stringify(body))
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('createPlexPlaylistTarget', () => {
+  it('returns connection metadata and sends the Plex token header', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      ok({
+        MediaContainer: {
+          friendlyName: 'Home Plex',
+          version: '1.41.0',
+          machineIdentifier: 'machine-1',
+        },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await createPlexPlaylistTarget(4, CONFIG).testConnection()
+
+    expect(result).toMatchObject({
+      success: true,
+      details: { machineIdentifier: 'machine-1', version: '1.41.0' },
+    })
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://plex:32400/')
+    expect(new Headers(init.headers).get('X-Plex-Token')).toBe(CONFIG.token)
+  })
+
+  it('uses the exact search match when creating a playlist', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string | URL | Request) => {
+      const value = String(url)
+      if (value.includes('/hubs/search')) {
+        return Promise.resolve(
+          ok({
+            MediaContainer: {
+              Hub: [
+                {
+                  type: 'track',
+                  Metadata: [
+                    {
+                      ratingKey: 'partial',
+                      title: 'Creep (Live)',
+                      grandparentTitle: 'Radiohead',
+                      type: 'track',
+                    },
+                    {
+                      ratingKey: 'exact',
+                      title: 'Creep',
+                      grandparentTitle: 'Radiohead',
+                      type: 'track',
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+        )
+      }
+      if (value.includes('/playlists?')) {
+        return Promise.resolve(
+          ok({ MediaContainer: { Metadata: [{ ratingKey: 'playlist-1', title: 'Picks' }] } }),
+        )
+      }
+      return Promise.resolve(ok({ MediaContainer: { machineIdentifier: 'machine-1' } }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await createPlexPlaylistTarget(4, CONFIG).createPlaylist?.('Picks', [
+      { artistName: 'Radiohead', artistMbid: 'mbid-rh', trackName: 'Creep' },
+    ])
+
+    expect(result).toMatchObject({ success: true, playlistId: 'playlist-1', itemsAdded: 1 })
+    const createUrl = String(
+      fetchMock.mock.calls.find(([url]) => String(url).includes('/playlists?'))?.[0],
+    )
+    expect(decodeURIComponent(createUrl)).toContain('/metadata/exact')
+    expect(decodeURIComponent(createUrl)).not.toContain('/metadata/partial')
+  })
+
+  it('makes one playlist-create request and retains a redacted HTTP body', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string | URL | Request) => {
+      if (String(url).includes('/playlists?')) {
+        return Promise.resolve(new Response(`token=${CONFIG.token}`, { status: 500 }))
+      }
+      return Promise.resolve(ok({ MediaContainer: { machineIdentifier: 'machine-1' } }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await createPlexPlaylistTarget(4, CONFIG).createPlaylist?.('Picks', [])
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Plex API 500: token=[REDACTED]',
+    })
+    expect(result?.error).not.toContain(CONFIG.token)
+    expect(
+      fetchMock.mock.calls.filter(([url]) => String(url).includes('/playlists?')),
+    ).toHaveLength(1)
+  })
+
+  it('returns a provider-shaped error for malformed JSON', async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string | URL | Request) => {
+      if (String(url).includes('/playlists?')) return Promise.resolve(new Response('not-json'))
+      return Promise.resolve(ok({ MediaContainer: { machineIdentifier: 'machine-1' } }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await createPlexPlaylistTarget(4, CONFIG).createPlaylist?.('Picks', [])
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Plex API 200: Invalid JSON: not-json',
+    })
+  })
+
+  it('returns timeout failures without exposing the token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new DOMException('request timed out', 'AbortError')),
+    )
+
+    const result = await createPlexPlaylistTarget(4, CONFIG).testConnection()
+
+    expect(result).toMatchObject({ success: false, message: 'request timed out' })
+    expect(result.message).not.toContain(CONFIG.token)
+  })
+})


### PR DESCRIPTION
## Summary

- move Jellyfin, Emby, Plex, and Navidrome playlist adapters onto the shared HTTP client
- add a per-request retry override while preserving the client's existing read retry defaults
- disable retries for playlist creation and song-add mutations, including Navidrome's GET-shaped mutation endpoints
- keep Navidrome's best-effort comment update retryable and redact credentials from provider error bodies
- document the endpoint-semantic retry invariant and close the transport drift item

## Tests

- TDD red/green coverage for per-request retry overrides and provider wiring
- `bun run lint`
- `bun run typecheck`
- full suite: 304 files passed, 4 skipped; 2,781 tests passed, 26 skipped
- `bun run build`
- `bun run i18n:check`
- `bun run check:api-docs`
- `bun run check:versions`
- Gitleaks, Semgrep, and Trivy secret scans

No dependency, configuration, API, or locale-catalog surface changed.
