### PR TITLE
refactor(clients): share MediaBrowser artist query and mappers

### DIFF
--- a/src/core/clients/emby.ts
+++ b/src/core/clients/emby.ts
@@ -1,12 +1,18 @@
 import type { ServiceTestResult } from '@/core/types'
 import { errMsg } from '@/core/validation'
 import { createHttpClient } from './http'
+import {
+  type MediaBrowserLibrary,
+  mapAlbum,
+  mapArtist,
+  mapLibraryArtist,
+  mapRecentTrack,
+  scopedArtistsPath,
+  toMusicLibraries,
+} from './media-browser'
 import { createMediaServerQueue } from './media-server-queue'
 
-export type EmbyMusicLibrary = {
-  id: string
-  name: string
-}
+export type EmbyMusicLibrary = MediaBrowserLibrary
 
 export function createEmbyClient(
   url: string,
@@ -35,27 +41,13 @@ export function createEmbyClient(
     const res = await get<{ Items?: Array<{ Id: string; Name: string; CollectionType?: string }> }>(
       `/Users/${userId}/Views`,
     )
-    return (res.Items ?? [])
-      .filter((v) => v.CollectionType === 'music')
-      .map((v) => ({ id: v.Id, name: v.Name }))
-  }
-
-  // MusicArtist items are server-global, so ParentId on the generic Items
-  // endpoint does not scope them - the dedicated /Artists endpoint does.
-  function scopedArtistsPath(extra: Record<string, string>): string {
-    const params = new URLSearchParams({
-      ParentId: configuredLibraryId as string,
-      UserId: userId,
-      EnableUserData: 'true',
-      ...extra,
-    })
-    return `/Artists?${params.toString()}`
+    return toMusicLibraries(res.Items)
   }
 
   async function getTopArtists(limit = 50) {
     let path: string
     if (configuredLibraryId) {
-      path = scopedArtistsPath({
+      path = scopedArtistsPath(userId, configuredLibraryId, {
         SortBy: 'PlayCount',
         SortOrder: 'Descending',
         Fields: 'UserData,Genres,ProviderIds',
@@ -73,14 +65,7 @@ export function createEmbyClient(
       path = `/Users/${userId}/Items?${params.toString()}`
     }
     const res = await get<{ Items: Array<Record<string, unknown>> }>(path)
-    return (res.Items ?? []).map((item) => ({
-      id: item.Id as string,
-      name: item.Name as string,
-      mbid: (item.ProviderIds as { MusicBrainzArtist?: string } | undefined)?.MusicBrainzArtist,
-      genres: (item.Genres as string[] | undefined) ?? [],
-      playCount: (item.UserData as { PlayCount?: number } | undefined)?.PlayCount ?? 0,
-      isFavorite: (item.UserData as { IsFavorite?: boolean } | undefined)?.IsFavorite ?? false,
-    }))
+    return (res.Items ?? []).map((item) => mapArtist(item, false))
   }
 
   async function testConnection(): Promise<ServiceTestResult> {
@@ -133,7 +118,7 @@ export function createEmbyClient(
     // Items endpoint and accept the top-level IsFavorite=true form.
     let path: string
     if (configuredLibraryId) {
-      path = scopedArtistsPath({
+      path = scopedArtistsPath(userId, configuredLibraryId, {
         SortBy: 'SortName',
         SortOrder: 'Ascending',
         IsFavorite: 'true',
@@ -153,14 +138,7 @@ export function createEmbyClient(
       path = `/Users/${userId}/Items?${params.toString()}`
     }
     const res = await get<{ Items: Array<Record<string, unknown>> }>(path)
-    return (res.Items ?? []).map((item) => ({
-      id: item.Id as string,
-      name: item.Name as string,
-      mbid: (item.ProviderIds as { MusicBrainzArtist?: string } | undefined)?.MusicBrainzArtist,
-      genres: (item.Genres as string[] | undefined) ?? [],
-      playCount: (item.UserData as { PlayCount?: number } | undefined)?.PlayCount ?? 0,
-      isFavorite: true,
-    }))
+    return (res.Items ?? []).map((item) => mapArtist(item, true))
   }
 
   return {
@@ -180,20 +158,12 @@ export function createEmbyClient(
       const res = await get<{ Items: Array<Record<string, unknown>> }>(
         `/Users/${userId}/Items?${params.toString()}`,
       )
-      return (res.Items ?? []).map((item) => ({
-        artistName:
-          (item.AlbumArtist as string) ||
-          ((item.Artists as string[] | undefined)?.[0] ?? 'Unknown Artist'),
-        trackName: item.Name as string,
-        datePlayed:
-          (item.UserData as { LastPlayedDate?: string } | undefined)?.LastPlayedDate ??
-          new Date().toISOString(),
-      }))
+      return (res.Items ?? []).map(mapRecentTrack)
     },
     getAllArtists: async () => {
       let path: string
       if (configuredLibraryId) {
-        path = scopedArtistsPath({
+        path = scopedArtistsPath(userId, configuredLibraryId, {
           SortBy: 'SortName',
           SortOrder: 'Ascending',
           Fields: 'Genres,ProviderIds',
@@ -209,12 +179,7 @@ export function createEmbyClient(
         path = `/Users/${userId}/Items?${params.toString()}`
       }
       const res = await get<{ Items: Array<Record<string, unknown>> }>(path)
-      return (res.Items ?? []).map((item) => ({
-        id: item.Id as string,
-        name: item.Name as string,
-        mbid: (item.ProviderIds as { MusicBrainzArtist?: string } | undefined)?.MusicBrainzArtist,
-        genres: (item.Genres as string[] | undefined) ?? [],
-      }))
+      return (res.Items ?? []).map((item) => mapLibraryArtist(item, false))
     },
     getAlbumsForArtist: async (artistId: string) => {
       const params = new URLSearchParams({
@@ -227,15 +192,7 @@ export function createEmbyClient(
       const res = await get<{ Items: Array<Record<string, unknown>> }>(
         `/Users/${userId}/Items?${params.toString()}`,
       )
-      return (res.Items ?? []).map((item) => ({
-        id: item.Id as string,
-        artistId,
-        title: item.Name as string,
-        mbid: (item.ProviderIds as { MusicBrainzReleaseGroup?: string } | undefined)
-          ?.MusicBrainzReleaseGroup,
-        releaseYear: item.ProductionYear as number | undefined,
-        primaryType: 'Album' as const,
-      }))
+      return (res.Items ?? []).map((item) => mapAlbum(item, artistId, false))
     },
     testConnection,
   }

--- a/src/core/clients/jellyfin.ts
+++ b/src/core/clients/jellyfin.ts
@@ -1,43 +1,26 @@
 import type { ServiceTestResult } from '@/core/types'
 import { errMsg } from '@/core/validation'
 import { createHttpClient } from './http'
+import {
+  type MediaBrowserArtist,
+  type MediaBrowserLibrary,
+  type MediaBrowserLibraryAlbum,
+  type MediaBrowserLibraryArtist,
+  type MediaBrowserRecentTrack,
+  mapAlbum,
+  mapArtist,
+  mapLibraryArtist,
+  mapRecentTrack,
+  scopedArtistsPath,
+  toMusicLibraries,
+} from './media-browser'
 import { createMediaServerQueue } from './media-server-queue'
 
-export type JellyfinArtist = {
-  name: string
-  id: string
-  mbid?: string
-  genres: string[]
-  playCount: number
-  isFavorite: boolean
-}
-
-export type JellyfinLibraryArtist = {
-  id: string
-  name: string
-  mbid?: string
-  genres: string[]
-}
-
-export type JellyfinLibraryAlbum = {
-  id: string
-  artistId: string
-  title: string
-  mbid?: string
-  releaseYear?: number
-  primaryType?: 'Album'
-}
-
-export type JellyfinRecentTrack = {
-  artistName: string
-  trackName: string
-  datePlayed: string
-}
-
-export type JellyfinMusicLibrary = {
-  id: string
-  name: string
-}
+export type JellyfinArtist = MediaBrowserArtist
+export type JellyfinLibraryArtist = MediaBrowserLibraryArtist
+export type JellyfinLibraryAlbum = MediaBrowserLibraryAlbum
+export type JellyfinRecentTrack = MediaBrowserRecentTrack
+export type JellyfinMusicLibrary = MediaBrowserLibrary
 
 type JellyfinItemsResponse = {
   Items: Array<Record<string, unknown>>
@@ -106,21 +89,7 @@ export function createJellyfinClient(
     const res = await get<{ Items?: Array<{ Id: string; Name: string; CollectionType?: string }> }>(
       `/Users/${userId}/Views`,
     )
-    return (res.Items ?? [])
-      .filter((v) => v.CollectionType === 'music')
-      .map((v) => ({ id: v.Id, name: v.Name }))
-  }
-
-  // MusicArtist items are server-global, so ParentId on the generic Items
-  // endpoint does not scope them - the dedicated /Artists endpoint does.
-  function scopedArtistsPath(userId: string, extra: Record<string, string>): string {
-    const params = new URLSearchParams({
-      ParentId: configuredLibraryId as string,
-      UserId: userId,
-      EnableUserData: 'true',
-      ...extra,
-    })
-    return `/Artists?${params.toString()}`
+    return toMusicLibraries(res.Items)
   }
 
   async function getTopArtists(limit = 50): Promise<JellyfinArtist[]> {
@@ -128,7 +97,7 @@ export function createJellyfinClient(
     let res: JellyfinItemsResponse
     if (configuredLibraryId) {
       res = await get<JellyfinItemsResponse>(
-        scopedArtistsPath(userId, {
+        scopedArtistsPath(userId, configuredLibraryId, {
           SortBy: 'PlayCount',
           SortOrder: 'Descending',
           Fields: 'UserData,Genres,ProviderIds',
@@ -150,20 +119,7 @@ export function createJellyfinClient(
     return res.Items.filter((item) => {
       const userData = item.UserData as { PlayCount?: number } | undefined
       return (userData?.PlayCount ?? 0) > 0
-    }).map((item) => {
-      const userData = item.UserData as {
-        PlayCount?: number
-        IsFavorite?: boolean
-      }
-      return {
-        name: item.Name as string,
-        id: item.Id as string,
-        mbid: (item.ProviderIds as { MusicBrainzArtist?: string } | undefined)?.MusicBrainzArtist,
-        genres: (item.Genres as string[] | undefined) ?? [],
-        playCount: userData?.PlayCount ?? 0,
-        isFavorite: userData?.IsFavorite ?? false,
-      }
-    })
+    }).map((item) => mapArtist(item, false))
   }
 
   async function getRecentlyPlayed(limit = 50): Promise<JellyfinRecentTrack[]> {
@@ -181,17 +137,7 @@ export function createJellyfinClient(
 
     const res = await get<JellyfinItemsResponse>(`/Users/${userId}/Items?${params.toString()}`)
 
-    return res.Items.map((item) => {
-      const artistName =
-        (item.AlbumArtist as string) ||
-        ((item.Artists as string[] | undefined)?.[0] ?? 'Unknown Artist')
-      const userData = item.UserData as { LastPlayedDate?: string } | undefined
-      return {
-        artistName,
-        trackName: item.Name as string,
-        datePlayed: userData?.LastPlayedDate ?? new Date().toISOString(),
-      }
-    })
+    return res.Items.map(mapRecentTrack)
   }
 
   async function getFavoriteArtists(limit = 50): Promise<JellyfinArtist[]> {
@@ -199,7 +145,7 @@ export function createJellyfinClient(
     let res: JellyfinItemsResponse
     if (configuredLibraryId) {
       res = await get<JellyfinItemsResponse>(
-        scopedArtistsPath(userId, {
+        scopedArtistsPath(userId, configuredLibraryId, {
           SortBy: 'SortName',
           SortOrder: 'Ascending',
           IsFavorite: 'true',
@@ -220,20 +166,7 @@ export function createJellyfinClient(
       res = await get<JellyfinItemsResponse>(`/Users/${userId}/Items?${params.toString()}`)
     }
 
-    return res.Items.map((item) => {
-      const userData = item.UserData as {
-        PlayCount?: number
-        IsFavorite?: boolean
-      }
-      return {
-        name: item.Name as string,
-        id: item.Id as string,
-        mbid: (item.ProviderIds as { MusicBrainzArtist?: string } | undefined)?.MusicBrainzArtist,
-        genres: (item.Genres as string[] | undefined) ?? [],
-        playCount: userData?.PlayCount ?? 0,
-        isFavorite: userData?.IsFavorite ?? true,
-      }
-    })
+    return res.Items.map((item) => mapArtist(item, true))
   }
 
   /**
@@ -253,7 +186,7 @@ export function createJellyfinClient(
       let path: string
       if (configuredLibraryId) {
         // SortName paging: /Artists needs an explicit sort for stable pages.
-        path = scopedArtistsPath(userId, {
+        path = scopedArtistsPath(userId, configuredLibraryId, {
           SortBy: 'SortName',
           SortOrder: 'Ascending',
           Fields: 'Genres,ProviderIds',
@@ -272,22 +205,12 @@ export function createJellyfinClient(
       }
       const res = await get<{
         TotalRecordCount: number
-        Items: Array<{
-          Id: string
-          Name: string
-          Genres?: string[]
-          ProviderIds?: { MusicBrainzArtist?: string }
-        }>
+        Items: Array<Record<string, unknown>>
       }>(path)
 
       total = res.TotalRecordCount ?? res.Items.length
       for (const item of res.Items) {
-        all.push({
-          id: item.Id,
-          name: item.Name,
-          mbid: item.ProviderIds?.MusicBrainzArtist?.trim() || undefined,
-          genres: item.Genres ?? [],
-        })
+        all.push(mapLibraryArtist(item, true))
       }
       if (res.Items.length === 0) break
       startIndex += res.Items.length
@@ -315,24 +238,12 @@ export function createJellyfinClient(
 
       const res = await get<{
         TotalRecordCount: number
-        Items: Array<{
-          Id: string
-          Name: string
-          ProductionYear?: number
-          ProviderIds?: { MusicBrainzReleaseGroup?: string; MusicBrainzAlbum?: string }
-        }>
+        Items: Array<Record<string, unknown>>
       }>(`/Users/${userId}/Items?${params}`)
 
       total = res.TotalRecordCount ?? res.Items.length
       for (const item of res.Items) {
-        all.push({
-          id: item.Id,
-          artistId,
-          title: item.Name,
-          mbid: item.ProviderIds?.MusicBrainzReleaseGroup?.trim() || undefined,
-          releaseYear: item.ProductionYear,
-          primaryType: 'Album',
-        })
+        all.push(mapAlbum(item, artistId, true))
       }
       if (res.Items.length === 0) break
       startIndex += res.Items.length

--- a/src/core/clients/media-browser.ts
+++ b/src/core/clients/media-browser.ts
@@ -1,0 +1,132 @@
+// Shared query and mapping helpers for the MediaBrowser API family (Jellyfin,
+// Emby). Both engines expose the same /Artists and /Users/{id}/Items endpoints
+// and identical item shapes; only auth headers and Jellyfin's username
+// resolution differ, so those stay in the per-client factories.
+
+export type MediaBrowserArtist = {
+  name: string
+  id: string
+  mbid?: string
+  genres: string[]
+  playCount: number
+  isFavorite: boolean
+}
+
+export type MediaBrowserLibraryArtist = {
+  id: string
+  name: string
+  mbid?: string
+  genres: string[]
+}
+
+export type MediaBrowserLibraryAlbum = {
+  id: string
+  artistId: string
+  title: string
+  mbid?: string
+  releaseYear?: number
+  primaryType?: 'Album'
+}
+
+export type MediaBrowserRecentTrack = {
+  artistName: string
+  trackName: string
+  datePlayed: string
+}
+
+export type MediaBrowserLibrary = {
+  id: string
+  name: string
+}
+
+type RawItem = Record<string, unknown>
+
+// MusicArtist items are server-global, so ParentId on the generic Items
+// endpoint does not scope them - the dedicated /Artists endpoint does.
+export function scopedArtistsPath(
+  userId: string,
+  libraryId: string,
+  extra: Record<string, string>,
+): string {
+  const params = new URLSearchParams({
+    ParentId: libraryId,
+    UserId: userId,
+    EnableUserData: 'true',
+    ...extra,
+  })
+  return `/Artists?${params.toString()}`
+}
+
+function providerId(item: RawItem, key: string): string | undefined {
+  return (item.ProviderIds as Record<string, string> | undefined)?.[key]
+}
+
+/**
+ * Map a MusicArtist item from a top/favorite query. `favoriteFallback` is the
+ * value used when the item carries no UserData.IsFavorite flag: `false` for
+ * play-count queries, `true` for favorite queries.
+ */
+export function mapArtist(item: RawItem, favoriteFallback: boolean): MediaBrowserArtist {
+  const userData = item.UserData as { PlayCount?: number; IsFavorite?: boolean } | undefined
+  return {
+    name: item.Name as string,
+    id: item.Id as string,
+    mbid: providerId(item, 'MusicBrainzArtist'),
+    genres: (item.Genres as string[] | undefined) ?? [],
+    playCount: userData?.PlayCount ?? 0,
+    isFavorite: userData?.IsFavorite ?? favoriteFallback,
+  }
+}
+
+/**
+ * Map a MusicArtist item for full-library sync. `trimMbid` reflects the
+ * per-client convention: Jellyfin trims and drops empty MBIDs, Emby passes the
+ * raw ProviderIds value through unchanged.
+ */
+export function mapLibraryArtist(item: RawItem, trimMbid: boolean): MediaBrowserLibraryArtist {
+  const raw = providerId(item, 'MusicBrainzArtist')
+  return {
+    id: item.Id as string,
+    name: item.Name as string,
+    mbid: trimMbid ? raw?.trim() || undefined : raw,
+    genres: (item.Genres as string[] | undefined) ?? [],
+  }
+}
+
+/** Map a MusicAlbum item. `trimMbid` follows the same convention as above. */
+export function mapAlbum(
+  item: RawItem,
+  artistId: string,
+  trimMbid: boolean,
+): MediaBrowserLibraryAlbum {
+  const raw = providerId(item, 'MusicBrainzReleaseGroup')
+  return {
+    id: item.Id as string,
+    artistId,
+    title: item.Name as string,
+    mbid: trimMbid ? raw?.trim() || undefined : raw,
+    releaseYear: item.ProductionYear as number | undefined,
+    primaryType: 'Album',
+  }
+}
+
+export function mapRecentTrack(item: RawItem): MediaBrowserRecentTrack {
+  const artistName =
+    (item.AlbumArtist as string) ||
+    ((item.Artists as string[] | undefined)?.[0] ?? 'Unknown Artist')
+  const userData = item.UserData as { LastPlayedDate?: string } | undefined
+  return {
+    artistName,
+    trackName: item.Name as string,
+    datePlayed: userData?.LastPlayedDate ?? new Date().toISOString(),
+  }
+}
+
+/** Filter music views to the CollectionType 'music' subset. */
+export function toMusicLibraries(
+  items: Array<{ Id: string; Name: string; CollectionType?: string }> | undefined,
+): MediaBrowserLibrary[] {
+  return (items ?? [])
+    .filter((v) => v.CollectionType === 'music')
+    .map((v) => ({ id: v.Id, name: v.Name }))
+}


### PR DESCRIPTION
## Summary

The Jellyfin and Emby clients duplicated the scoped `/Artists` query builder and the per-method item mapping (top / favorite / all artists, albums, recent tracks). This extracts a shared `media-browser.ts` module for:

- `scopedArtistsPath(userId, libraryId, extra)` — the byte-identical scoped-query builder
- `mapArtist` / `mapLibraryArtist` / `mapAlbum` / `mapRecentTrack` item mappers
- `toMusicLibraries` view filter
- shared item/library types

## Preserved behavior

Provider-specific auth headers, Jellyfin username resolution, the scoped/unscoped branch selection, pagination, and error messages stay explicit in each client factory. The two known divergences are kept via explicit mapper arguments:

- MBID handling: Jellyfin trims and drops empties (`trimMbid: true`), Emby passes the raw ProviderIds value (`trimMbid: false`).
- Favorite-flag fallback: `false` for play-count queries, `true` for favorite queries.

Scoped and unscoped query URLs remain byte-equivalent; mapped values are unchanged.

## Verification

- `bun run typecheck` clean
- `bun run lint` clean (798 files)
- `bun run test -- jellyfin emby` -> 62 passed (8 files: clients, library-sources, plugins, playlist-targets)

Net -132 lines.

Closes #485