### PR TITLE
fix(security): isolate Spotify controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Releases that have been promoted to the `:stable` Docker channel carry a `(stabl
 
 ### Fixed
 
+- **Spotify's preview controller no longer runs inside the authenticated app.** Continuous audition now loads the supported controller in a no-same-origin sandbox and exchanges only validated commands and playback events over a private channel. Standalone previews retain the standard Spotify iframe fallback when the bridge fails.
 - **Slow OpenAI-compatible providers no longer fail with opaque abort errors.** Connection tests now honor `DIGARR_AI_TIMEOUT_SECONDS` instead of stopping after 10 seconds, recommendation timeouts report their configured duration, and Open WebUI `/api` base URLs use its documented chat-completions route. Standard `/v1` bases and full completion URLs are normalized without duplicate path segments.
 
 ## v1.13.0 - 2026-07-15

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,13 +118,18 @@ Adding a new implementation means:
 
 Recommendation-card tracks and the Discover audition queue share the global
 preview context, so starting one preview stops the other audio surface. Deezer
-clips advance from the native `ended` event. Spotify audition playback uses one
-persistent iframe controller: it reports real playback start and completion,
-only completion advances the queue, and an autoplay block leaves the current
-native control usable. Controller initialization is bounded and falls back to
-the standard Spotify iframe for standalone previews; an active audition queue
-skips the unavailable item. YouTube embeds have no equivalent
-completion signal in this integration and use a bounded 30-second fallback.
+clips advance from the native `ended` event. Spotify audition playback keeps one
+persistent local bridge iframe with `sandbox="allow-scripts"` and no
+same-origin capability. Spotify's controller script and embed run only inside
+that opaque-origin document; the authenticated SPA transfers a private
+`MessageChannel` and accepts exact, token-bound playback events. The narrow
+protocol carries load/play/pause/destroy commands plus ready, started, state,
+and failure events. Playback start, pause, completion deduplication, controller
+reuse, and queue advancement remain in the SPA. Bridge initialization is
+bounded and falls back to the standard Spotify iframe for standalone previews;
+an active audition queue skips the unavailable item. YouTube embeds have no
+equivalent completion signal in this integration and use a bounded 30-second
+fallback.
 
 ## Boot order
 

--- a/spotify-embed-bridge.html
+++ b/spotify-embed-bridge.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spotify</title>
+    <style>
+      html,
+      body,
+      #spotify-embed-host {
+        width: 100%;
+        min-height: 80px;
+        margin: 0;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="spotify-embed-host"></div>
+    <script type="module" src="/src/web/spotify-embed-bridge.ts"></script>
+  </body>
+</html>

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -58,6 +58,18 @@ export type { AppDependencies } from './deps'
 
 import type { AppDependencies } from './deps'
 
+const SPOTIFY_BRIDGE_CSP = [
+  "default-src 'none'",
+  "script-src 'self' https://open.spotify.com/embed/iframe-api/v1 https://embed-cdn.spotifycdn.com/_next/static/",
+  "style-src 'unsafe-inline'",
+  'img-src data: https://i.scdn.co https://*.spotifycdn.com',
+  'connect-src https://*.spotify.com https://*.spotifycdn.com',
+  'frame-src https://open.spotify.com',
+  "frame-ancestors 'self'",
+  "base-uri 'none'",
+  "form-action 'none'",
+].join('; ')
+
 export function createApp(deps: AppDependencies) {
   const app = new Hono<HonoEnv>()
 
@@ -108,6 +120,11 @@ export function createApp(deps: AppDependencies) {
         envConfig.allowedOrigin ?? (process.env.NODE_ENV === 'production' ? () => undefined : '*'),
     }),
   )
+  app.use('/spotify-embed-bridge.html', async (c, next) => {
+    await next()
+    c.header('Content-Security-Policy', SPOTIFY_BRIDGE_CSP)
+    c.header('X-Frame-Options', 'SAMEORIGIN')
+  })
   app.use(
     '*',
     secureHeaders({
@@ -118,11 +135,7 @@ export function createApp(deps: AppDependencies) {
       strictTransportSecurity: 'max-age=31536000; includeSubDomains',
       contentSecurityPolicy: {
         defaultSrc: ["'self'"],
-        scriptSrc: [
-          "'self'",
-          'https://open.spotify.com/embed/iframe-api/v1',
-          'https://embed-cdn.spotifycdn.com/_next/static/',
-        ],
+        scriptSrc: ["'self'"],
         styleSrc: ["'self'", "'unsafe-inline'"],
         imgSrc: ["'self'", 'data:', 'https:'],
         connectSrc: ["'self'", 'https:'],

--- a/src/server/routes/test-seed.ts
+++ b/src/server/routes/test-seed.ts
@@ -18,7 +18,7 @@ const SEED_ARTISTS = [
     score: 0.92,
     wikidataId: 'Q100000001',
     description: 'Seed Artist Alpha is a fictional indie rock act used by the E2E harness.',
-    streamingUrls: { spotify: 'https://open.spotify.com/artist/seed-alpha' },
+    streamingUrls: { spotify: 'https://open.spotify.com/artist/seedalpha' },
     externalLinks: {
       wikipedia: 'https://en.wikipedia.org/wiki/Seed_Artist_Alpha',
       officialSite: 'https://example.com/seed-alpha',
@@ -32,7 +32,7 @@ const SEED_ARTISTS = [
     score: 0.81,
     wikidataId: 'Q100000002',
     description: 'Seed Artist Bravo is a fictional synthpop act used by the E2E harness.',
-    streamingUrls: { spotify: 'https://open.spotify.com/artist/seed-bravo' },
+    streamingUrls: { spotify: 'https://open.spotify.com/artist/seedbravo' },
     externalLinks: {
       wikipedia: 'https://en.wikipedia.org/wiki/Seed_Artist_Bravo',
     },
@@ -44,7 +44,7 @@ const SEED_ARTISTS = [
     score: 0.74,
     wikidataId: 'Q100000003',
     description: 'Seed Artist Charlie is a fictional folk act used by the E2E harness.',
-    streamingUrls: { spotify: 'https://open.spotify.com/artist/seed-charlie' },
+    streamingUrls: { spotify: 'https://open.spotify.com/artist/seedcharlie' },
     externalLinks: {
       wikipedia: 'https://en.wikipedia.org/wiki/Seed_Artist_Charlie',
     },

--- a/src/web/hooks/use-spotify-embed.ts
+++ b/src/web/hooks/use-spotify-embed.ts
@@ -1,90 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { isSpotifyBridgeEvent, type SpotifyBridgeCommand } from '@/web/lib/spotify-bridge-protocol'
 
-const SPOTIFY_IFRAME_API_SRC = 'https://open.spotify.com/embed/iframe-api/v1'
-const SPOTIFY_API_TIMEOUT_MS = 10_000
+const SPOTIFY_BRIDGE_SRC = '/spotify-embed-bridge.html'
+const SPOTIFY_BRIDGE_TIMEOUT_MS = 10_000
+
+function createBridgeToken(): string {
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID()
+
+  const bytes = crypto.getRandomValues(new Uint8Array(16))
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('')
+}
 
 export type SpotifyPlaybackCommand = {
   id: number
   action: 'play' | 'pause'
 }
 
-type SpotifyPlaybackEvent = {
-  data: {
-    isPaused?: boolean
-    isBuffering?: boolean
-    duration?: number
-    position?: number
-    playingURI?: string
-  }
-}
-
-type SpotifyEmbedController = {
-  addListener: (event: string, listener: (event: SpotifyPlaybackEvent) => void) => void
-  loadEntity: (url: string) => void
-  play: () => void
-  pause: () => void
+type SpotifyBridgeController = {
+  token: string
+  post: (command: SpotifyBridgeCommand) => void
   destroy: () => void
-}
-
-type SpotifyIframeApi = {
-  createController: (
-    element: HTMLElement,
-    options: { url: string; width: string; height: number },
-    callback: (controller: SpotifyEmbedController) => void,
-  ) => void
-}
-
-declare global {
-  interface Window {
-    onSpotifyIframeApiReady?: (api: SpotifyIframeApi) => void
-  }
-}
-
-let spotifyIframeApiPromise: Promise<SpotifyIframeApi> | null = null
-
-function loadSpotifyIframeApi(): Promise<SpotifyIframeApi> {
-  if (spotifyIframeApiPromise) return spotifyIframeApiPromise
-
-  spotifyIframeApiPromise = new Promise((resolve, reject) => {
-    let settled = false
-    const existing = document.querySelector<HTMLScriptElement>(
-      `script[src="${SPOTIFY_IFRAME_API_SRC}"]`,
-    )
-    const script = existing ?? document.createElement('script')
-
-    const clearCallback = () => {
-      if (window.onSpotifyIframeApiReady === handleReady) {
-        delete window.onSpotifyIframeApiReady
-      }
-    }
-    const fail = () => {
-      if (settled) return
-      settled = true
-      clearTimeout(timeout)
-      clearCallback()
-      script.remove()
-      spotifyIframeApiPromise = null
-      reject(new Error('Spotify iframe API failed to load'))
-    }
-    const handleReady = (api: SpotifyIframeApi) => {
-      if (settled) return
-      settled = true
-      clearTimeout(timeout)
-      clearCallback()
-      resolve(api)
-    }
-    const timeout = setTimeout(fail, SPOTIFY_API_TIMEOUT_MS)
-
-    window.onSpotifyIframeApiReady = handleReady
-    script.addEventListener('error', fail, { once: true })
-    if (!existing) {
-      script.src = SPOTIFY_IFRAME_API_SRC
-      script.async = true
-      document.body.append(script)
-    }
-  })
-
-  return spotifyIframeApiPromise
 }
 
 type UseSpotifyEmbedOptions = {
@@ -105,7 +40,7 @@ export function useSpotifyEmbed({
   onPlaybackEnded,
 }: UseSpotifyEmbedOptions) {
   const hostRef = useRef<HTMLDivElement>(null)
-  const controllerRef = useRef<SpotifyEmbedController | null>(null)
+  const controllerRef = useRef<SpotifyBridgeController | null>(null)
   const creatingRef = useRef(false)
   const attemptRef = useRef(0)
   const createTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -167,9 +102,9 @@ export function useSpotifyEmbed({
     [removeController],
   )
 
-  const loadUrl = useCallback((controller: SpotifyEmbedController, nextUrl: string) => {
+  const loadUrl = useCallback((controller: SpotifyBridgeController, nextUrl: string) => {
     if (loadedUrlRef.current === nextUrl) return
-    controller.loadEntity(nextUrl)
+    controller.post({ type: 'load', token: controller.token, url: nextUrl })
     loadedUrlRef.current = nextUrl
     startedRef.current = false
     pausedRef.current = false
@@ -177,69 +112,38 @@ export function useSpotifyEmbed({
   }, [])
 
   const applyLatest = useCallback(
-    (controller: SpotifyEmbedController) => {
+    (controller: SpotifyBridgeController) => {
       const latest = latestRef.current
       if (!latest.url) {
-        controller.pause()
+        controller.post({ type: 'pause', token: controller.token })
         if (!latest.keepAlive) destroyController()
         return
       }
       if (!readyRef.current) return
 
       loadUrl(controller, latest.url)
-      controller[latest.command.action]()
+      controller.post({ type: latest.command.action, token: controller.token })
     },
     [destroyController, loadUrl],
   )
 
-  const attachListeners = useCallback((controller: SpotifyEmbedController, attempt: number) => {
-    controller.addListener('playback_started', () => {
-      if (attemptRef.current !== attempt) return
-      startedRef.current = true
-      pausedRef.current = false
-      endedRef.current = false
-      onPlaybackStartedRef.current()
-    })
-    controller.addListener('playback_update', (event) => {
-      if (attemptRef.current !== attempt || !startedRef.current || endedRef.current) return
-
-      const duration = event.data.duration ?? 0
-      const position = event.data.position ?? 0
-      if (duration > 0 && position >= duration) {
-        endedRef.current = true
-        onPlaybackEndedRef.current()
-        return
-      }
-      if (event.data.isBuffering) return
-      if (event.data.isPaused === true && !pausedRef.current) {
-        pausedRef.current = true
-        onPlaybackPausedRef.current()
-      } else if (event.data.isPaused === false && pausedRef.current) {
-        pausedRef.current = false
-        onPlaybackStartedRef.current()
-      }
-    })
-  }, [])
-
   useEffect(() => {
-    const controller = controllerRef.current
-    if (controller) {
+    const existingController = controllerRef.current
+    if (existingController && !creatingRef.current) {
       if (!url) {
-        if (readyRef.current) controller.pause()
+        if (readyRef.current) {
+          existingController.post({ type: 'pause', token: existingController.token })
+        }
         if (!keepAlive) destroyController()
       } else if (readyRef.current) {
-        loadUrl(controller, url)
-        controller[command.action]()
+        loadUrl(existingController, url)
+        existingController.post({ type: command.action, token: existingController.token })
       }
       return
     }
 
     if (!url) {
-      if (creatingRef.current) {
-        attemptRef.current += 1
-        creatingRef.current = false
-        clearControllerTimeouts()
-      }
+      if (creatingRef.current) destroyController()
       return
     }
     if (creatingRef.current || !hostRef.current) return
@@ -248,58 +152,136 @@ export function useSpotifyEmbed({
     attemptRef.current = attempt
     creatingRef.current = true
     setFailedUrl(null)
+    resetPlaybackState()
 
-    void loadSpotifyIframeApi()
-      .then((api) => {
+    const initialUrl = url
+    const token = createBridgeToken()
+    const iframe = document.createElement('iframe')
+    const channel = new MessageChannel()
+    let destroyed = false
+    iframe.src = SPOTIFY_BRIDGE_SRC
+    iframe.setAttribute('sandbox', 'allow-scripts')
+    iframe.allow = 'autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture'
+    iframe.title = 'Spotify'
+    iframe.width = '100%'
+    iframe.height = '80'
+    iframe.style.border = '0'
+
+    const controller: SpotifyBridgeController = {
+      token,
+      post: (nextCommand) => {
+        if (destroyed) return
+        try {
+          channel.port1.postMessage(nextCommand)
+        } catch {
+          failAttempt(attempt)
+        }
+      },
+      destroy: () => {
+        if (destroyed) return
+        try {
+          channel.port1.postMessage({ type: 'destroy', token } satisfies SpotifyBridgeCommand)
+        } catch {
+          // A closed channel must not keep the iframe alive.
+        }
+        destroyed = true
+        try {
+          channel.port1.close()
+        } catch {
+          // The iframe still needs to be detached.
+        }
+        try {
+          channel.port2.close()
+        } catch {
+          // The transferred endpoint may already be detached.
+        }
+        iframe.remove()
+      },
+    }
+    controllerRef.current = controller
+    loadedUrlRef.current = initialUrl
+
+    channel.port1.onmessage = (event: MessageEvent<unknown>) => {
+      if (
+        attemptRef.current !== attempt ||
+        disposedRef.current ||
+        !isSpotifyBridgeEvent(event.data) ||
+        event.data.token !== token
+      ) {
+        return
+      }
+
+      if (event.data.type === 'failure') {
+        failAttempt(attempt)
+        return
+      }
+      if (event.data.type === 'ready') {
+        if (readyRef.current) return
+        if (readyTimeoutRef.current) clearTimeout(readyTimeoutRef.current)
+        readyTimeoutRef.current = null
+        creatingRef.current = false
+        readyRef.current = true
+        applyLatest(controller)
+        return
+      }
+      if (event.data.type === 'playback-started') {
+        startedRef.current = true
+        pausedRef.current = false
+        endedRef.current = false
+        onPlaybackStartedRef.current()
+        return
+      }
+      if (!startedRef.current || endedRef.current) return
+
+      if (event.data.duration > 0 && event.data.position >= event.data.duration) {
+        endedRef.current = true
+        onPlaybackEndedRef.current()
+        return
+      }
+      if (event.data.buffering) return
+      if (event.data.paused && !pausedRef.current) {
+        pausedRef.current = true
+        onPlaybackPausedRef.current()
+      } else if (!event.data.paused && pausedRef.current) {
+        pausedRef.current = false
+        onPlaybackStartedRef.current()
+      }
+    }
+    channel.port1.onmessageerror = () => failAttempt(attempt)
+    channel.port1.start()
+
+    iframe.addEventListener(
+      'load',
+      () => {
         if (attemptRef.current !== attempt || disposedRef.current) return
-
-        const host = hostRef.current
-        const initialUrl = latestRef.current.url
-        if (!host || !initialUrl) {
-          creatingRef.current = false
+        if (createTimeoutRef.current) clearTimeout(createTimeoutRef.current)
+        createTimeoutRef.current = null
+        const bridgeWindow = iframe.contentWindow
+        if (!bridgeWindow) {
+          failAttempt(attempt)
           return
         }
 
-        host.replaceChildren()
-        const target = document.createElement('div')
-        host.append(target)
-        createTimeoutRef.current = setTimeout(() => failAttempt(attempt), SPOTIFY_API_TIMEOUT_MS)
-
-        api.createController(
-          target,
-          { url: initialUrl, width: '100%', height: 80 },
-          (createdController) => {
-            if (attemptRef.current !== attempt || disposedRef.current) {
-              createdController.destroy()
-              return
-            }
-
-            if (createTimeoutRef.current) clearTimeout(createTimeoutRef.current)
-            createTimeoutRef.current = null
-            creatingRef.current = false
-            controllerRef.current = createdController
-            resetPlaybackState()
-            loadedUrlRef.current = initialUrl
-            attachListeners(createdController, attempt)
-            readyTimeoutRef.current = setTimeout(() => failAttempt(attempt), SPOTIFY_API_TIMEOUT_MS)
-            createdController.addListener('ready', () => {
-              if (attemptRef.current !== attempt || disposedRef.current) return
-              if (readyTimeoutRef.current) clearTimeout(readyTimeoutRef.current)
-              readyTimeoutRef.current = null
-              readyRef.current = true
-              applyLatest(createdController)
-            })
-          },
-        )
-      })
-      .catch(() => failAttempt(attempt))
+        readyTimeoutRef.current = setTimeout(() => failAttempt(attempt), SPOTIFY_BRIDGE_TIMEOUT_MS)
+        try {
+          // Opaque sandbox origins require "*"; the exact iframe receives a private token-bound port.
+          // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+          bridgeWindow.postMessage({ type: 'spotify-bridge-init', token, url: initialUrl }, '*', [
+            channel.port2,
+          ])
+        } catch {
+          failAttempt(attempt)
+        }
+      },
+      { once: true },
+    )
+    createTimeoutRef.current = setTimeout(() => failAttempt(attempt), SPOTIFY_BRIDGE_TIMEOUT_MS)
+    hostRef.current.replaceChildren(iframe)
   }, [
     url,
     keepAlive,
     command,
     applyLatest,
-    attachListeners,
-    clearControllerTimeouts,
     destroyController,
     failAttempt,
     loadUrl,

--- a/src/web/lib/spotify-bridge-protocol.ts
+++ b/src/web/lib/spotify-bridge-protocol.ts
@@ -1,0 +1,107 @@
+export type SpotifyBridgeInit = {
+  type: 'spotify-bridge-init'
+  token: string
+  url: string
+}
+
+export type SpotifyBridgeCommand =
+  | { type: 'load'; token: string; url: string }
+  | { type: 'play'; token: string }
+  | { type: 'pause'; token: string }
+  | { type: 'destroy'; token: string }
+
+export type SpotifyBridgeEvent =
+  | { type: 'ready'; token: string }
+  | { type: 'playback-started'; token: string }
+  | {
+      type: 'playback-state'
+      token: string
+      paused: boolean
+      buffering: boolean
+      duration: number
+      position: number
+    }
+  | { type: 'failure'; token: string }
+
+const MAX_TOKEN_LENGTH = 128
+const MAX_URL_LENGTH = 2_048
+
+function hasExactKeys(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false
+  if (Object.getPrototypeOf(value) !== Object.prototype) return false
+
+  const ownKeys = Reflect.ownKeys(value)
+  return ownKeys.length === keys.length && ownKeys.every((key) => keys.includes(String(key)))
+}
+
+function isToken(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= MAX_TOKEN_LENGTH &&
+    value.trim().length > 0
+  )
+}
+
+function isSpotifyUrl(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > MAX_URL_LENGTH) return false
+  try {
+    const url = new URL(value)
+    return (
+      url.protocol === 'https:' &&
+      url.host === 'open.spotify.com' &&
+      url.username === '' &&
+      url.password === ''
+    )
+  } catch {
+    return false
+  }
+}
+
+function isPlaybackNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+export function isSpotifyBridgeInit(value: unknown): value is SpotifyBridgeInit {
+  return (
+    hasExactKeys(value, ['type', 'token', 'url']) &&
+    value.type === 'spotify-bridge-init' &&
+    isToken(value.token) &&
+    isSpotifyUrl(value.url)
+  )
+}
+
+export function isSpotifyBridgeCommand(value: unknown): value is SpotifyBridgeCommand {
+  if (hasExactKeys(value, ['type', 'token'])) {
+    return (
+      (value.type === 'play' || value.type === 'pause' || value.type === 'destroy') &&
+      isToken(value.token)
+    )
+  }
+
+  return (
+    hasExactKeys(value, ['type', 'token', 'url']) &&
+    value.type === 'load' &&
+    isToken(value.token) &&
+    isSpotifyUrl(value.url)
+  )
+}
+
+export function isSpotifyBridgeEvent(value: unknown): value is SpotifyBridgeEvent {
+  if (hasExactKeys(value, ['type', 'token'])) {
+    return (
+      (value.type === 'ready' || value.type === 'playback-started' || value.type === 'failure') &&
+      isToken(value.token)
+    )
+  }
+
+  return (
+    hasExactKeys(value, ['type', 'token', 'paused', 'buffering', 'duration', 'position']) &&
+    value.type === 'playback-state' &&
+    isToken(value.token) &&
+    typeof value.paused === 'boolean' &&
+    typeof value.buffering === 'boolean' &&
+    isPlaybackNumber(value.duration) &&
+    isPlaybackNumber(value.position)
+  )
+}

--- a/src/web/spotify-embed-bridge.ts
+++ b/src/web/spotify-embed-bridge.ts
@@ -1,0 +1,210 @@
+import {
+  isSpotifyBridgeCommand,
+  isSpotifyBridgeEvent,
+  isSpotifyBridgeInit,
+  type SpotifyBridgeEvent,
+} from './lib/spotify-bridge-protocol'
+
+const SPOTIFY_IFRAME_API_SRC = 'https://open.spotify.com/embed/iframe-api/v1'
+const SPOTIFY_API_TIMEOUT_MS = 10_000
+
+type SpotifyPlaybackEvent = {
+  data?: {
+    isPaused?: unknown
+    isBuffering?: unknown
+    duration?: unknown
+    position?: unknown
+  }
+}
+
+type SpotifyEmbedController = {
+  addListener: (event: string, listener: (event: SpotifyPlaybackEvent) => void) => void
+  loadEntity: (url: string) => void
+  play: () => void
+  pause: () => void
+  destroy: () => void
+}
+
+type SpotifyIframeApi = {
+  createController: (
+    element: HTMLElement,
+    options: { url: string; width: string; height: number },
+    callback: (controller: SpotifyEmbedController) => void,
+  ) => void
+}
+
+type SpotifyWindow = Window & {
+  onSpotifyIframeApiReady?: (api: SpotifyIframeApi) => void
+}
+
+function referrerOrigin(): string | null {
+  if (!document.referrer) return null
+  try {
+    return new URL(document.referrer).origin
+  } catch {
+    return null
+  }
+}
+
+function nonnegativeNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0
+}
+
+const expectedParentOrigin = referrerOrigin()
+const host = document.querySelector<HTMLElement>('#spotify-embed-host')
+const spotifyWindow = window as SpotifyWindow
+
+let port: MessagePort | null = null
+let token: string | null = null
+let script: HTMLScriptElement | null = null
+let controller: SpotifyEmbedController | null = null
+let timeout: ReturnType<typeof setTimeout> | null = null
+let closed = false
+
+function clearBridgeTimeout() {
+  if (timeout) clearTimeout(timeout)
+  timeout = null
+}
+
+function send(event: SpotifyBridgeEvent) {
+  if (!port || !isSpotifyBridgeEvent(event)) return
+  try {
+    port.postMessage(event)
+  } catch {
+    closeBridge()
+  }
+}
+
+function clearReadyCallback() {
+  delete spotifyWindow.onSpotifyIframeApiReady
+}
+
+function closeBridge() {
+  if (closed) return
+  closed = true
+  clearBridgeTimeout()
+  clearReadyCallback()
+  try {
+    controller?.destroy()
+  } catch {
+    // The remote adapter must not block local cleanup.
+  }
+  controller = null
+  script?.remove()
+  script = null
+  host?.replaceChildren()
+  try {
+    port?.close()
+  } catch {
+    // The document and controller are already detached.
+  }
+  port = null
+}
+
+function failBridge() {
+  if (closed || !token) return
+  send({ type: 'failure', token })
+  closeBridge()
+}
+
+function applyCommand(event: MessageEvent<unknown>) {
+  if (!token || !isSpotifyBridgeCommand(event.data) || event.data.token !== token) return
+
+  if (event.data.type === 'destroy') {
+    closeBridge()
+    return
+  }
+  if (!controller) return
+
+  try {
+    if (event.data.type === 'load') controller.loadEntity(event.data.url)
+    else controller[event.data.type]()
+  } catch {
+    failBridge()
+  }
+}
+
+function attachController(nextController: SpotifyEmbedController) {
+  if (!token || closed) {
+    nextController.destroy()
+    return
+  }
+
+  clearBridgeTimeout()
+  controller = nextController
+  try {
+    nextController.addListener('ready', () => {
+      if (token && !closed) send({ type: 'ready', token })
+    })
+    nextController.addListener('playback_started', () => {
+      if (token && !closed) send({ type: 'playback-started', token })
+    })
+    nextController.addListener('playback_update', (event) => {
+      if (!token || closed) return
+      send({
+        type: 'playback-state',
+        token,
+        paused: event.data?.isPaused === true,
+        buffering: event.data?.isBuffering === true,
+        duration: nonnegativeNumber(event.data?.duration),
+        position: nonnegativeNumber(event.data?.position),
+      })
+    })
+    nextController.addListener('playback_error', failBridge)
+  } catch {
+    failBridge()
+  }
+}
+
+function loadSpotifyController(url: string) {
+  if (!host) {
+    failBridge()
+    return
+  }
+
+  script = document.createElement('script')
+  script.src = SPOTIFY_IFRAME_API_SRC
+  script.async = true
+  script.addEventListener('error', failBridge, { once: true })
+  spotifyWindow.onSpotifyIframeApiReady = (api) => {
+    if (closed) return
+    clearReadyCallback()
+    clearBridgeTimeout()
+    timeout = setTimeout(failBridge, SPOTIFY_API_TIMEOUT_MS)
+    try {
+      api.createController(host, { url, width: '100%', height: 80 }, attachController)
+    } catch {
+      failBridge()
+    }
+  }
+  timeout = setTimeout(failBridge, SPOTIFY_API_TIMEOUT_MS)
+  document.body.append(script)
+}
+
+function acceptInit(event: MessageEvent<unknown>) {
+  if (
+    port ||
+    !expectedParentOrigin ||
+    event.source !== window.parent ||
+    event.origin !== expectedParentOrigin ||
+    event.ports.length !== 1 ||
+    !isSpotifyBridgeInit(event.data)
+  ) {
+    return
+  }
+
+  window.removeEventListener('message', acceptInit)
+  token = event.data.token
+  port = event.ports[0] ?? null
+  if (!port) return
+  try {
+    port.onmessage = applyCommand
+    port.onmessageerror = failBridge
+    port.start()
+    loadSpotifyController(event.data.url)
+  } catch {
+    failBridge()
+  }
+}
+
+window.addEventListener('message', acceptInit)

--- a/tests/e2e/browser/spotify-bridge.spec.ts
+++ b/tests/e2e/browser/spotify-bridge.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test'
+import { ensureAdminToken, installAuthToken } from './auth'
+import { installDiscoverListView, seedRecommendations } from './seed'
+
+test.describe('Spotify preview bridge', () => {
+  test('isolates the controller and keeps fallback responsive after failure', async ({ page }) => {
+    const token = await ensureAdminToken(page.request, { completeSetup: true })
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    await seedRecommendations(page.request, token)
+    await installAuthToken(page, token)
+    await installDiscoverListView(page)
+    await page.route('**/spotify-embed-bridge.html', (route) =>
+      route.fulfill({
+        contentType: 'text/html',
+        body: `<!doctype html>
+          <script>
+            window.bridgeReady = false;
+            window.addEventListener('message', (event) => {
+              const port = event.ports[0];
+              if (!port) return;
+              window.bridgeReady = true;
+              window.triggerBridgeReady = () => {
+                port.postMessage({ type: 'ready', token: event.data.token });
+              };
+              window.triggerPlaybackStarted = () => {
+                port.postMessage({ type: 'playback-started', token: event.data.token });
+              };
+              window.triggerBridgeFailure = () => {
+                port.postMessage({ type: 'failure', token: event.data.token });
+              };
+            });
+          </script>`,
+      }),
+    )
+
+    await page.goto('/discover')
+    const card = page.locator('[data-testid="rec-card-button"]').first()
+    await expect(card).toBeVisible({ timeout: 10_000 })
+    await card.getByRole('button', { name: /play preview/i }).click()
+
+    const bridgeElement = page.locator('iframe[src="/spotify-embed-bridge.html"]')
+    await expect(bridgeElement).toHaveAttribute('sandbox', 'allow-scripts')
+    const bridgeFrame = page.frames().find((frame) => frame.url().includes('spotify-embed-bridge'))
+    expect(bridgeFrame).toBeTruthy()
+    if (!bridgeFrame) return
+
+    await bridgeFrame.waitForFunction(() => Boolean(window.bridgeReady))
+    const parentAccessBlocked = await bridgeFrame.evaluate(() => {
+      try {
+        void window.parent.document.body
+        return false
+      } catch {
+        return true
+      }
+    })
+    expect(parentAccessBlocked).toBe(true)
+
+    await bridgeFrame.evaluate(() => {
+      window.triggerBridgeReady?.()
+      window.triggerPlaybackStarted?.()
+    })
+    await expect(card.getByRole('button', { name: /stop preview/i })).toBeVisible()
+
+    await bridgeFrame.evaluate(() => window.triggerBridgeFailure?.())
+    await expect(bridgeElement).toHaveCount(0)
+    await expect(
+      page.locator('iframe[src^="https://open.spotify.com/embed/artist/seedalpha"]'),
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: /close preview/i }).click()
+    await expect(page.getByRole('region', { name: /preview player/i })).toHaveCount(0)
+  })
+})
+
+declare global {
+  interface Window {
+    bridgeReady?: boolean
+    triggerBridgeReady?: () => void
+    triggerPlaybackStarted?: () => void
+    triggerBridgeFailure?: () => void
+  }
+}

--- a/tests/server/security-headers.test.ts
+++ b/tests/server/security-headers.test.ts
@@ -3,16 +3,36 @@
 import { describe, expect, it } from 'vitest'
 import { createTestApp } from '../helpers/test-app'
 
+function directive(policy: string, name: string): string | undefined {
+  return policy
+    .split(';')
+    .map((value) => value.trim())
+    .find((value) => value.startsWith(`${name} `))
+}
+
 describe('content security policy', () => {
-  it('allows the Spotify iframe controller script from the same trusted host as embeds', async () => {
+  it('keeps remote scripts out of the authenticated application document', async () => {
     const { app } = createTestApp()
 
     const response = await app.request('/api/v1/auth/status')
-    const policy = response.headers.get('content-security-policy')
+    const policy = response.headers.get('content-security-policy') ?? ''
 
-    expect(policy).toContain(
+    expect(directive(policy, 'script-src')).toBe("script-src 'self'")
+    expect(policy).toContain("frame-src 'self' https://open.spotify.com")
+    expect(response.headers.get('x-frame-options')).toBe('DENY')
+  })
+
+  it('scopes Spotify controller access to the same-origin bridge page', async () => {
+    const { app } = createTestApp()
+
+    const response = await app.request('/spotify-embed-bridge.html')
+    const policy = response.headers.get('content-security-policy') ?? ''
+
+    expect(directive(policy, 'script-src')).toBe(
       "script-src 'self' https://open.spotify.com/embed/iframe-api/v1 https://embed-cdn.spotifycdn.com/_next/static/",
     )
-    expect(policy).toContain("frame-src 'self' https://open.spotify.com")
+    expect(directive(policy, 'frame-src')).toBe('frame-src https://open.spotify.com')
+    expect(directive(policy, 'frame-ancestors')).toBe("frame-ancestors 'self'")
+    expect(response.headers.get('x-frame-options')).toBe('SAMEORIGIN')
   })
 })

--- a/tests/web/components/preview-player.test.tsx
+++ b/tests/web/components/preview-player.test.tsx
@@ -209,6 +209,7 @@ describe('PreviewPlayer', () => {
       onPlaybackPaused: spotify.onPlaybackPaused,
       onPlaybackEnded: spotify.onPlaybackEnded,
     })
+    expect(screen.queryByTitle('Radiohead')).not.toBeInTheDocument()
   })
 
   it('falls back to a usable Spotify iframe when controller initialization fails', () => {

--- a/tests/web/hooks/use-spotify-embed.test.tsx
+++ b/tests/web/hooks/use-spotify-embed.test.tsx
@@ -1,12 +1,35 @@
 // @vitest-environment jsdom
 
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { RefObject } from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSpotifyEmbed } from '@/web/hooks/use-spotify-embed'
 
-type SpotifyEvent = { data: Record<string, unknown> }
-type SpotifyListener = (event: SpotifyEvent) => void
+class FakePort {
+  messages: unknown[] = []
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onmessageerror: (() => void) | null = null
+  start = vi.fn()
+  close = vi.fn()
+
+  postMessage(message: unknown) {
+    this.messages.push(message)
+  }
+
+  dispatch(message: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: message }))
+  }
+}
+
+class FakeMessageChannel {
+  static instances: FakeMessageChannel[] = []
+  port1 = new FakePort()
+  port2 = new FakePort()
+
+  constructor() {
+    FakeMessageChannel.instances.push(this)
+  }
+}
 
 function Harness({
   url,
@@ -40,194 +63,221 @@ function Harness({
   )
 }
 
+const callbacks = {
+  onPlaybackStarted: vi.fn(),
+  onPlaybackPaused: vi.fn(),
+  onPlaybackEnded: vi.fn(),
+}
+
+function bridgeIframe(): HTMLIFrameElement {
+  const iframe = document.querySelector<HTMLIFrameElement>(
+    'iframe[src="/spotify-embed-bridge.html"]',
+  )
+  if (!iframe) throw new Error('Spotify bridge iframe was not created')
+  return iframe
+}
+
+function startBridge() {
+  const iframe = bridgeIframe()
+  const postMessage = vi
+    .spyOn(iframe.contentWindow as Window, 'postMessage')
+    .mockImplementation(() => undefined)
+  fireEvent.load(iframe)
+  const channel = FakeMessageChannel.instances.at(-1)
+  if (!channel) throw new Error('Spotify bridge channel was not created')
+  const init = postMessage.mock.calls[0]?.[0] as {
+    type: string
+    token: string
+    url: string
+  }
+  return { iframe, postMessage, channel, token: init.token }
+}
+
+beforeEach(() => {
+  FakeMessageChannel.instances = []
+  callbacks.onPlaybackStarted.mockReset()
+  callbacks.onPlaybackPaused.mockReset()
+  callbacks.onPlaybackEnded.mockReset()
+  vi.stubGlobal('MessageChannel', FakeMessageChannel)
+})
+
 afterEach(() => {
   vi.useRealTimers()
-  document.querySelector('script[src="https://open.spotify.com/embed/iframe-api/v1"]')?.remove()
-  delete window.onSpotifyIframeApiReady
+  vi.unstubAllGlobals()
 })
 
 describe('useSpotifyEmbed', () => {
-  it('recovers initialization, preserves React ownership, and reports playback state', async () => {
-    const listeners = new Map<string, SpotifyListener>()
-    let iframe: HTMLIFrameElement | null = null
-    const controller = {
-      addListener: vi.fn((event: string, listener: SpotifyListener) => {
-        listeners.set(event, listener)
-      }),
-      loadEntity: vi.fn(),
-      play: vi.fn(),
-      pause: vi.fn(),
-      destroy: vi.fn(() => iframe?.remove()),
-    }
-    const iframeApi = {
-      createController: vi.fn(
-        (
-          element: HTMLElement,
-          _options: Record<string, unknown>,
-          callback: (created: typeof controller) => void,
-        ) => {
-          iframe = document.createElement('iframe')
-          element.replaceWith(iframe)
-          callback(controller)
-        },
-      ),
-    }
-    const onPlaybackStarted = vi.fn()
-    const onPlaybackPaused = vi.fn()
-    const onPlaybackEnded = vi.fn()
-
+  it('uses one sandboxed bridge and preserves playback state semantics', () => {
     const { rerender, unmount } = render(
       <Harness
         url="https://open.spotify.com/artist/first"
         keepAlive
         command={{ id: 1, action: 'play' }}
-        onPlaybackStarted={onPlaybackStarted}
-        onPlaybackPaused={onPlaybackPaused}
-        onPlaybackEnded={onPlaybackEnded}
+        {...callbacks}
       />,
     )
 
-    expect(
-      document.querySelector('script[src="https://open.spotify.com/embed/iframe-api/v1"]'),
-    ).toBeInTheDocument()
-
-    const firstScript = document.querySelector<HTMLScriptElement>(
-      'script[src="https://open.spotify.com/embed/iframe-api/v1"]',
-    )
-    act(() => firstScript?.dispatchEvent(new Event('error')))
-    await waitFor(() => expect(screen.getByTestId('spotify-failed')).toHaveTextContent('true'))
-    expect(firstScript).not.toBeInTheDocument()
-
-    rerender(
-      <Harness
-        url="https://open.spotify.com/artist/first"
-        keepAlive
-        command={{ id: 2, action: 'play' }}
-        onPlaybackStarted={onPlaybackStarted}
-        onPlaybackPaused={onPlaybackPaused}
-        onPlaybackEnded={onPlaybackEnded}
-      />,
-    )
-    expect(
-      document.querySelector('script[src="https://open.spotify.com/embed/iframe-api/v1"]'),
-    ).toBeInTheDocument()
-
-    rerender(
-      <Harness
-        url={null}
-        keepAlive
-        command={{ id: 3, action: 'pause' }}
-        onPlaybackStarted={onPlaybackStarted}
-        onPlaybackPaused={onPlaybackPaused}
-        onPlaybackEnded={onPlaybackEnded}
-      />,
-    )
-    await act(async () => {
-      window.onSpotifyIframeApiReady?.(iframeApi)
-      await Promise.resolve()
-    })
-    expect(iframeApi.createController).not.toHaveBeenCalled()
-
-    rerender(
-      <Harness
-        url="https://open.spotify.com/artist/first"
-        keepAlive
-        command={{ id: 4, action: 'play' }}
-        onPlaybackStarted={onPlaybackStarted}
-        onPlaybackPaused={onPlaybackPaused}
-        onPlaybackEnded={onPlaybackEnded}
-      />,
-    )
-
-    await waitFor(() => expect(iframeApi.createController).toHaveBeenCalledTimes(1))
-    expect(screen.getByTestId('spotify-failed')).toHaveTextContent('false')
-    expect(iframeApi.createController.mock.calls[0]?.[1]).toMatchObject({
-      url: 'https://open.spotify.com/artist/first',
-      width: '100%',
-      height: 80,
-    })
-    expect(controller.play).not.toHaveBeenCalled()
+    const { iframe, postMessage, channel, token } = startBridge()
+    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
+    expect(iframe.getAttribute('sandbox')).not.toContain('allow-same-origin')
     expect(screen.getByTestId('spotify-host')).toContainElement(iframe)
-
-    listeners.get('ready')?.({ data: {} })
-    expect(controller.play).toHaveBeenCalledTimes(1)
-
-    listeners.get('playback_update')?.({
-      data: { isPaused: true, duration: 30_000, position: 30_000 },
-    })
-    expect(onPlaybackEnded).not.toHaveBeenCalled()
-
-    listeners.get('playback_started')?.({ data: { playingURI: 'spotify:track:first' } })
-    expect(onPlaybackStarted).toHaveBeenCalledTimes(1)
-
-    listeners.get('playback_update')?.({
-      data: { isPaused: true, isBuffering: false, duration: 30_000, position: 15_000 },
-    })
-    expect(onPlaybackPaused).toHaveBeenCalledTimes(1)
-
-    listeners.get('playback_update')?.({
-      data: { isPaused: false, isBuffering: false, duration: 30_000, position: 16_000 },
-    })
-    expect(onPlaybackStarted).toHaveBeenCalledTimes(2)
-
-    listeners.get('playback_update')?.({
-      data: { isPaused: true, duration: 30_000, position: 30_000 },
-    })
-    listeners.get('playback_update')?.({
-      data: { isPaused: true, duration: 30_000, position: 30_000 },
-    })
-    expect(onPlaybackEnded).toHaveBeenCalledTimes(1)
-
-    rerender(
-      <Harness
-        url={null}
-        keepAlive
-        command={{ id: 2, action: 'pause' }}
-        onPlaybackStarted={onPlaybackStarted}
-        onPlaybackPaused={onPlaybackPaused}
-        onPlaybackEnded={onPlaybackEnded}
-      />,
+    expect(
+      document.querySelector('script[src^="https://open.spotify.com"]'),
+    ).not.toBeInTheDocument()
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: 'spotify-bridge-init',
+        token,
+        url: 'https://open.spotify.com/artist/first',
+      },
+      '*',
+      [channel.port2],
     )
-    expect(controller.pause).toHaveBeenCalledTimes(1)
-    expect(controller.destroy).not.toHaveBeenCalled()
+    expect(channel.port1.start).toHaveBeenCalledTimes(1)
+
+    act(() => channel.port1.dispatch({ type: 'ready', token: 'wrong-token' }))
+    act(() => channel.port1.dispatch({ type: 'ready', token }))
+    expect(channel.port1.messages).toEqual([{ type: 'play', token }])
+
+    act(() =>
+      channel.port1.dispatch({
+        type: 'playback-state',
+        token,
+        paused: true,
+        buffering: false,
+        duration: 30_000,
+        position: 30_000,
+      }),
+    )
+    expect(callbacks.onPlaybackEnded).not.toHaveBeenCalled()
+
+    act(() => channel.port1.dispatch({ type: 'playback-started', token }))
+    expect(callbacks.onPlaybackStarted).toHaveBeenCalledTimes(1)
+
+    act(() =>
+      channel.port1.dispatch({
+        type: 'playback-state',
+        token,
+        paused: true,
+        buffering: false,
+        duration: 30_000,
+        position: 15_000,
+      }),
+    )
+    expect(callbacks.onPlaybackPaused).toHaveBeenCalledTimes(1)
+
+    act(() =>
+      channel.port1.dispatch({
+        type: 'playback-state',
+        token,
+        paused: false,
+        buffering: false,
+        duration: 30_000,
+        position: 16_000,
+      }),
+    )
+    expect(callbacks.onPlaybackStarted).toHaveBeenCalledTimes(2)
+
+    const ended = {
+      type: 'playback-state',
+      token,
+      paused: true,
+      buffering: false,
+      duration: 30_000,
+      position: 30_000,
+    }
+    act(() => channel.port1.dispatch(ended))
+    act(() => channel.port1.dispatch(ended))
+    expect(callbacks.onPlaybackEnded).toHaveBeenCalledTimes(1)
+
+    rerender(<Harness url={null} keepAlive command={{ id: 2, action: 'pause' }} {...callbacks} />)
+    expect(channel.port1.messages.at(-1)).toEqual({ type: 'pause', token })
+    expect(channel.port1.close).not.toHaveBeenCalled()
 
     rerender(
       <Harness
         url="https://open.spotify.com/artist/second"
         keepAlive
         command={{ id: 3, action: 'play' }}
-        onPlaybackStarted={onPlaybackStarted}
-        onPlaybackPaused={onPlaybackPaused}
-        onPlaybackEnded={onPlaybackEnded}
+        {...callbacks}
       />,
     )
-    expect(controller.loadEntity).toHaveBeenCalledWith('https://open.spotify.com/artist/second')
-    expect(controller.play).toHaveBeenCalledTimes(2)
-    expect(iframeApi.createController).toHaveBeenCalledTimes(1)
+    expect(channel.port1.messages.slice(-2)).toEqual([
+      { type: 'load', token, url: 'https://open.spotify.com/artist/second' },
+      { type: 'play', token },
+    ])
+    expect(FakeMessageChannel.instances).toHaveLength(1)
 
     unmount()
-    expect(controller.destroy).toHaveBeenCalledTimes(1)
+    expect(channel.port1.messages.at(-1)).toEqual({ type: 'destroy', token })
+    expect(channel.port1.close).toHaveBeenCalledTimes(1)
+  })
 
+  it('reports bridge failure and clears it on a fresh attempt', async () => {
+    const { rerender } = render(
+      <Harness
+        url="https://open.spotify.com/artist/first"
+        keepAlive
+        command={{ id: 1, action: 'play' }}
+        {...callbacks}
+      />,
+    )
+    const first = startBridge()
+
+    act(() => first.channel.port1.dispatch({ type: 'failure', token: first.token }))
+    await waitFor(() => expect(screen.getByTestId('spotify-failed')).toHaveTextContent('true'))
+    expect(first.iframe).not.toBeInTheDocument()
+    expect(first.channel.port1.close).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <Harness
+        url="https://open.spotify.com/artist/first"
+        keepAlive
+        command={{ id: 2, action: 'play' }}
+        {...callbacks}
+      />,
+    )
+    const second = startBridge()
+    expect(screen.getByTestId('spotify-failed')).toHaveTextContent('false')
+
+    act(() => second.channel.port1.dispatch({ type: 'ready', token: second.token }))
+    expect(second.channel.port1.messages).toContainEqual({ type: 'play', token: second.token })
+  })
+
+  it('fails when the bridge loads but never becomes ready', () => {
     vi.useFakeTimers()
-    iframeApi.createController.mockImplementationOnce((element: HTMLElement) => {
-      iframe = document.createElement('iframe')
-      element.replaceWith(iframe)
-    })
-    const timedOut = render(
+    render(
       <Harness
         url="https://open.spotify.com/artist/third"
         keepAlive
-        command={{ id: 6, action: 'play' }}
-        onPlaybackStarted={onPlaybackStarted}
-        onPlaybackPaused={onPlaybackPaused}
-        onPlaybackEnded={onPlaybackEnded}
+        command={{ id: 1, action: 'play' }}
+        {...callbacks}
       />,
     )
-    await act(async () => Promise.resolve())
-    expect(iframeApi.createController).toHaveBeenCalledTimes(2)
+    const { iframe, channel } = startBridge()
 
     act(() => vi.advanceTimersByTime(10_000))
     expect(screen.getByTestId('spotify-failed')).toHaveTextContent('true')
-    timedOut.unmount()
+    expect(iframe).not.toBeInTheDocument()
+    expect(channel.port1.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes the bridge when posting the destroy command fails', () => {
+    const { unmount } = render(
+      <Harness
+        url="https://open.spotify.com/artist/first"
+        keepAlive
+        command={{ id: 1, action: 'play' }}
+        {...callbacks}
+      />,
+    )
+    const { iframe, channel } = startBridge()
+    channel.port1.postMessage = vi.fn(() => {
+      throw new Error('closed port')
+    })
+
+    expect(() => unmount()).not.toThrow()
+    expect(iframe).not.toBeInTheDocument()
+    expect(channel.port1.close).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/web/lib/spotify-bridge-protocol.test.ts
+++ b/tests/web/lib/spotify-bridge-protocol.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSpotifyBridgeCommand,
+  isSpotifyBridgeEvent,
+  isSpotifyBridgeInit,
+} from '@/web/lib/spotify-bridge-protocol'
+
+const token = 'test'
+const url = 'https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC'
+
+describe('Spotify bridge init guard', () => {
+  it('accepts the exact init payload', () => {
+    expect(isSpotifyBridgeInit({ type: 'spotify-bridge-init', token, url })).toBe(true)
+  })
+
+  it.each([
+    null,
+    { type: 'spotify-bridge-init', token: '', url },
+    { type: 'spotify-bridge-init', token: 'x'.repeat(129), url },
+    { type: 'spotify-bridge-init', token, url: 'http://open.spotify.com/track/abc' },
+    { type: 'spotify-bridge-init', token, url: 'https://open.spotify.com:8443/track/abc' },
+    { type: 'spotify-bridge-init', token, url: 'https://evil.example/track/abc' },
+    { type: 'spotify-bridge-init', token, url, extra: true },
+    Object.assign(Object.create({ inherited: true }), {
+      type: 'spotify-bridge-init',
+      token,
+      url,
+    }),
+  ])('rejects malformed init payload %#', (value) => {
+    expect(isSpotifyBridgeInit(value)).toBe(false)
+  })
+})
+
+describe('Spotify bridge command guard', () => {
+  it.each([
+    { type: 'load', token, url },
+    { type: 'play', token },
+    { type: 'pause', token },
+    { type: 'destroy', token },
+  ])('accepts command $type', (value) => {
+    expect(isSpotifyBridgeCommand(value)).toBe(true)
+  })
+
+  it.each([
+    { type: 'load', token, url: 'https://open.spotify.com.evil.example/track/abc' },
+    { type: 'play', token: '' },
+    { type: 'seek', token },
+    { type: 'pause', token, url },
+    Object.assign(Object.create(null), { type: 'destroy', token }),
+  ])('rejects malformed command %#', (value) => {
+    expect(isSpotifyBridgeCommand(value)).toBe(false)
+  })
+})
+
+describe('Spotify bridge event guard', () => {
+  it.each([
+    { type: 'ready', token },
+    { type: 'playback-started', token },
+    {
+      type: 'playback-state',
+      token,
+      paused: false,
+      buffering: false,
+      duration: 30_000,
+      position: 10_000,
+    },
+    { type: 'failure', token },
+  ])('accepts event $type', (value) => {
+    expect(isSpotifyBridgeEvent(value)).toBe(true)
+  })
+
+  it.each([
+    { type: 'ready', token, extra: true },
+    { type: 'playback-started' },
+    {
+      type: 'playback-state',
+      token,
+      paused: false,
+      buffering: false,
+      duration: Number.POSITIVE_INFINITY,
+      position: 0,
+    },
+    {
+      type: 'playback-state',
+      token,
+      paused: false,
+      buffering: false,
+      duration: 1,
+      position: Number.NaN,
+    },
+    { type: 'error', token },
+  ])('rejects malformed event %#', (value) => {
+    expect(isSpotifyBridgeEvent(value)).toBe(false)
+  })
+})

--- a/tests/web/spotify-embed-bridge.test.ts
+++ b/tests/web/spotify-embed-bridge.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const token = 'test'
+const url = 'https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC'
+const parentOrigin = 'https://app.example'
+const spotifyWindow = window as Window & {
+  onSpotifyIframeApiReady?: (api: never) => void
+}
+
+class FakePort {
+  messages: unknown[] = []
+  onmessage: ((event: MessageEvent) => void) | null = null
+  start = vi.fn()
+  close = vi.fn()
+
+  postMessage(message: unknown) {
+    this.messages.push(message)
+  }
+
+  dispatch(message: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: message }))
+  }
+}
+
+function dispatchInit(
+  port: FakePort,
+  overrides: {
+    origin?: string
+    source?: MessageEventSource | null
+    ports?: MessagePort[]
+  } = {},
+) {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type: 'spotify-bridge-init', token, url },
+      origin: overrides.origin ?? parentOrigin,
+      source: overrides.source === undefined ? window.parent : overrides.source,
+      ports: overrides.ports ?? ([port] as unknown as MessagePort[]),
+    }),
+  )
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  document.body.innerHTML = '<div id="spotify-embed-host"></div>'
+  Object.defineProperty(document, 'referrer', {
+    configurable: true,
+    value: `${parentOrigin}/discover`,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  document.querySelector('script[src="https://open.spotify.com/embed/iframe-api/v1"]')?.remove()
+  delete spotifyWindow.onSpotifyIframeApiReady
+})
+
+describe('Spotify embed bridge', () => {
+  it('has a minimal standalone document', () => {
+    const html = readFileSync('spotify-embed-bridge.html', 'utf8')
+
+    expect(html).toContain('id="spotify-embed-host"')
+    expect(html).toContain('src="/src/web/spotify-embed-bridge.ts"')
+    expect(html).not.toContain('/src/web/main.tsx')
+  })
+
+  it('accepts one parent handshake and translates controller traffic', async () => {
+    await import('@/web/spotify-embed-bridge')
+    const port = new FakePort()
+
+    dispatchInit(port, { source: null })
+    dispatchInit(port, { origin: 'https://evil.example' })
+    dispatchInit(port, { ports: [] })
+    expect(document.querySelector('script')).not.toBeInTheDocument()
+
+    dispatchInit(port)
+    const script = document.querySelector<HTMLScriptElement>(
+      'script[src="https://open.spotify.com/embed/iframe-api/v1"]',
+    )
+    expect(script).toBeInTheDocument()
+    expect(port.start).toHaveBeenCalledTimes(1)
+
+    const secondPort = new FakePort()
+    dispatchInit(secondPort)
+    expect(secondPort.start).not.toHaveBeenCalled()
+
+    const listeners = new Map<string, (event: { data?: Record<string, unknown> }) => void>()
+    const controller = {
+      addListener: vi.fn(
+        (name: string, listener: (event: { data?: Record<string, unknown> }) => void) => {
+          listeners.set(name, listener)
+        },
+      ),
+      loadEntity: vi.fn(),
+      play: vi.fn(),
+      pause: vi.fn(),
+      destroy: vi.fn(() => {
+        throw new Error('remote destroy failed')
+      }),
+    }
+    const iframeApi = {
+      createController: vi.fn(
+        (
+          _host: HTMLElement,
+          _options: Record<string, unknown>,
+          callback: (value: typeof controller) => void,
+        ) => callback(controller),
+      ),
+    }
+
+    spotifyWindow.onSpotifyIframeApiReady?.(iframeApi as never)
+    expect(iframeApi.createController).toHaveBeenCalledWith(
+      document.querySelector('#spotify-embed-host'),
+      { url, width: '100%', height: 80 },
+      expect.any(Function),
+    )
+
+    listeners.get('ready')?.({})
+    listeners.get('playback_started')?.({})
+    listeners.get('playback_update')?.({
+      data: {
+        isPaused: false,
+        isBuffering: true,
+        duration: 30_000,
+        position: 5_000,
+      },
+    })
+    expect(port.messages).toEqual([
+      { type: 'ready', token },
+      { type: 'playback-started', token },
+      {
+        type: 'playback-state',
+        token,
+        paused: false,
+        buffering: true,
+        duration: 30_000,
+        position: 5_000,
+      },
+    ])
+
+    port.dispatch({ type: 'play', token: 'wrong-token' })
+    port.dispatch({ type: 'load', token, url: 'https://evil.example/track/abc' })
+    expect(controller.play).not.toHaveBeenCalled()
+    expect(controller.loadEntity).not.toHaveBeenCalled()
+
+    port.dispatch({ type: 'load', token, url: 'https://open.spotify.com/track/second' })
+    port.dispatch({ type: 'play', token })
+    port.dispatch({ type: 'pause', token })
+    expect(controller.loadEntity).toHaveBeenCalledWith('https://open.spotify.com/track/second')
+    expect(controller.play).toHaveBeenCalledTimes(1)
+    expect(controller.pause).toHaveBeenCalledTimes(1)
+
+    port.dispatch({ type: 'destroy', token })
+    expect(controller.destroy).toHaveBeenCalledTimes(1)
+    expect(script).not.toBeInTheDocument()
+    expect(port.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports script failure and removes bridge resources', async () => {
+    await import('@/web/spotify-embed-bridge')
+    const port = new FakePort()
+    dispatchInit(port)
+
+    const script = document.querySelector<HTMLScriptElement>(
+      'script[src="https://open.spotify.com/embed/iframe-api/v1"]',
+    )
+    script?.dispatchEvent(new Event('error'))
+
+    expect(port.messages).toEqual([{ type: 'failure', token }])
+    expect(script).not.toBeInTheDocument()
+    expect(port.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
   build: {
     outDir: 'dist/web',
     emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        app: path.resolve(__dirname, 'index.html'),
+        spotifyBridge: path.resolve(__dirname, 'spotify-embed-bridge.html'),
+      },
+    },
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

- move Spotify's remote embed controller out of the authenticated application document
- run it in a no-same-origin bridge iframe with an exact, token-bound private protocol
- retain the standard Spotify iframe fallback when bridge playback is unavailable

## Verification

- `bun run test`
- `bun run lint`
- `bun run typecheck`
- `bun run i18n:check`
- `bun run check:versions`
- `bun run build`
- `bun run test:api-routes`
- `DATABASE_URL= DB_HOST= DB_USER= DB_NAME= bunx playwright test tests/e2e/browser/spotify-bridge.spec.ts`
- full security, correctness, code-quality, and documentation review

Fixes #486
