### PR TITLE
fix(build): preserve image identity at runtime

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -85,6 +85,11 @@ jobs:
           fetch-depth: 1
       - run: bun install --frozen-lockfile
       - run: bun run build
+      - name: Verify container build identity
+        run: bun run check:docker-identity
+        env:
+          # Container jobs on this runner do not expose a Docker daemon.
+          DIGARR_ALLOW_MISSING_DOCKER: "1"
 
   api-route-test:
     runs-on: docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
           restore-keys: bun-${{ runner.os }}-
       - run: bun install --frozen-lockfile
       - run: bun run build
+      - name: Verify container build identity
+        run: bun run check:docker-identity
 
   api-route-test:
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Releases that have been promoted to the `:stable` Docker channel carry a `(stabl
 - **Database backend migration now copies and verifies one table at a time.** The admin migration tool no longer holds whole-source and whole-target backup objects in application memory. It keeps the consistent read-only source transaction and atomic target transaction, restores in bounded chunks, and reports the same count/content verification result while the working set follows the largest individual table.
 - **Playlist targets now share one safe HTTP transport policy.** Jellyfin, Emby, Plex, and Navidrome playlist requests use the shared timeout, TLS, JSON parsing, response-body error, and credential-redaction path. Read-only requests and best-effort metadata updates may retry; duplicate-producing playlist creation and song-add requests make exactly one attempt, including Subsonic's GET-shaped mutation endpoints.
 
+### Fixed
+
+- **Nightly containers now report their real build identity.** The image keeps the build-time commit SHA and release channel in the runtime stage, so the web footer and `GET /health` no longer fall back to `dev` / `local` in deployed nightly images.
+
 ## v1.12.0 - 2026-07-05
 
 AI provider problems are now visible everywhere they matter, plus a batch of Lidarr, library-sync, and OIDC fixes.

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -34,6 +34,13 @@ RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \
 # checkov:skip=CKV_DOCKER_7: Default and release override runtime images are version-and-digest pinned.
 FROM ${RUNTIME_IMAGE}
 
+# The backend bundle retains custom process.env reads, so preserve the build
+# identity in the runtime image as well as the builder stage.
+ARG DIGARR_GIT_SHA=dev
+ARG DIGARR_CHANNEL=local
+ENV DIGARR_GIT_SHA=${DIGARR_GIT_SHA}
+ENV DIGARR_CHANNEL=${DIGARR_CHANNEL}
+
 LABEL org.opencontainers.image.source="https://github.com/iuliandita/digarr"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.title="digarr"

--- a/docs/guides/switching-backends.md
+++ b/docs/guides/switching-backends.md
@@ -141,6 +141,8 @@ The response includes `"dbBackend"`:
 {
   "status": "ok",
   "version": "...",
+  "gitSha": "...",
+  "channel": "stable",
   "dbBackend": "postgres"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "vite build && bun build src/index.ts --outdir dist/server --target bun --external @electric-sql/pglite && bun build scripts/rotate-encryption-key.ts --outfile dist/scripts/rotate-encryption-key.js --target bun --external @electric-sql/pglite",
     "start": "bun dist/server/index.js",
     "i18n:check": "bun scripts/i18n-check.ts",
+    "check:docker-identity": "./scripts/check-docker-identity.sh",
     "check:versions": "bun scripts/check-version-drift.ts",
     "check:api-docs": "bun scripts/check-api-docs.ts",
     "i18n:translate": "bun scripts/i18n-machine-translate.ts",

--- a/scripts/check-docker-identity.sh
+++ b/scripts/check-docker-identity.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+  if [[ "${DIGARR_ALLOW_MISSING_DOCKER:-0}" == "1" ]]; then
+    printf 'docker unavailable; skipping runtime identity check\n'
+    exit 0
+  fi
+  printf 'error: docker not found on PATH\n' >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+image="digarr:identity-check-$$"
+container="digarr-identity-check-$$"
+
+cleanup() {
+  docker rm -f "${container}" >/dev/null 2>&1 || true
+  docker image rm "${image}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker build \
+  --file "${repo_root}/deploy/docker/Dockerfile" \
+  --build-arg DIGARR_GIT_SHA=ci-identity-sha \
+  --build-arg DIGARR_CHANNEL=nightly \
+  --tag "${image}" \
+  "${repo_root}"
+
+docker run --detach --name "${container}" "${image}" >/dev/null
+
+for _ in {1..30}; do
+  if docker exec "${container}" /app/healthcheck.sh >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+docker exec "${container}" bun -e '
+  const response = await fetch("http://127.0.0.1:3000/health")
+  const health = await response.json()
+  if (health.gitSha !== "ci-identity-sha" || health.channel !== "nightly") {
+    console.error(JSON.stringify(health))
+    process.exit(1)
+  }
+  console.log(`runtime identity: ${health.gitSha} ${health.channel}`)
+'

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,7 +2,7 @@ import pkg from '../package.json'
 
 export const VERSION = pkg.version
 
-// Stamped at build time via Docker build-args -> ENV (Bun inlines process.env.*).
-// On the web side, Vite `define` replaces these same identifiers (see vite.config.ts).
+// Docker build args become runtime ENV values for the backend container.
+// On the web side, Vite `define` replaces these identifiers at build time.
 export const GIT_SHA = process.env.DIGARR_GIT_SHA ?? 'dev'
 export const CHANNEL = process.env.DIGARR_CHANNEL ?? 'local'


### PR DESCRIPTION
## Summary
- preserve the image commit SHA and channel in the runtime Docker stage
- verify the deployed `/health` identity with a real-container CI check
- align the changelog and health-response guide with the runtime contract

## Verification
- `bunx vitest run --maxWorkers=4` (2,787 passed, 26 skipped)
- `bun run check:docker-identity`
- `bun run lint`
- `bun run typecheck`
- `bun run i18n:check`
- `bun run check:versions`
- `bun run check:api-docs`
- `bun run build`
- `docker build --check -f deploy/docker/Dockerfile .`
- `shellcheck scripts/check-docker-identity.sh`
- `actionlint .github/workflows/ci.yml`

Closes #469