### PR TITLE
fix(slskd): reject empty search jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Releases that have been promoted to the `:stable` Docker channel carry a `(stabl
 
 ### Fixed
 
+- **Malformed slskd jobs no longer send empty searches or repeat HTTP 400 errors.** New jobs must contain an artist name or release title, while legacy jobs that still need a search are retained as terminal failures before any request reaches slskd.
 - **Subsonic library syncs no longer fail when one album appears under multiple artists.** Digarr now collapses duplicate source-album rows before replacing the library snapshot and reports the underlying database cause as a short, credential-redacted error instead of dumping generated SQL.
 - **Overflowing Settings tabs now reveal and expose the hidden tabs.** Conditional left/right chevrons and edge fades show when more tabs exist in either direction, while native touch, trackpad, shift-wheel, and horizontal-wheel scrolling remain available. Selecting or deep-linking a tab brings it into view. Both controls have translated accessible labels across all 15 shipped locales.
 - **Discovery over time bars are visible again.** Each batch column now owns the full chart height, so its existing percentage segments render instead of resolving to zero. Scaling, ordering, date labels, and tooltips are unchanged.

--- a/src/core/slskd/orchestrator.ts
+++ b/src/core/slskd/orchestrator.ts
@@ -373,9 +373,17 @@ export function createSlskdOrchestrator<TJob extends SlskdPendingJobBase = Slskd
   async function processSearchableJob(job: SlskdPendingJob, slskd: SlskdClient) {
     if (!deps.updateJobState) return
 
+    const searchQuery = buildSearchQuery(job)
+    if (!searchQuery) {
+      await deps.updateJobState(job.id, 'failed', {
+        lastError: 'slskd job requires an artist name or release title',
+      })
+      return
+    }
+
     let searchId = job.slskdSearchId
     if (!searchId) {
-      const search = await slskd.createSearch(buildSearchQuery(job))
+      const search = await slskd.createSearch(searchQuery)
       searchId = normalizeString(search.id)
       if (!searchId) {
         throw new Error(`slskd search did not return an id for job ${job.id}`)

--- a/src/db/queries/slskd-jobs.ts
+++ b/src/db/queries/slskd-jobs.ts
@@ -65,6 +65,10 @@ export async function createSlskdJob(
   db: Database,
   data: CreateSlskdJobInput,
 ): Promise<SlskdJobRow> {
+  if (!data.artistName.trim() && !data.releaseTitle.trim()) {
+    throw new Error('slskd job requires an artist name or release title')
+  }
+
   for (let attempt = 0; attempt < 2; attempt++) {
     const [row] = await db
       .insert(slskdJobs)

--- a/tests/core/slskd/orchestrator.test.ts
+++ b/tests/core/slskd/orchestrator.test.ts
@@ -183,6 +183,57 @@ describe('createSlskdOrchestrator', () => {
     )
   })
 
+  it('fails empty-query jobs without calling slskd', async () => {
+    const updateJobState = vi.fn(async () => makeJob())
+    const slskdClient = {
+      createSearch: vi.fn(async () => ({ id: 'must-not-run' })),
+      getSearchResults: vi.fn(async (): Promise<SlskdSearchResult[]> => []),
+      enqueueResult: vi.fn(async () => ({ id: 'must-not-run' })),
+      getDownloads: vi.fn(async () => []),
+    }
+    const orchestrator = createSlskdOrchestrator({
+      listPendingJobs: vi.fn(async () => [makeJob({ id: 8, artistName: ' ', releaseTitle: '\t' })]),
+      processPendingJobs: vi.fn(async () => {}),
+      createSlskdClient: vi.fn(() => slskdClient),
+      updateJobState,
+    } as never)
+
+    await orchestrator.triggerSync()
+
+    expect(slskdClient.createSearch).not.toHaveBeenCalled()
+    expect(slskdClient.getSearchResults).not.toHaveBeenCalled()
+    expect(slskdClient.enqueueResult).not.toHaveBeenCalled()
+    expect(updateJobState).toHaveBeenCalledWith(8, 'failed', {
+      lastError: 'slskd job requires an artist name or release title',
+    })
+  })
+
+  it.each([
+    { artistName: 'Burial', releaseTitle: '   ', expectedQuery: 'Burial' },
+    { artistName: '   ', releaseTitle: 'Untrue', expectedQuery: 'Untrue' },
+  ])('searches when one query field is present', async ({
+    artistName,
+    releaseTitle,
+    expectedQuery,
+  }) => {
+    const slskdClient = {
+      createSearch: vi.fn(async () => ({ id: 'search-partial' })),
+      getSearchResults: vi.fn(async (): Promise<SlskdSearchResult[]> => []),
+      enqueueResult: vi.fn(async () => ({ id: 'must-not-run' })),
+      getDownloads: vi.fn(async () => []),
+    }
+    const orchestrator = createSlskdOrchestrator({
+      listPendingJobs: vi.fn(async () => [makeJob({ artistName, releaseTitle })]),
+      processPendingJobs: vi.fn(async () => {}),
+      createSlskdClient: vi.fn(() => slskdClient),
+      updateJobState: vi.fn(async () => makeJob()),
+    } as never)
+
+    await orchestrator.triggerSync()
+
+    expect(slskdClient.createSearch).toHaveBeenCalledWith(expectedQuery)
+  })
+
   it('moves ambiguous matches to manual review instead of auto-queueing', async () => {
     const updateJobState = vi.fn(async () => makeJob())
     const updateRecommendationAction = vi.fn(async () => {})

--- a/tests/db/queries/slskd-jobs.test.ts
+++ b/tests/db/queries/slskd-jobs.test.ts
@@ -103,6 +103,42 @@ describe('slskd job queries', () => {
     expect(db._mocks.insertReturning).toHaveBeenCalledOnce()
   })
 
+  it('rejects jobs without searchable text before inserting', async () => {
+    const db = makeDb()
+
+    await expect(
+      createSlskdJob(db as unknown as Database, {
+        targetId: 2,
+        sourceType: 'recommendation',
+        workKey: 'artist:empty',
+        artistMbid: '11111111-1111-1111-1111-111111111111',
+        artistName: '   ',
+        releaseTitle: '\t',
+      }),
+    ).rejects.toThrow('slskd job requires an artist name or release title')
+    expect(db.insert).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { artistName: 'Example Artist', releaseTitle: '   ' },
+    { artistName: '   ', releaseTitle: 'Example Release' },
+  ])('accepts a job when one searchable field is present', async ({ artistName, releaseTitle }) => {
+    const row = { id: 8, state: 'pending' }
+    const db = makeDb({ insertedRows: [row] })
+
+    await expect(
+      createSlskdJob(db as unknown as Database, {
+        targetId: 2,
+        sourceType: 'recommendation',
+        workKey: 'artist:partial',
+        artistMbid: '11111111-1111-1111-1111-111111111111',
+        artistName,
+        releaseTitle,
+      }),
+    ).resolves.toEqual(row)
+    expect(db.insert).toHaveBeenCalledOnce()
+  })
+
   it('createSlskdJob returns the active row when the insert is skipped by conflict', async () => {
     const row = { id: 9, workKey: 'artist:mbid-1', state: 'pending' }
     const db = makeDb({ insertedRows: [], selectedRows: [row] })


### PR DESCRIPTION
## Summary

- Reject new slskd jobs when both searchable fields are blank after trimming.
- Mark legacy pending/searching jobs with an empty query as terminal failures before any slskd request.
- Preserve artist-only and release-only searches, recommendation records, and failed-job audit history.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bunx vitest run tests/core/slskd/orchestrator.test.ts tests/db/queries/slskd-jobs.test.ts` (23 passed)
- `bunx vitest run --maxWorkers=4` (2,831 passed, 26 skipped)
- `bun run build`
- `bun run i18n:check`
- `bun run check:api-docs`
- `bun run check:versions`

Fixes #482
