### PR TITLE
fix(discovery): honor Subsonic TLS setting

### DIFF
--- a/src/core/discovery-modes/modes/runtime.ts
+++ b/src/core/discovery-modes/modes/runtime.ts
@@ -8,6 +8,15 @@ export async function getDiscoveryModeConnections(userId: number) {
   return getUserConnections(db, userId)
 }
 
+export async function getDiscoveryModeSkipTlsVerify(): Promise<boolean> {
+  const [{ db }, { getSettings }] = await Promise.all([
+    import('@/db'),
+    import('@/db/queries/settings'),
+  ])
+  const settings = await getSettings(db)
+  return settings?.skipTlsVerify ?? false
+}
+
 export async function getDiscoveryModeSpotifyToken(userId: number): Promise<string | null> {
   try {
     const [{ db }, { resolveSpotifyToken }] = await Promise.all([

--- a/src/core/discovery-modes/modes/subsonic-starred.ts
+++ b/src/core/discovery-modes/modes/subsonic-starred.ts
@@ -1,6 +1,10 @@
 import { createSubsonicClient } from '@/core/clients/subsonic'
 import type { DiscoveryModeDefinition } from '../types'
-import { getDiscoveryModeConnections, getNormalizedLimit } from './runtime'
+import {
+  getDiscoveryModeConnections,
+  getDiscoveryModeSkipTlsVerify,
+  getNormalizedLimit,
+} from './runtime'
 
 export function createSubsonicStarredMode(): DiscoveryModeDefinition {
   return {
@@ -25,7 +29,10 @@ export function createSubsonicStarredMode(): DiscoveryModeDefinition {
       },
     ],
     executor: async (request) => {
-      const conns = await getDiscoveryModeConnections(request.userId)
+      const [conns, skipTlsVerify] = await Promise.all([
+        getDiscoveryModeConnections(request.userId),
+        getDiscoveryModeSkipTlsVerify(),
+      ])
       if (!conns?.subsonicUrl || !conns.subsonicUsername || !conns.subsonicPassword) {
         throw new Error('Connect Subsonic to use this mode.')
       }
@@ -35,6 +42,7 @@ export function createSubsonicStarredMode(): DiscoveryModeDefinition {
         conns.subsonicUrl,
         conns.subsonicUsername,
         conns.subsonicPassword,
+        { skipTlsVerify },
       )
       const starred = await client.getStarredArtists()
 

--- a/tests/core/discovery-modes/runtime.test.ts
+++ b/tests/core/discovery-modes/runtime.test.ts
@@ -2,16 +2,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DiscoveryModeRequest } from '@/core/discovery-modes/request'
 
-const { db, mockGetUserConnections, mockResolveDeezerToken, mockResolveSpotifyToken } = vi.hoisted(
-  () => ({
-    db: { kind: 'test-db' },
-    mockGetUserConnections: vi.fn(),
-    mockResolveDeezerToken: vi.fn(),
-    mockResolveSpotifyToken: vi.fn(),
-  }),
-)
+const {
+  db,
+  mockGetSettings,
+  mockGetUserConnections,
+  mockResolveDeezerToken,
+  mockResolveSpotifyToken,
+} = vi.hoisted(() => ({
+  db: { kind: 'test-db' },
+  mockGetSettings: vi.fn(),
+  mockGetUserConnections: vi.fn(),
+  mockResolveDeezerToken: vi.fn(),
+  mockResolveSpotifyToken: vi.fn(),
+}))
 
 vi.mock('@/db', () => ({ db }))
+vi.mock('@/db/queries/settings', () => ({ getSettings: mockGetSettings }))
 vi.mock('@/db/queries/users', () => ({ getUserConnections: mockGetUserConnections }))
 vi.mock('@/core/spotify-auth', () => ({ resolveSpotifyToken: mockResolveSpotifyToken }))
 vi.mock('@/core/deezer-auth', () => ({ resolveDeezerToken: mockResolveDeezerToken }))
@@ -19,6 +25,7 @@ vi.mock('@/core/deezer-auth', () => ({ resolveDeezerToken: mockResolveDeezerToke
 import {
   getDiscoveryModeConnections,
   getDiscoveryModeDeezerToken,
+  getDiscoveryModeSkipTlsVerify,
   getDiscoveryModeSpotifyToken,
   getNormalizedLimit,
   getProviderPath,
@@ -96,6 +103,17 @@ describe('discovery mode runtime helpers', () => {
 
     await expect(getDiscoveryModeConnections(7)).resolves.toBe(connections)
     expect(mockGetUserConnections).toHaveBeenCalledWith(db, 7)
+  })
+
+  it.each([
+    [{ skipTlsVerify: true }, true],
+    [{ skipTlsVerify: false }, false],
+    [null, false],
+  ] as const)('resolves the global TLS setting from %j as %s', async (settings, expected) => {
+    mockGetSettings.mockResolvedValue(settings)
+
+    await expect(getDiscoveryModeSkipTlsVerify()).resolves.toBe(expected)
+    expect(mockGetSettings).toHaveBeenCalledWith(db)
   })
 
   it('returns resolved provider tokens', async () => {

--- a/tests/core/discovery-modes/subsonic-starred.test.ts
+++ b/tests/core/discovery-modes/subsonic-starred.test.ts
@@ -1,20 +1,33 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockGetStarredArtists, mockGetDiscoveryModeConnections } = vi.hoisted(() => ({
+const {
+  mockCreateSubsonicClient,
+  mockGetStarredArtists,
+  mockGetDiscoveryModeConnections,
+  mockGetDiscoveryModeSkipTlsVerify,
+} = vi.hoisted(() => ({
+  mockCreateSubsonicClient: vi.fn(() => ({
+    getStarredArtists: vi.fn(),
+  })),
   mockGetStarredArtists: vi.fn(),
   mockGetDiscoveryModeConnections: vi.fn(),
+  mockGetDiscoveryModeSkipTlsVerify: vi.fn(),
 }))
 
 vi.mock('@/core/clients/subsonic', () => ({
-  createSubsonicClient: vi.fn(() => ({
+  createSubsonicClient: mockCreateSubsonicClient.mockImplementation(() => ({
     getStarredArtists: mockGetStarredArtists,
   })),
 }))
 
 vi.mock('@/core/discovery-modes/modes/runtime', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/core/discovery-modes/modes/runtime')>()
-  return { ...actual, getDiscoveryModeConnections: mockGetDiscoveryModeConnections }
+  return {
+    ...actual,
+    getDiscoveryModeConnections: mockGetDiscoveryModeConnections,
+    getDiscoveryModeSkipTlsVerify: mockGetDiscoveryModeSkipTlsVerify,
+  }
 })
 
 import {
@@ -74,13 +87,16 @@ describe('subsonic-starred mode – availability', () => {
 
 describe('subsonic-starred mode – executor', () => {
   beforeEach(() => {
+    mockCreateSubsonicClient.mockClear()
     mockGetStarredArtists.mockReset()
     mockGetDiscoveryModeConnections.mockReset()
+    mockGetDiscoveryModeSkipTlsVerify.mockReset()
     mockGetDiscoveryModeConnections.mockResolvedValue({
       subsonicUrl: 'https://music.example.com',
       subsonicUsername: 'alice',
       subsonicPassword: 'secret',
     })
+    mockGetDiscoveryModeSkipTlsVerify.mockResolvedValue(false)
     mockGetStarredArtists.mockResolvedValue([
       { id: '1', name: 'Artist A' },
       { id: '2', name: 'Artist B' },
@@ -107,6 +123,20 @@ describe('subsonic-starred mode – executor', () => {
 
     const names = result.candidates.map((c) => c.name)
     expect(names).toEqual(['Artist A', 'Artist B', 'Artist C'])
+  })
+
+  it.each([true, false])('forwards skipTlsVerify=%s to the Subsonic client', async (value) => {
+    mockGetDiscoveryModeSkipTlsVerify.mockResolvedValue(value)
+
+    const mode = createSubsonicStarredMode()
+    await mode.executor(makeRequest({ limit: 10 }))
+
+    expect(mockCreateSubsonicClient).toHaveBeenCalledWith(
+      'https://music.example.com',
+      'alice',
+      'secret',
+      { skipTlsVerify: value },
+    )
   })
 
   it('clamps to the first `limit` starred artists', async () => {


### PR DESCRIPTION
## Summary\n\n- forward the global TLS verification setting to Subsonic Starred discovery\n- cover enabled, disabled, and missing-setting behavior\n\n## Verification\n\n- lint\n- typecheck\n- full test suite: 2,836 passed, 26 skipped\n- production build\n- four-lane pre-PR review\n\nCloses #487