### PR TITLE
fix(ai): stabilize compatible providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,7 @@ PORT=3000
 # AI_MODEL=gpt-4o-mini
 # AI_API_KEY=your-ai-api-key
 # AI_BASE_URL=              # optional, for ollama or compatible APIs (threaded to Anthropic/OpenAI SDKs too)
-# DIGARR_AI_TIMEOUT_SECONDS=  # optional, request timeout in seconds (Ollama defaults to 120, others 30)
+# DIGARR_AI_TIMEOUT_SECONDS=  # optional; overrides AI request and OpenAI-compatible connection-test timeouts
 
 # =============================================================================
 # Deezer OAuth (optional -- enables Deezer favorites, followed, Flow, playlists)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes are documented here.
 
 Releases that have been promoted to the `:stable` Docker channel carry a `(stable)` marker after the version heading. Promotion happens after a release has been live for at least seven days with no follow-up patch.
 
+## Unreleased
+
+### Fixed
+
+- **Slow OpenAI-compatible providers no longer fail with opaque abort errors.** Connection tests now honor `DIGARR_AI_TIMEOUT_SECONDS` instead of stopping after 10 seconds, recommendation timeouts report their configured duration, and Open WebUI `/api` base URLs use its documented chat-completions route. Standard `/v1` bases and full completion URLs are normalized without duplicate path segments.
+
 ## v1.13.0 - 2026-07-15
 
 New discovery inputs and review controls, continuous audition playback, broader genre coverage, and safer library and operations paths.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ Most day-to-day configuration lives in the web UI after initial setup: connectio
 
 Env-var auto-setup needs initial admin credentials plus an AI provider and model. Listening sources, Lidarr, and Emby can be added later in the UI or supplied during setup. `slskd` targets are added later in Settings > Targets and can be linked to a Lidarr target, so a single approval can add the artist to Lidarr first and then queue the matched Soulseek release. See [`.env.example`](.env.example) for local development fallbacks and [`deploy/docker/.env.example`](deploy/docker/.env.example) for Compose deployments.
 
+### Local and OpenAI-Compatible AI
+
+For Open WebUI, choose **OpenAI-Compatible** and use a base URL ending in `/api`, such as `http://<open-webui-host>:<port>/api`. Digarr sends requests to Open WebUI's documented `/api/chat/completions` route. Other compatible servers can use their server root or a base ending in `/v1`. If a local model needs longer to load or generate, set `DIGARR_AI_TIMEOUT_SECONDS` to a suitable value, such as `180`, and restart Digarr; the override applies to both connection tests and recommendation requests.
+
 ### Connecting Spotify
 
 Spotify uses your own Spotify app credentials over OAuth:

--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -88,4 +88,4 @@ PORT=3000
 # AI_MODEL=gpt-4o-mini
 # AI_API_KEY=
 # AI_BASE_URL=               # optional, for ollama or compatible APIs (threaded to Anthropic/OpenAI SDKs too)
-# DIGARR_AI_TIMEOUT_SECONDS=   # optional, request timeout in seconds (Ollama defaults to 120, others 30)
+# DIGARR_AI_TIMEOUT_SECONDS=   # optional; overrides AI request and OpenAI-compatible connection-test timeouts

--- a/src/core/providers/openai-compatible.ts
+++ b/src/core/providers/openai-compatible.ts
@@ -11,8 +11,23 @@ import type { AiUsage, RecommendationProvider } from './types'
 
 const DEFAULT_TIMEOUT_SECONDS = 60
 
+function buildChatCompletionsUrl(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/+$/, '')
+  if (normalized.endsWith('/chat/completions')) return normalized
+  if (normalized.endsWith('/v1') || normalized.endsWith('/api')) {
+    return `${normalized}/chat/completions`
+  }
+  return `${normalized}/v1/chat/completions`
+}
+
+function timeoutMessage(operation: string, timeoutMs: number): string {
+  const seconds = timeoutMs / 1000
+  return `OpenAI-Compatible ${operation} timed out after ${seconds} second${seconds === 1 ? '' : 's'}`
+}
+
 export class OpenAICompatibleProvider implements RecommendationProvider {
   private baseUrl: string
+  private chatCompletionsUrl: string
   private apiKey: string | null
   private model: string
   private timeoutMs: number
@@ -25,6 +40,7 @@ export class OpenAICompatibleProvider implements RecommendationProvider {
     timeoutSeconds?: number | null,
   ) {
     this.baseUrl = baseUrl.replace(/\/+$/, '')
+    this.chatCompletionsUrl = buildChatCompletionsUrl(this.baseUrl)
     this.model = model
     this.apiKey = apiKey
     this.timeoutMs = timeoutSecondsWithDefaultToMs(timeoutSeconds, DEFAULT_TIMEOUT_SECONDS)
@@ -40,7 +56,7 @@ export class OpenAICompatibleProvider implements RecommendationProvider {
     const timer = setTimeout(() => controller.abort(), this.timeoutMs)
     try {
       const res = await fetchWithRetry(
-        `${this.baseUrl}/v1/chat/completions`,
+        this.chatCompletionsUrl,
         {
           method: 'POST',
           headers,
@@ -72,6 +88,11 @@ export class OpenAICompatibleProvider implements RecommendationProvider {
       const text = data.choices?.[0]?.message?.content
       if (!text) throw new Error('Empty response')
       return parseRecommendationResponse(unwrapRecommendationArrayPayload(text))
+    } catch (err: unknown) {
+      if (controller.signal.aborted) {
+        throw new Error(timeoutMessage('recommendation request', this.timeoutMs))
+      }
+      throw err
     } finally {
       clearTimeout(timer)
     }
@@ -79,12 +100,12 @@ export class OpenAICompatibleProvider implements RecommendationProvider {
 
   async testConnection(): Promise<{ success: boolean; message: string }> {
     const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), 10_000)
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
     try {
       const headers: Record<string, string> = { 'Content-Type': 'application/json' }
       if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`
 
-      const res = await fetch(`${this.baseUrl}/v1/chat/completions`, {
+      const res = await fetch(this.chatCompletionsUrl, {
         method: 'POST',
         headers,
         body: JSON.stringify({
@@ -103,7 +124,9 @@ export class OpenAICompatibleProvider implements RecommendationProvider {
     } catch (err: unknown) {
       return {
         success: false,
-        message: errMsg(err),
+        message: controller.signal.aborted
+          ? timeoutMessage('connection test', this.timeoutMs)
+          : errMsg(err),
       }
     } finally {
       clearTimeout(timer)

--- a/tests/core/providers/openai-compatible.test.ts
+++ b/tests/core/providers/openai-compatible.test.ts
@@ -46,6 +46,26 @@ describe('OpenAICompatibleProvider', () => {
     expect(url).toBe(`${TEST_BASE_URL}/v1/chat/completions`)
   })
 
+  it.each([
+    ['http://provider.example.com', 'http://provider.example.com/v1/chat/completions'],
+    ['http://provider.example.com/v1', 'http://provider.example.com/v1/chat/completions'],
+    ['http://provider.example.com/api', 'http://provider.example.com/api/chat/completions'],
+    ['http://provider.example.com/api/v1', 'http://provider.example.com/api/v1/chat/completions'],
+    [
+      'http://provider.example.com/custom/chat/completions',
+      'http://provider.example.com/custom/chat/completions',
+    ],
+  ])('resolves completion URL from %s', async (baseUrl, expectedUrl) => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ choices: [{ message: { content: '[]' } }] })),
+    )
+    const provider = new OpenAICompatibleProvider(baseUrl, 'model')
+
+    await provider.getRecommendations(sampleProfile)
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(expectedUrl)
+  })
+
   it('works without API key', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(
@@ -103,6 +123,48 @@ describe('OpenAICompatibleProvider', () => {
     expect(result.message).toContain('openai.example.com:8080')
   })
 
+  it('uses the configured timeout for connection tests and reports its duration', async () => {
+    vi.useFakeTimers()
+    const provider = new OpenAICompatibleProvider(TEST_BASE_URL, 'model', null, 30)
+    const startedAt = Date.now()
+    let abortedAfterMs: number | undefined
+    fetchSpy.mockImplementationOnce(
+      (_url: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const abortErr = new Error('aborted')
+          abortErr.name = 'AbortError'
+          init?.signal?.addEventListener('abort', () => {
+            abortedAfterMs = Date.now() - startedAt
+            reject(abortErr)
+          })
+        }),
+    )
+
+    try {
+      const pending = provider.testConnection()
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      await expect(pending).resolves.toEqual({
+        success: false,
+        message: 'OpenAI-Compatible connection test timed out after 30 seconds',
+      })
+      expect(abortedAfterMs).toBe(30_000)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('tests Open WebUI through its documented completion URL', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ choices: [{ message: { content: 'pong' } }] })),
+    )
+    const provider = new OpenAICompatibleProvider('http://webui.example.com/api', 'model')
+
+    await provider.testConnection()
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('http://webui.example.com/api/chat/completions')
+  })
+
   it('handles wrapped JSON object response', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(
@@ -151,10 +213,14 @@ describe('OpenAICompatibleProvider', () => {
     )
 
     try {
-      const pending = provider.getRecommendations(sampleProfile)
-      const rejection = expect(pending).rejects.toThrow(/abort/i)
+      const rejection = provider.getRecommendations(sampleProfile).catch((error: unknown) => error)
       await vi.advanceTimersByTimeAsync(1000)
-      await rejection
+      const error = await rejection
+
+      expect(error).toBeInstanceOf(Error)
+      expect((error as Error).message).toBe(
+        'OpenAI-Compatible recommendation request timed out after 1 second',
+      )
       expect(fetchSpy).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()


### PR DESCRIPTION
## Summary

- normalize OpenAI-compatible chat-completion URLs, including Open WebUI `/api` bases
- honor the configured timeout for connection probes and return explicit timeout diagnostics
- document compatible local-provider setup and timeout configuration

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test -- --maxWorkers=4`
- `bun run build`
- `bun run check:versions`

Fixes #500
