### PR TITLE
refactor(discovery): dedup mode field arrays

### DIFF
--- a/src/core/discovery-modes/modes/charts.ts
+++ b/src/core/discovery-modes/modes/charts.ts
@@ -1,5 +1,5 @@
 import { createLastFmClient } from '@/core/clients/lastfm'
-import type { DiscoveryModeDefinition } from '../types'
+import type { DiscoveryConfigField, DiscoveryModeDefinition } from '../types'
 import { getDiscoveryModeConnections, getNormalizedLimit } from './runtime'
 
 // Country values for the region select. Last.fm geo.gettopartists uses the
@@ -22,41 +22,28 @@ function parseChartLimit(value: unknown): number {
 }
 
 export function createChartsMode(): DiscoveryModeDefinition {
+  const fields: DiscoveryConfigField[] = [
+    {
+      key: 'region',
+      label: 'discoveryMode.field.region',
+      type: 'select',
+      required: false,
+      options: REGION_OPTIONS,
+    },
+    {
+      key: 'limit',
+      label: 'discoveryMode.field.limit',
+      type: 'number',
+      required: false,
+    },
+  ]
   return {
     id: 'charts',
     label: 'Charts',
     description: 'Discover artists trending on global or regional charts',
     availability: 'fallback',
-    easyFields: [
-      {
-        key: 'region',
-        label: 'discoveryMode.field.region',
-        type: 'select',
-        required: false,
-        options: REGION_OPTIONS,
-      },
-      {
-        key: 'limit',
-        label: 'discoveryMode.field.limit',
-        type: 'number',
-        required: false,
-      },
-    ],
-    advancedFields: [
-      {
-        key: 'region',
-        label: 'discoveryMode.field.region',
-        type: 'select',
-        required: false,
-        options: REGION_OPTIONS,
-      },
-      {
-        key: 'limit',
-        label: 'discoveryMode.field.limit',
-        type: 'number',
-        required: false,
-      },
-    ],
+    easyFields: fields,
+    advancedFields: fields,
     executor: async (request) => {
       const connections = await getDiscoveryModeConnections(request.userId)
       if (!connections?.lastfmApiKey) {

--- a/src/core/discovery-modes/modes/deezer-flow.ts
+++ b/src/core/discovery-modes/modes/deezer-flow.ts
@@ -1,29 +1,23 @@
 import { createDeezerUserClient } from '@/core/clients/deezer-user'
-import type { DiscoveryModeDefinition } from '../types'
+import type { DiscoveryConfigField, DiscoveryModeDefinition } from '../types'
 import { getDiscoveryModeDeezerToken, getNormalizedLimit } from './runtime'
 
 export function createDeezerFlowMode(): DiscoveryModeDefinition {
+  const fields: DiscoveryConfigField[] = [
+    {
+      key: 'limit',
+      label: 'discoveryMode.field.limit',
+      type: 'number',
+      required: false,
+    },
+  ]
   return {
     id: 'deezer-flow',
     label: 'Deezer Flow',
     description: 'Discover artists from your personalized Deezer Flow feed',
     availability: 'fallback',
-    easyFields: [
-      {
-        key: 'limit',
-        label: 'discoveryMode.field.limit',
-        type: 'number',
-        required: false,
-      },
-    ],
-    advancedFields: [
-      {
-        key: 'limit',
-        label: 'discoveryMode.field.limit',
-        type: 'number',
-        required: false,
-      },
-    ],
+    easyFields: fields,
+    advancedFields: fields,
     executor: async (request) => {
       const token = await getDiscoveryModeDeezerToken(request.userId)
       if (!token) {

--- a/src/core/discovery-modes/modes/spotify-saved-albums.ts
+++ b/src/core/discovery-modes/modes/spotify-saved-albums.ts
@@ -1,29 +1,23 @@
 import { createSpotifyClient } from '@/core/clients/spotify'
-import type { DiscoveryModeDefinition } from '../types'
+import type { DiscoveryConfigField, DiscoveryModeDefinition } from '../types'
 import { getDiscoveryModeSpotifyToken, getNormalizedLimit } from './runtime'
 
 export function createSpotifySavedAlbumsMode(): DiscoveryModeDefinition {
+  const fields: DiscoveryConfigField[] = [
+    {
+      key: 'limit',
+      label: 'discoveryMode.field.limit',
+      type: 'number',
+      required: false,
+    },
+  ]
   return {
     id: 'spotify-saved-albums',
     label: 'Spotify Saved Albums',
     description: 'Discover artists from the albums you saved on Spotify',
     availability: 'fallback',
-    easyFields: [
-      {
-        key: 'limit',
-        label: 'discoveryMode.field.limit',
-        type: 'number',
-        required: false,
-      },
-    ],
-    advancedFields: [
-      {
-        key: 'limit',
-        label: 'discoveryMode.field.limit',
-        type: 'number',
-        required: false,
-      },
-    ],
+    easyFields: fields,
+    advancedFields: fields,
     executor: async (request) => {
       const token = await getDiscoveryModeSpotifyToken(request.userId)
       if (!token) {

--- a/src/core/discovery-modes/modes/subsonic-starred.ts
+++ b/src/core/discovery-modes/modes/subsonic-starred.ts
@@ -1,5 +1,5 @@
 import { createSubsonicClient } from '@/core/clients/subsonic'
-import type { DiscoveryModeDefinition } from '../types'
+import type { DiscoveryConfigField, DiscoveryModeDefinition } from '../types'
 import {
   getDiscoveryModeConnections,
   getDiscoveryModeSkipTlsVerify,
@@ -7,27 +7,21 @@ import {
 } from './runtime'
 
 export function createSubsonicStarredMode(): DiscoveryModeDefinition {
+  const fields: DiscoveryConfigField[] = [
+    {
+      key: 'limit',
+      label: 'discoveryMode.field.limit',
+      type: 'number',
+      required: false,
+    },
+  ]
   return {
     id: 'subsonic-starred',
     label: 'Subsonic Starred',
     description: 'Discover artists similar to the ones you starred on your Subsonic server',
     availability: 'fallback',
-    easyFields: [
-      {
-        key: 'limit',
-        label: 'discoveryMode.field.limit',
-        type: 'number',
-        required: false,
-      },
-    ],
-    advancedFields: [
-      {
-        key: 'limit',
-        label: 'discoveryMode.field.limit',
-        type: 'number',
-        required: false,
-      },
-    ],
+    easyFields: fields,
+    advancedFields: fields,
     executor: async (request) => {
       const [conns, skipTlsVerify] = await Promise.all([
         getDiscoveryModeConnections(request.userId),


### PR DESCRIPTION
## Summary

Charts, Deezer Flow, Spotify Saved Albums, and Subsonic Starred each declared identical `easyFields` and `advancedFields` arrays. Each factory now binds one local array to both properties.

## Behavior

- Serialized API shape unchanged: both `easyFields` and `advancedFields` still present, same field ordering/labels/types/options/required flags.
- No behavior or public API change.

## Verification

- `bun run typecheck` clean
- `bun run lint` clean (797 files)
- `bun run test -- discovery` -> 142 passed (27 files)

Closes #484