### PR TITLE
refactor(clients): name media server rate policy

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,6 +154,11 @@ Albums are a first-class recommendation unit. Key additions:
   Read-only calls retain the client retry default. Duplicate-producing playlist
   creation and song-add calls pass `retries: 0`; this classification is based on
   endpoint semantics because Subsonic mutations use GET-shaped endpoints.
+- Emby, Jellyfin, and Subsonic source clients each own a media-server request
+  queue capped at three concurrent requests and ten starts per second. This is
+  an internal load-smoothing policy for self-hosted servers, not a claimed
+  vendor limit. It is deliberately per client instance; configurable overrides
+  and queue metrics remain deferred until an operational need is demonstrated.
 - Field-level encryption uses AES-256-GCM with HKDF-derived keys (`src/core/crypto.ts`). Encrypted DB values are prefixed `enc:v1:`. Legacy SHA-256 decryption is retained as a read-path fallback for pre-migration values.
 - Tests run in Node.js (vitest), not Bun. `Bun.serve()`, `Bun.file()` and similar Bun-only APIs are unavailable in tests; password hashing uses `node:crypto` `scrypt`.
 - Migrations are idempotent. Drizzle generates bare DDL, so every generated migration must add `IF NOT EXISTS` / `IF EXISTS` clauses by hand.

--- a/src/core/clients/emby.ts
+++ b/src/core/clients/emby.ts
@@ -1,7 +1,7 @@
-import PQueue from 'p-queue'
 import type { ServiceTestResult } from '@/core/types'
 import { errMsg } from '@/core/validation'
 import { createHttpClient } from './http'
+import { createMediaServerQueue } from './media-server-queue'
 
 export type EmbyMusicLibrary = {
   id: string
@@ -24,7 +24,7 @@ export function createEmbyClient(
     skipTlsVerify: options?.skipTlsVerify,
   })
 
-  const queue = new PQueue({ concurrency: 3, interval: 1000, intervalCap: 10 })
+  const queue = createMediaServerQueue()
 
   function get<T>(path: string): Promise<T> {
     return queue.add(() => http.get<T>(path)) as Promise<T>

--- a/src/core/clients/jellyfin.ts
+++ b/src/core/clients/jellyfin.ts
@@ -1,7 +1,7 @@
-import PQueue from 'p-queue'
 import type { ServiceTestResult } from '@/core/types'
 import { errMsg } from '@/core/validation'
 import { createHttpClient } from './http'
+import { createMediaServerQueue } from './media-server-queue'
 
 export type JellyfinArtist = {
   name: string
@@ -73,7 +73,7 @@ export function createJellyfinClient(
     skipTlsVerify: options?.skipTlsVerify,
   })
 
-  const queue = new PQueue({ concurrency: 3, interval: 1000, intervalCap: 10 })
+  const queue = createMediaServerQueue()
 
   function get<T>(path: string): Promise<T> {
     return queue.add(() => http.get<T>(path)) as Promise<T>

--- a/src/core/clients/media-server-queue.ts
+++ b/src/core/clients/media-server-queue.ts
@@ -1,0 +1,11 @@
+import PQueue from 'p-queue'
+
+export const MEDIA_SERVER_QUEUE_OPTIONS = {
+  concurrency: 3,
+  interval: 1000,
+  intervalCap: 10,
+} as const
+
+export function createMediaServerQueue(): PQueue {
+  return new PQueue(MEDIA_SERVER_QUEUE_OPTIONS)
+}

--- a/src/core/clients/subsonic.ts
+++ b/src/core/clients/subsonic.ts
@@ -1,8 +1,8 @@
 import { randomBytes } from 'node:crypto'
-import PQueue from 'p-queue'
 import type { ServiceTestResult } from '@/core/types'
 import { errMsg } from '@/core/validation'
 import { createHttpClient } from './http'
+import { createMediaServerQueue } from './media-server-queue'
 import {
   buildSubsonicAuthParams,
   type SubsonicEnvelope,
@@ -58,7 +58,7 @@ export function createSubsonicClient(
     skipTlsVerify: options?.skipTlsVerify,
   })
 
-  const queue = new PQueue({ concurrency: 3, interval: 1000, intervalCap: 10 })
+  const queue = createMediaServerQueue()
 
   function get<T>(path: string): Promise<T> {
     return queue.add(() => http.get<T>(path)) as Promise<T>

--- a/tests/core/clients/emby.test.ts
+++ b/tests/core/clients/emby.test.ts
@@ -3,9 +3,27 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createEmbyClient } from '@/core/clients/emby'
 
+const queueMocks = vi.hoisted(() => {
+  const add = vi.fn((task: () => unknown) => task())
+  return { add, create: vi.fn(() => ({ add })) }
+})
+
+vi.mock('@/core/clients/media-server-queue', () => ({
+  createMediaServerQueue: queueMocks.create,
+}))
+
 describe('createEmbyClient', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    queueMocks.add.mockClear()
+    queueMocks.create.mockClear()
+  })
+
+  it('creates one media-server queue per client instance', () => {
+    createEmbyClient('http://emby:8096', 'key', 'user-1')
+    createEmbyClient('http://emby:8096', 'key', 'user-2')
+
+    expect(queueMocks.create).toHaveBeenCalledTimes(2)
   })
 
   it('maps top artists from the Emby items endpoint', async () => {

--- a/tests/core/clients/jellyfin.test.ts
+++ b/tests/core/clients/jellyfin.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createJellyfinClient } from '@/core/clients/jellyfin'
 
 const mockGet = vi.fn()
+const queueMocks = vi.hoisted(() => {
+  const add = vi.fn((task: () => unknown) => task())
+  return { add, create: vi.fn(() => ({ add })) }
+})
 
 vi.mock('@/core/clients/http', () => ({
   createHttpClient: vi.fn(() => ({
@@ -13,8 +17,23 @@ vi.mock('@/core/clients/http', () => ({
   })),
 }))
 
+vi.mock('@/core/clients/media-server-queue', () => ({
+  createMediaServerQueue: queueMocks.create,
+}))
+
 beforeEach(() => {
   mockGet.mockReset()
+  queueMocks.add.mockClear()
+  queueMocks.create.mockClear()
+})
+
+describe('jellyfin media-server queue', () => {
+  it('creates one queue per client instance', () => {
+    createJellyfinClient('http://jf:8096', 'key', '00000000-0000-0000-0000-000000000001')
+    createJellyfinClient('http://jf:8096', 'key', '00000000-0000-0000-0000-000000000002')
+
+    expect(queueMocks.create).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('jellyfin client.getAllArtists()', () => {

--- a/tests/core/clients/media-server-queue.test.ts
+++ b/tests/core/clients/media-server-queue.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  createMediaServerQueue,
+  MEDIA_SERVER_QUEUE_OPTIONS,
+} from '@/core/clients/media-server-queue'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('media server queue policy', () => {
+  it('names the shared per-client limits', () => {
+    expect(MEDIA_SERVER_QUEUE_OPTIONS).toEqual({
+      concurrency: 3,
+      interval: 1000,
+      intervalCap: 10,
+    })
+  })
+
+  it('runs no more than three requests concurrently', async () => {
+    const queue = createMediaServerQueue()
+    const started: number[] = []
+    const releases: Array<() => void> = []
+
+    const tasks = Array.from({ length: 4 }, (_, index) =>
+      queue.add(
+        () =>
+          new Promise<void>((resolve) => {
+            started.push(index)
+            releases.push(resolve)
+          }),
+      ),
+    )
+
+    await Promise.resolve()
+    expect(started).toEqual([0, 1, 2])
+
+    releases[0]?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(started).toEqual([0, 1, 2, 3])
+
+    for (const release of releases.slice(1)) release()
+    await Promise.all(tasks)
+  })
+
+  it('starts no more than ten requests per second', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(10_000)
+    const queue = createMediaServerQueue()
+    const started: number[] = []
+
+    const tasks = Array.from({ length: 11 }, (_, index) =>
+      queue.add(async () => {
+        started.push(index)
+      }),
+    )
+
+    await queue.onRateLimit()
+    expect(started).toHaveLength(10)
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(started).toHaveLength(10)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(started).toHaveLength(11)
+    await Promise.all(tasks)
+  })
+})

--- a/tests/core/clients/subsonic.test.ts
+++ b/tests/core/clients/subsonic.test.ts
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSubsonicClient } from '@/core/clients/subsonic'
 
 const mockGet = vi.fn()
+const queueMocks = vi.hoisted(() => {
+  const add = vi.fn((task: () => unknown) => task())
+  return { add, create: vi.fn(() => ({ add })) }
+})
 
 vi.mock('@/core/clients/http', () => ({
   createHttpClient: vi.fn(() => ({
@@ -14,8 +18,23 @@ vi.mock('@/core/clients/http', () => ({
   })),
 }))
 
+vi.mock('@/core/clients/media-server-queue', () => ({
+  createMediaServerQueue: queueMocks.create,
+}))
+
 beforeEach(() => {
   mockGet.mockReset()
+  queueMocks.add.mockClear()
+  queueMocks.create.mockClear()
+})
+
+describe('subsonic media-server queue', () => {
+  it('creates one queue per client instance', () => {
+    createSubsonicClient('http://nav:4533', 'admin', 'secret')
+    createSubsonicClient('http://nav:4533', 'listener', 'secret')
+
+    expect(queueMocks.create).toHaveBeenCalledTimes(2)
+  })
 })
 
 describe('subsonic client.getStarredArtists()', () => {


### PR DESCRIPTION
## Summary

- name the intentional load-smoothing policy shared by Emby, Jellyfin, and Subsonic source clients
- preserve one queue per client instance with three concurrent requests and ten starts per second
- add deterministic behavioral tests for both limits and wiring tests for all three providers
- document that the values are internal defaults, not vendor limits, while deferring configuration and metrics until needed

## Tests

- TDD red/green coverage for queue behavior and provider wiring
- `bun run lint`
- `bun run typecheck`
- full suite: 305 files passed, 4 skipped; 2,787 tests passed, 26 skipped
- `bun run build`
- `bun run i18n:check`
- `bun run check:api-docs`
- `bun run check:versions`
- Gitleaks, Semgrep, and Trivy secret scans

Runtime limits, dependencies, configuration, APIs, and locale catalogs are unchanged.
