### PR TITLE
fix(release): harden promotion checks

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -138,11 +138,36 @@ jobs:
       HELM_SHA256: fc307327959aa38ed8f9f7e66d45492bb022a66c3e5da6063958254b9767d179
     steps:
       - name: Install git and curl
-        run: apt-get update -qq && apt-get install -y -qq git curl ca-certificates > /dev/null && rm -rf /var/lib/apt/lists/*
-      - name: Install Helm
+        timeout-minutes: 5
         run: |
           set -euo pipefail
-          curl -fsSLo /tmp/helm.tgz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update -qq
+          apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y -qq git curl ca-certificates > /dev/null
+          rm -rf /var/lib/apt/lists/*
+      - name: Install Helm
+        timeout-minutes: 3
+        run: |
+          set -euo pipefail
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --location \
+            --retry 4 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            --connect-timeout 15 \
+            --max-time 120 \
+            --output /tmp/helm.tgz \
+            "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
           echo "${HELM_SHA256}  /tmp/helm.tgz" | sha256sum -c -
           tar -xzf /tmp/helm.tgz -C /tmp
           install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -104,14 +104,15 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Install Docker
+        timeout-minutes: 5
+        run: brew install --cask docker
+
+      - name: Start Docker Desktop
         id: docker
-        timeout-minutes: 8
-        continue-on-error: true
+        timeout-minutes: 6
         run: |
-          brew install --cask docker
           open /Applications/Docker.app
-          # Docker Desktop on macOS runners can take 3+ minutes to initialize
-          for i in $(seq 1 90); do
+          for i in $(seq 1 150); do
             if docker info > /dev/null 2>&1; then
               echo "Docker ready after $((i * 2))s"
               echo "ready=true" >> "$GITHUB_OUTPUT"
@@ -119,8 +120,9 @@ jobs:
             fi
             sleep 2
           done
-          echo "::warning::Docker Desktop failed to start; skipping macOS Docker compatibility check"
+          echo "::error::Docker Desktop did not become ready within 300 seconds"
           echo "ready=false" >> "$GITHUB_OUTPUT"
+          exit 1
 
       - name: Prepare env
         if: steps.docker.outputs.ready == 'true'
@@ -136,6 +138,7 @@ jobs:
         run: docker compose -f docker-compose.yml -f docker-compose.compat.yml up -d --build
 
       - name: Assert postgres backend
+        id: postgres_assert
         if: steps.docker.outputs.ready == 'true'
         run: |
           for i in $(seq 1 30); do
@@ -146,6 +149,7 @@ jobs:
             sleep 2
           done
           curl -fsS http://localhost:3000/health | grep -q '"dbBackend":"postgres"'
+          echo "ran=true" >> "$GITHUB_OUTPUT"
 
       - name: Tear down postgres stack
         if: steps.docker.outputs.ready == 'true'
@@ -161,6 +165,7 @@ jobs:
         run: docker compose -f docker-compose.pglite.yml -f docker-compose.compat.yml up -d --build
 
       - name: Assert pglite backend + persistence across restart
+        id: pglite_assert
         if: steps.docker.outputs.ready == 'true'
         working-directory: deploy/docker
         run: |
@@ -181,6 +186,7 @@ jobs:
             sleep 2
           done
           curl -fsS http://localhost:3000/health | grep -q '"status":"ok"'
+          echo "ran=true" >> "$GITHUB_OUTPUT"
 
       - name: Dump logs on failure
         if: failure() && steps.docker.outputs.ready == 'true'
@@ -195,3 +201,15 @@ jobs:
         run: |
           docker compose -f docker-compose.yml -f docker-compose.compat.yml down -v 2>/dev/null || true
           docker compose -f docker-compose.pglite.yml -f docker-compose.compat.yml down -v 2>/dev/null || true
+
+      - name: Verify compatibility assertions ran
+        if: always()
+        env:
+          DOCKER_READY: ${{ steps.docker.outputs.ready }}
+          POSTGRES_ASSERTED: ${{ steps.postgres_assert.outputs.ran }}
+          PGLITE_ASSERTED: ${{ steps.pglite_assert.outputs.ran }}
+        run: |
+          set -eu
+          test "$DOCKER_READY" = true
+          test "$POSTGRES_ASSERTED" = true
+          test "$PGLITE_ASSERTED" = true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,17 +102,12 @@ jobs:
           INPUT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          if [[ ! "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
-            echo "::error::Release tag must look like v1.2.3 or v1.2.3-rc.0"
+          if [[ ! "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must look like v1.2.3"
             exit 1
           fi
 
           echo "value=$INPUT_TAG" >> "$GITHUB_OUTPUT"
-          if [[ "$INPUT_TAG" == *-* ]]; then
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Extract metadata
         id: meta
@@ -128,7 +123,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ steps.tag.outputs.value }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag.outputs.value }}
             type=semver,pattern={{major}},value=${{ steps.tag.outputs.value }}
-            type=raw,value=debian,enable=${{ matrix.variant == 'debian' && steps.tag.outputs.prerelease != 'true' }},suffix=
+            type=raw,value=debian,enable=${{ matrix.variant == 'debian' }},suffix=
 
       - name: Build and push
         id: build
@@ -143,7 +138,7 @@ jobs:
           build-args: |
             RUNTIME_IMAGE=${{ matrix.runtime-image }}
             DIGARR_GIT_SHA=${{ steps.sha.outputs.sha }}
-            DIGARR_CHANNEL=${{ steps.tag.outputs.prerelease == 'true' && 'rc' || 'stable' }}
+            DIGARR_CHANNEL=stable
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -203,18 +198,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.value }}
-          PRERELEASE: ${{ steps.tag.outputs.prerelease }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             echo "release $TAG already exists; skipping create"
           else
-            release_args=(gh release create "$TAG" --repo "$REPO" --title "$TAG" --generate-notes)
-            if [ "$PRERELEASE" = "true" ]; then
-              release_args+=(--prerelease)
-            fi
-            "${release_args[@]}"
+            gh release create "$TAG" --repo "$REPO" --title "$TAG" --generate-notes
           fi
           gh release upload "$TAG" sbom-container.spdx.json sbom-source.spdx.json --clobber
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Releases that have been promoted to the `:stable` Docker channel carry a `(stabl
 ### Fixed
 
 - **Slow OpenAI-compatible providers no longer fail with opaque abort errors.** Connection tests now honor `DIGARR_AI_TIMEOUT_SECONDS` instead of stopping after 10 seconds, recommendation timeouts report their configured duration, and Open WebUI `/api` base URLs use its documented chat-completions route. Standard `/v1` bases and full completion URLs are normalized without duplicate path segments.
+- **Release candidates can no longer bypass the nightly soak channel.** Release and digest-sync tooling now accepts stable `vX.Y.Z` tags only. Development builds continue to publish through `:nightly`; accepted builds promote through `main` to the normal version and `:latest` tags.
+- **Digest synchronization validates every deployment example before writing.** A changed file format now stops the release helper before its first write, avoiding a partially updated set of digests and example tags.
+- **Advisory macOS compatibility runs no longer pass after skipping their backend checks.** Docker installation and startup have independent time budgets, and the job fails visibly unless both PostgreSQL and PGlite assertions complete. The advisory job remains non-blocking.
+- **Contention-sensitive encryption rotation coverage has more CI headroom.** The real PGlite subprocess keeps its failure assertions while using nested timeouts with enough margin for a loaded runner, and temporary state is removed even when setup or assertions fail.
+- **Forgejo Helm setup failures are bounded and easier to distinguish from manifest drift.** Package and pinned Helm downloads now have retry and timeout limits, while checksum verification, chart linting, deterministic rendering, and the final clean-diff assertion remain strict.
 
 ## v1.13.0 - 2026-07-15
 

--- a/scripts/sync-deploy-digests.ts
+++ b/scripts/sync-deploy-digests.ts
@@ -30,23 +30,37 @@ import { readFileSync, writeFileSync } from 'node:fs'
 
 const REPO = 'iuliandita/digarr'
 
-const tagArg = process.argv[2]
-if (!tagArg) {
-  console.error('usage: bun scripts/sync-deploy-digests.ts <tag>')
-  process.exit(1)
-}
-const tag = tagArg.replace(/^v/, '')
-if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?$/.test(tag)) {
-  console.error(`invalid tag "${tagArg}" - expected vX.Y.Z or X.Y.Z (optionally -rc.N)`)
-  process.exit(1)
-}
-const minor = tag.split('.').slice(0, 2).join('.')
+type Fetch = typeof fetch
 
-async function bearerToken(): Promise<string> {
+export type SyncTarget = {
+  path: string
+  pattern: RegExp
+  replacement: (digest: string, match: string, ...groups: string[]) => string
+}
+
+type SyncDeps = {
+  tagArg?: string
+  fetch: Fetch
+  readFile: (path: string) => string
+  writeFile: (path: string, content: string) => void
+  log: (message: string) => void
+}
+
+export function parseReleaseTag(tagArg: string | undefined): string {
+  if (!tagArg) throw new Error('usage: bun scripts/sync-deploy-digests.ts <tag>')
+
+  const tag = tagArg.replace(/^v/, '')
+  if (!/^\d+\.\d+\.\d+$/.test(tag)) {
+    throw new Error(`invalid tag "${tagArg}" - expected vX.Y.Z or X.Y.Z`)
+  }
+  return tag
+}
+
+async function bearerToken(request: Fetch): Promise<string> {
   if (process.env.GH_TOKEN) {
     return Buffer.from(`v1:${process.env.GH_TOKEN}`).toString('base64')
   }
-  const resp = await fetch(`https://ghcr.io/token?scope=repository:${REPO}:pull&service=ghcr.io`)
+  const resp = await request(`https://ghcr.io/token?scope=repository:${REPO}:pull&service=ghcr.io`)
   if (!resp.ok) {
     throw new Error(`anonymous token request failed: ${resp.status}`)
   }
@@ -55,15 +69,15 @@ async function bearerToken(): Promise<string> {
   return body.token
 }
 
-async function ghcrDigest(tag: string): Promise<string> {
-  const token = await bearerToken()
+async function ghcrDigest(tag: string, request: Fetch): Promise<string> {
+  const token = await bearerToken(request)
   const accept = [
     'application/vnd.oci.image.index.v1+json',
     'application/vnd.oci.image.manifest.v1+json',
     'application/vnd.docker.distribution.manifest.list.v2+json',
     'application/vnd.docker.distribution.manifest.v2+json',
   ].join(',')
-  const resp = await fetch(`https://ghcr.io/v2/${REPO}/manifests/${tag}`, {
+  const resp = await request(`https://ghcr.io/v2/${REPO}/manifests/${tag}`, {
     headers: { accept, authorization: `Bearer ${token}` },
   })
   if (!resp.ok) {
@@ -77,113 +91,149 @@ async function ghcrDigest(tag: string): Promise<string> {
   return digest
 }
 
-type Target = {
-  path: string
-  pattern: RegExp
-  replacement: (digest: string, match: string, ...groups: string[]) => string
+function createTargets(tag: string): SyncTarget[] {
+  const minor = tag.split('.').slice(0, 2).join('.')
+  return [
+    {
+      path: 'deploy/k8s/deployment.yaml',
+      pattern: /ghcr\.io\/iuliandita\/digarr@sha256:[a-f0-9]+/g,
+      replacement: (d) => `ghcr.io/iuliandita/digarr@${d}`,
+    },
+    {
+      path: 'deploy/helm/digarr/values.yaml',
+      pattern: /(^image:\n(?: {2}.*\n)*? {2}digest: ")sha256:[a-f0-9]+(")/m,
+      replacement: (d, _match, prefix, suffix) => `${prefix}${d}${suffix}`,
+    },
+    {
+      path: 'deploy/k8s/rendered.yaml',
+      pattern: /ghcr\.io\/iuliandita\/digarr@sha256:[a-f0-9]+/g,
+      replacement: (d) => `ghcr.io/iuliandita/digarr@${d}`,
+    },
+    {
+      path: 'deploy/unraid/digarr.xml',
+      pattern: /(Digest pin \(synced via scripts\/sync-deploy-digests\.ts\): )sha256:[a-f0-9]+/,
+      replacement: (d, _match, prefix) => `${prefix}${d}`,
+    },
+    // Version-tag pins. These close over `tag` (not the digest) so the visible
+    // image reference stays in lockstep with the digest above. Without these the
+    // tags freeze at whatever release first wrote them while the digest advances.
+    {
+      path: 'deploy/helm/digarr/values.yaml',
+      pattern: /(^ {2}tag: ")[^"]+(")/m,
+      replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
+    },
+    {
+      path: 'deploy/unraid/digarr.xml',
+      pattern: /(<Repository>docker\.io\/iuliandita\/digarr:)[^<]+(<\/Repository>)/,
+      replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
+    },
+    {
+      path: 'deploy/unraid/digarr.xml',
+      pattern: /(<Tag>)[^<]+(<\/Tag>)/,
+      replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
+    },
+    {
+      path: 'deploy/unraid/digarr.xml',
+      pattern: /<TagDescription>[^<]*<\/TagDescription>/,
+      replacement: () => `<TagDescription>v${tag} release</TagDescription>`,
+    },
+    // Example pins in compose comments and the README. Never the active image
+    // (compose defaults to :latest), but stale examples read as the current
+    // release to anyone copying them.
+    {
+      path: 'deploy/docker/docker-compose.yml',
+      pattern: /(# {3}:)\d+\.\d+( -> current minor release line)/,
+      replacement: (_d, _match, prefix, suffix) => `${prefix}${minor}${suffix}`,
+    },
+    {
+      path: 'deploy/docker/docker-compose.yml',
+      pattern: /(# image: docker\.io\/iuliandita\/digarr:)\d+\.\d+\.\d+/g,
+      replacement: (_d, _match, prefix) => `${prefix}${tag}`,
+    },
+    {
+      path: 'deploy/docker/docker-compose.pglite.yml',
+      pattern: /(Track patch fixes only: docker\.io\/iuliandita\/digarr:)\d+\.\d+/,
+      replacement: (_d, _match, prefix) => `${prefix}${minor}`,
+    },
+    {
+      path: 'deploy/docker/docker-compose.pglite.yml',
+      pattern: /(surprises: docker\.io\/iuliandita\/digarr:)\d+\.\d+\.\d+/,
+      replacement: (_d, _match, prefix) => `${prefix}${tag}`,
+    },
+    {
+      path: 'deploy/docker/docker-compose.pglite.yml',
+      pattern: /(variant: docker\.io\/iuliandita\/digarr:)\d+\.\d+\.\d+(-debian)/,
+      replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
+    },
+    {
+      path: 'README.md',
+      pattern: /(minor tag like `:)\d+\.\d+(`)/,
+      replacement: (_d, _match, prefix, suffix) => `${prefix}${minor}${suffix}`,
+    },
+    {
+      path: 'README.md',
+      pattern: /(specific patch like `:)\d+\.\d+\.\d+(`)/,
+      replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
+    },
+  ]
 }
 
-const digest = await ghcrDigest(tag)
-console.log(`digest for ${tag}: ${digest}`)
-
-const targets: Target[] = [
-  {
-    path: 'deploy/k8s/deployment.yaml',
-    pattern: /ghcr\.io\/iuliandita\/digarr@sha256:[a-f0-9]+/g,
-    replacement: (d) => `ghcr.io/iuliandita/digarr@${d}`,
-  },
-  {
-    path: 'deploy/helm/digarr/values.yaml',
-    pattern: /(^image:\n(?: {2}.*\n)*? {2}digest: ")sha256:[a-f0-9]+(")/m,
-    replacement: (d, _match, prefix, suffix) => `${prefix}${d}${suffix}`,
-  },
-  {
-    path: 'deploy/k8s/rendered.yaml',
-    pattern: /ghcr\.io\/iuliandita\/digarr@sha256:[a-f0-9]+/g,
-    replacement: (d) => `ghcr.io/iuliandita/digarr@${d}`,
-  },
-  {
-    path: 'deploy/unraid/digarr.xml',
-    pattern: /(Digest pin \(synced via scripts\/sync-deploy-digests\.ts\): )sha256:[a-f0-9]+/,
-    replacement: (d, _match, prefix) => `${prefix}${d}`,
-  },
-  // Version-tag pins. These close over `tag` (not the digest) so the visible
-  // image reference stays in lockstep with the digest above. Without these the
-  // tags freeze at whatever release first wrote them while the digest advances.
-  {
-    path: 'deploy/helm/digarr/values.yaml',
-    pattern: /(^ {2}tag: ")[^"]+(")/m,
-    replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
-  },
-  {
-    path: 'deploy/unraid/digarr.xml',
-    pattern: /(<Repository>docker\.io\/iuliandita\/digarr:)[^<]+(<\/Repository>)/,
-    replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
-  },
-  {
-    path: 'deploy/unraid/digarr.xml',
-    pattern: /(<Tag>)[^<]+(<\/Tag>)/,
-    replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
-  },
-  {
-    path: 'deploy/unraid/digarr.xml',
-    pattern: /<TagDescription>[^<]*<\/TagDescription>/,
-    replacement: () => `<TagDescription>v${tag} release</TagDescription>`,
-  },
-  // Example pins in compose comments and the README. Never the active image
-  // (compose defaults to :latest), but stale examples read as the current
-  // release to anyone copying them.
-  {
-    path: 'deploy/docker/docker-compose.yml',
-    pattern: /(# {3}:)\d+\.\d+( -> current minor release line)/,
-    replacement: (_d, _match, prefix, suffix) => `${prefix}${minor}${suffix}`,
-  },
-  {
-    path: 'deploy/docker/docker-compose.yml',
-    pattern: /(# image: docker\.io\/iuliandita\/digarr:)\d+\.\d+\.\d+/g,
-    replacement: (_d, _match, prefix) => `${prefix}${tag}`,
-  },
-  {
-    path: 'deploy/docker/docker-compose.pglite.yml',
-    pattern: /(Track patch fixes only: docker\.io\/iuliandita\/digarr:)\d+\.\d+/,
-    replacement: (_d, _match, prefix) => `${prefix}${minor}`,
-  },
-  {
-    path: 'deploy/docker/docker-compose.pglite.yml',
-    pattern: /(surprises: docker\.io\/iuliandita\/digarr:)\d+\.\d+\.\d+/,
-    replacement: (_d, _match, prefix) => `${prefix}${tag}`,
-  },
-  {
-    path: 'deploy/docker/docker-compose.pglite.yml',
-    pattern: /(variant: docker\.io\/iuliandita\/digarr:)\d+\.\d+\.\d+(-debian)/,
-    replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
-  },
-  {
-    path: 'README.md',
-    pattern: /(minor tag like `:)\d+\.\d+(`)/,
-    replacement: (_d, _match, prefix, suffix) => `${prefix}${minor}${suffix}`,
-  },
-  {
-    path: 'README.md',
-    pattern: /(specific patch like `:)\d+\.\d+\.\d+(`)/,
-    replacement: (_d, _match, prefix, suffix) => `${prefix}${tag}${suffix}`,
-  },
-]
-
-let drift = false
-for (const t of targets) {
-  const content = readFileSync(t.path, 'utf8')
-  if (!t.pattern.test(content)) {
-    console.error(`no match in ${t.path} - file format changed?`)
-    drift = true
-    continue
+export function planTargetUpdates(
+  targets: SyncTarget[],
+  digest: string,
+  readFile: (path: string) => string,
+): Map<string, string> {
+  const errors: string[] = []
+  const updates = new Map<string, string>()
+  for (const target of targets) {
+    const content = updates.get(target.path) ?? readFile(target.path)
+    target.pattern.lastIndex = 0
+    if (!target.pattern.test(content)) {
+      errors.push(`no match in ${target.path} - file format changed?`)
+      continue
+    }
+    target.pattern.lastIndex = 0
+    const updated = content.replace(target.pattern, (match, ...groups) =>
+      target.replacement(digest, match, ...groups),
+    )
+    updates.set(target.path, updated)
   }
-  t.pattern.lastIndex = 0
-  const updated = content.replace(t.pattern, (match, ...groups) =>
-    t.replacement(digest, match, ...groups),
-  )
-  writeFileSync(t.path, updated)
-  console.log(`updated ${t.path}`)
+
+  if (errors.length > 0) throw new Error(errors.join('\n'))
+  return updates
 }
 
-if (drift) process.exit(1)
+export function applyTargetUpdates(
+  targets: SyncTarget[],
+  digest: string,
+  readFile: (path: string) => string,
+  writeFile: (path: string, content: string) => void,
+): void {
+  const updates = planTargetUpdates(targets, digest, readFile)
+  for (const [path, content] of updates) writeFile(path, content)
+}
+
+export async function syncDeployDigests(overrides: Partial<SyncDeps> = {}): Promise<void> {
+  const deps: SyncDeps = {
+    tagArg: process.argv[2],
+    fetch,
+    readFile: (path) => readFileSync(path, 'utf8'),
+    writeFile: writeFileSync,
+    log: console.log,
+    ...overrides,
+  }
+  const tag = parseReleaseTag(deps.tagArg)
+  const digest = await ghcrDigest(tag, deps.fetch)
+  deps.log(`digest for ${tag}: ${digest}`)
+  applyTargetUpdates(createTargets(tag), digest, deps.readFile, (path, content) => {
+    deps.writeFile(path, content)
+    deps.log(`updated ${path}`)
+  })
+}
+
+if (import.meta.main) {
+  await syncDeployDigests().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  })
+}

--- a/tests/scripts/rotate-encryption-key.test.ts
+++ b/tests/scripts/rotate-encryption-key.test.ts
@@ -44,65 +44,71 @@ describe('encryption-key rotation coverage', () => {
 
   it('exits nonzero when encrypted ciphertext cannot be rotated', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'digarr-rotation-'))
-    const client = new PGlite(dataDir)
-    await client.exec(`
-      CREATE TABLE settings (
-        id integer PRIMARY KEY,
-        lidarr_api_key text,
-        ai_api_key text,
-        audiodb_api_key text,
-        oidc_client_secret text,
-        tidal_client_secret text,
-        preferences jsonb
-      );
-      CREATE TABLE users (
-        id integer PRIMARY KEY,
-        listenbrainz_token text,
-        lastfm_api_key text,
-        plex_token text,
-        jellyfin_api_key text,
-        emby_api_key text,
-        discogs_token text,
-        subsonic_password text
-      );
-      CREATE TABLE oauth_tokens (
-        id integer PRIMARY KEY,
-        access_token text,
-        refresh_token text,
-        client_secret text
-      );
-      CREATE TABLE oidc_tokens (
-        id integer PRIMARY KEY,
-        access_token text,
-        refresh_token text,
-        id_token text
-      );
-      CREATE TABLE targets (id integer PRIMARY KEY, config jsonb);
-      INSERT INTO settings (id, ai_api_key) VALUES (1, 'enc:v1:malformed');
-    `)
-    await client.close()
+    try {
+      const client = new PGlite(dataDir)
+      try {
+        await client.exec(`
+          CREATE TABLE settings (
+            id integer PRIMARY KEY,
+            lidarr_api_key text,
+            ai_api_key text,
+            audiodb_api_key text,
+            oidc_client_secret text,
+            tidal_client_secret text,
+            preferences jsonb
+          );
+          CREATE TABLE users (
+            id integer PRIMARY KEY,
+            listenbrainz_token text,
+            lastfm_api_key text,
+            plex_token text,
+            jellyfin_api_key text,
+            emby_api_key text,
+            discogs_token text,
+            subsonic_password text
+          );
+          CREATE TABLE oauth_tokens (
+            id integer PRIMARY KEY,
+            access_token text,
+            refresh_token text,
+            client_secret text
+          );
+          CREATE TABLE oidc_tokens (
+            id integer PRIMARY KEY,
+            access_token text,
+            refresh_token text,
+            id_token text
+          );
+          CREATE TABLE targets (id integer PRIMARY KEY, config jsonb);
+          INSERT INTO settings (id, ai_api_key) VALUES (1, 'enc:v1:malformed');
+        `)
+      } finally {
+        await client.close()
+      }
 
-    const env: NodeJS.ProcessEnv = {
-      ...process.env,
-      DB_PATH: dataDir,
-      DATABASE_URL: '',
-      DB_HOST: '',
-      DB_USER: '',
-      DB_NAME: '',
-      DIGARR_ENCRYPTION_KEY: 'test-key-please-do-not-use-in-prod',
-      DIGARR_ENCRYPTION_KEY_NEXT: '',
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        DB_PATH: dataDir,
+        DATABASE_URL: '',
+        DB_HOST: '',
+        DB_USER: '',
+        DB_NAME: '',
+        DIGARR_ENCRYPTION_KEY: 'test-key-please-do-not-use-in-prod',
+        DIGARR_ENCRYPTION_KEY_NEXT: '',
+      }
+
+      const result = spawnSync('bun', ['scripts/rotate-encryption-key.ts'], {
+        cwd: process.cwd(),
+        env,
+        encoding: 'utf8',
+        timeout: 30_000,
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('rotation incomplete: 1 encrypted values')
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true })
     }
-
-    const result = spawnSync('bun', ['scripts/rotate-encryption-key.ts'], {
-      cwd: process.cwd(),
-      env,
-      encoding: 'utf8',
-      timeout: 15_000,
-    })
-    rmSync(dataDir, { recursive: true, force: true })
-
-    expect(result.error).toBeUndefined()
-    expect(result.status).toBe(1)
-    expect(result.stderr).toContain('rotation incomplete: 1 encrypted values')
-  }, 20_000)
+  }, 35_000)
 })

--- a/tests/scripts/sync-deploy-digests.test.ts
+++ b/tests/scripts/sync-deploy-digests.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment node
+
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyTargetUpdates,
+  parseReleaseTag,
+  type SyncTarget,
+  syncDeployDigests,
+} from '../../scripts/sync-deploy-digests'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('sync-deploy-digests CLI', () => {
+  it('rejects a malformed tag', () => {
+    const result = spawnSync('bun', ['scripts/sync-deploy-digests.ts', 'not-a-version'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      timeout: 5_000,
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('invalid tag "not-a-version"')
+  })
+})
+
+describe('stable release tags', () => {
+  it.each([
+    ['v1.2.3', '1.2.3'],
+    ['1.2.3', '1.2.3'],
+  ])('normalizes %s', (input, expected) => {
+    expect(parseReleaseTag(input)).toBe(expected)
+  })
+
+  it.each(['v1.2.3-rc.1', '1.2.3+build.4'])('rejects non-release tag %s', (input) => {
+    expect(() => parseReleaseTag(input)).toThrow('expected vX.Y.Z or X.Y.Z')
+  })
+
+  it('rejects a prerelease before registry access', async () => {
+    const fetchMock = vi.fn<typeof fetch>()
+
+    await expect(
+      syncDeployDigests({
+        tagArg: 'v1.2.3-rc.1',
+        fetch: fetchMock,
+        readFile: vi.fn(),
+        writeFile: vi.fn(),
+        log: vi.fn(),
+      }),
+    ).rejects.toThrow('expected vX.Y.Z or X.Y.Z')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('release workflow policy', () => {
+  it('contains no prerelease release path', () => {
+    const workflow = readFileSync('.github/workflows/release.yml', 'utf8')
+
+    expect(workflow).toMatch(/\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/)
+    expect(workflow).not.toMatch(
+      /prerelease=true|prerelease=false|--prerelease|channel=rc|steps\.tag\.outputs\.prerelease/,
+    )
+  })
+})
+
+describe('CI workflow reliability policy', () => {
+  it('requires every macOS compatibility assertion to complete', () => {
+    const workflow = readFileSync('.github/workflows/compatibility.yml', 'utf8')
+    const macJob = workflow.split('  docker-macos:')[1] ?? ''
+
+    expect(macJob.match(/continue-on-error: true/g)).toHaveLength(1)
+    expect(macJob).toContain('id: docker')
+    expect(macJob).toContain('id: postgres_assert')
+    expect(macJob).toContain('id: pglite_assert')
+    expect(macJob).toContain('if: always()')
+    expect(macJob).toContain('POSTGRES_ASSERTED')
+    expect(macJob).toContain('PGLITE_ASSERTED')
+  })
+
+  it('bounds Forgejo package and Helm downloads without suppressing drift', () => {
+    const workflow = readFileSync('.forgejo/workflows/ci.yml', 'utf8')
+    const helmJob = workflow.split('  helm-drift:')[1]?.split('\n  browser-test:')[0] ?? ''
+
+    expect(helmJob).toContain('Acquire::Retries=3')
+    expect(helmJob).toContain('--connect-timeout 15')
+    expect(helmJob).toContain('--max-time 120')
+    expect(helmJob).toContain('sha256sum -c -')
+    expect(helmJob).toContain('helm lint deploy/helm/digarr')
+    expect(helmJob).toContain('git diff --exit-code -- deploy/k8s/rendered.yaml')
+  })
+})
+
+describe('preflighted target updates', () => {
+  it('writes nothing when any target pattern is missing', () => {
+    const targets: SyncTarget[] = [
+      {
+        path: 'first.txt',
+        pattern: /old/,
+        replacement: () => 'new',
+      },
+      {
+        path: 'second.txt',
+        pattern: /missing/,
+        replacement: () => 'new',
+      },
+    ]
+    const contents = new Map([
+      ['first.txt', 'old'],
+      ['second.txt', 'unchanged'],
+    ])
+    const writeFile = vi.fn()
+
+    expect(() =>
+      applyTargetUpdates(
+        targets,
+        'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        (path) => contents.get(path) ?? '',
+        writeFile,
+      ),
+    ).toThrow('no match in second.txt')
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  it('stages repeated rules and writes each deploy file once', async () => {
+    vi.stubEnv('GH_TOKEN', '')
+    const digest = `sha256:${'a'.repeat(64)}`
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({ token: 'anonymous-token' }))
+      .mockResolvedValueOnce(new Response(null, { headers: { 'docker-content-digest': digest } }))
+    const writeFile = vi.fn()
+
+    await syncDeployDigests({
+      tagArg: 'v9.8.7',
+      fetch: fetchMock,
+      readFile: (path) => readFileSync(path, 'utf8'),
+      writeFile,
+      log: vi.fn(),
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(writeFile).toHaveBeenCalledTimes(7)
+    expect(writeFile.mock.calls.map(([path]) => path)).toEqual([
+      'deploy/k8s/deployment.yaml',
+      'deploy/helm/digarr/values.yaml',
+      'deploy/k8s/rendered.yaml',
+      'deploy/unraid/digarr.xml',
+      'deploy/docker/docker-compose.yml',
+      'deploy/docker/docker-compose.pglite.yml',
+      'README.md',
+    ])
+
+    const writes = new Map<string, string>()
+    for (const [path, content] of writeFile.mock.calls) writes.set(path, content)
+
+    expect(writes.get('deploy/k8s/deployment.yaml')).toContain(`@${digest}`)
+    expect(writes.get('deploy/helm/digarr/values.yaml')).toContain('tag: "9.8.7"')
+    expect(writes.get('deploy/helm/digarr/values.yaml')).toContain(`digest: "${digest}"`)
+    expect(writes.get('deploy/k8s/rendered.yaml')).toContain(`@${digest}`)
+    expect(writes.get('deploy/unraid/digarr.xml')).toContain(
+      `<Repository>docker.io/iuliandita/digarr:9.8.7</Repository>`,
+    )
+    expect(writes.get('deploy/unraid/digarr.xml')).toContain('<Tag>9.8.7</Tag>')
+    expect(writes.get('deploy/unraid/digarr.xml')).toContain(
+      '<TagDescription>v9.8.7 release</TagDescription>',
+    )
+    expect(writes.get('deploy/docker/docker-compose.yml')).toContain(
+      ':9.8 -> current minor release line',
+    )
+    expect(writes.get('deploy/docker/docker-compose.yml')).toContain(
+      'docker.io/iuliandita/digarr:9.8.7-debian',
+    )
+    expect(writes.get('deploy/docker/docker-compose.pglite.yml')).toContain(
+      'docker.io/iuliandita/digarr:9.8',
+    )
+    expect(writes.get('deploy/docker/docker-compose.pglite.yml')).toContain(
+      'docker.io/iuliandita/digarr:9.8.7-debian',
+    )
+    expect(writes.get('README.md')).toContain('minor tag like `:9.8`')
+    expect(writes.get('README.md')).toContain('specific patch like `:9.8.7`')
+  })
+})


### PR DESCRIPTION
## Summary

- make the advisory macOS compatibility job prove both database backends ran instead of passing after skipped setup
- add bounded retries and timeouts to Forgejo package and pinned Helm setup while keeping lint, checksum, render, and drift assertions strict
- remove prerelease branches from release and digest-sync tooling so nightly is the only test channel before `main` / `:latest`
- preflight every digest and example replacement before the first write, with regression coverage for all staged outputs
- give the real encryption-rotation subprocess enough runner headroom and guarantee temporary database cleanup

## Verification

- `bun run test` (2,855 passed, 26 skipped)
- `bun run test:api-routes` (41 passed)
- `bun run lint`
- `bun run typecheck`
- `bun run i18n:check`
- `bun run check:versions`
- `bun run build`
- workflow YAML parse and `actionlint`
- `helm lint deploy/helm/digarr --set postgresql.auth.password=lint`
- `./scripts/k8s-sync.sh` with a clean rendered-manifest diff
- Gitleaks, TruffleHog, Semgrep, Trivy, and `bun audit --audit-level=high`

Closes #489
Closes #493
Closes #495
Closes #499
