### PR TITLE
chore(deps-dev): bump dev-tools group (biome 2.5.4, vite 8.1.5)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
   "files": {
     "includes": [
       "**",

--- a/bun.lock
+++ b/bun.lock
@@ -21,9 +21,9 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
-        "@biomejs/biome": "^2.5.3",
+        "@biomejs/biome": "^2.5.4",
         "@playwright/test": "^1.61.1",
-        "@tailwindcss/vite": "^4.3.3",
+        "@tailwindcss/vite": "^4.3.2",
         "@tanstack/react-query": "^5.101.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -45,7 +45,7 @@
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4",
+        "vite": "^8.1.5",
         "vitest": "^4.1.10",
       },
     },
@@ -83,23 +83,23 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.3", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.3", "@biomejs/cli-darwin-x64": "2.5.3", "@biomejs/cli-linux-arm64": "2.5.3", "@biomejs/cli-linux-arm64-musl": "2.5.3", "@biomejs/cli-linux-x64": "2.5.3", "@biomejs/cli-linux-x64-musl": "2.5.3", "@biomejs/cli-win32-arm64": "2.5.3", "@biomejs/cli-win32-x64": "2.5.3" }, "bin": { "biome": "bin/biome" } }, "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.4", "@biomejs/cli-darwin-x64": "2.5.4", "@biomejs/cli-linux-arm64": "2.5.4", "@biomejs/cli-linux-arm64-musl": "2.5.4", "@biomejs/cli-linux-x64": "2.5.4", "@biomejs/cli-linux-x64-musl": "2.5.4", "@biomejs/cli-win32-arm64": "2.5.4", "@biomejs/cli-win32-x64": "2.5.4" }, "bin": { "biome": "bin/biome" } }, "sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.3", "", { "os": "win32", "cpu": "x64" }, "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q=="],
 
     "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
 
@@ -199,39 +199,39 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
+    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.4", "", { "os": "android", "cpu": "arm64" }, "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.4", "", { "os": "linux", "cpu": "arm" }, "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.4", "", { "os": "none", "cpu": "arm64" }, "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.4", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
@@ -545,7 +545,7 @@
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
-    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+    "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
 
@@ -575,7 +575,7 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
-    "rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
+    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
@@ -643,7 +643,7 @@
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
-    "vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
+    "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
 
     "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
 
@@ -686,5 +686,41 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "vitest/vite": ["vite@8.1.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA=="],
+
+    "vitest/vite/postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+
+    "vitest/vite/rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
+
+    "vitest/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.4", "", { "os": "android", "cpu": "arm64" }, "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.4", "", { "os": "linux", "cpu": "arm" }, "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.4", "", { "os": "none", "cpu": "arm64" }, "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.4", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA=="],
+
+    "vitest/vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
-    "@biomejs/biome": "^2.5.3",
+    "@biomejs/biome": "^2.5.4",
     "@playwright/test": "^1.61.1",
-    "@tailwindcss/vite": "^4.3.3",
+    "@tailwindcss/vite": "^4.3.2",
     "@tanstack/react-query": "^5.101.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -56,7 +56,7 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4",
+    "vite": "^8.1.5",
     "vitest": "^4.1.10"
   },
   "dependencies": {

--- a/tests/core/ops/backup.test.ts
+++ b/tests/core/ops/backup.test.ts
@@ -311,23 +311,23 @@ describe('restoreBackup', () => {
   it.each([
     { count: 1, warning: 'Ignored 1 legacy OIDC token record.' },
     { count: 2, warning: 'Ignored 2 legacy OIDC token records.' },
-  ])('ignores $count legacy OIDC token record(s) with a count-only warning', async ({
-    count,
-    warning,
-  }) => {
-    const db = makeMockUpsertDb()
-    const backup = makeBackupFile()
-    backup.data.oidcTokens = Array.from({ length: count }, (_, index) => ({
-      id: index + 1,
-      accessToken: `must-not-appear-${index + 1}`,
-    }))
+  ])(
+    'ignores $count legacy OIDC token record(s) with a count-only warning',
+    async ({ count, warning }) => {
+      const db = makeMockUpsertDb()
+      const backup = makeBackupFile()
+      backup.data.oidcTokens = Array.from({ length: count }, (_, index) => ({
+        id: index + 1,
+        accessToken: `must-not-appear-${index + 1}`,
+      }))
 
-    const result = await restoreBackup(db, backup)
+      const result = await restoreBackup(db, backup)
 
-    expect(result.warnings).toEqual([warning])
-    expect(db.insertCalls).not.toHaveProperty('oidc_tokens')
-    expect(db.deleteCalls).not.toContain('oidc_tokens')
-  })
+      expect(result.warnings).toEqual([warning])
+      expect(db.insertCalls).not.toHaveProperty('oidc_tokens')
+      expect(db.deleteCalls).not.toContain('oidc_tokens')
+    },
+  )
 
   it('clears included tables before restoring to avoid stale rows surviving', async () => {
     const db = makeMockUpsertDb()

--- a/tests/core/slskd/orchestrator.test.ts
+++ b/tests/core/slskd/orchestrator.test.ts
@@ -211,28 +211,27 @@ describe('createSlskdOrchestrator', () => {
   it.each([
     { artistName: 'Burial', releaseTitle: '   ', expectedQuery: 'Burial' },
     { artistName: '   ', releaseTitle: 'Untrue', expectedQuery: 'Untrue' },
-  ])('searches when one query field is present', async ({
-    artistName,
-    releaseTitle,
-    expectedQuery,
-  }) => {
-    const slskdClient = {
-      createSearch: vi.fn(async () => ({ id: 'search-partial' })),
-      getSearchResults: vi.fn(async (): Promise<SlskdSearchResult[]> => []),
-      enqueueResult: vi.fn(async () => ({ id: 'must-not-run' })),
-      getDownloads: vi.fn(async () => []),
-    }
-    const orchestrator = createSlskdOrchestrator({
-      listPendingJobs: vi.fn(async () => [makeJob({ artistName, releaseTitle })]),
-      processPendingJobs: vi.fn(async () => {}),
-      createSlskdClient: vi.fn(() => slskdClient),
-      updateJobState: vi.fn(async () => makeJob()),
-    } as never)
+  ])(
+    'searches when one query field is present',
+    async ({ artistName, releaseTitle, expectedQuery }) => {
+      const slskdClient = {
+        createSearch: vi.fn(async () => ({ id: 'search-partial' })),
+        getSearchResults: vi.fn(async (): Promise<SlskdSearchResult[]> => []),
+        enqueueResult: vi.fn(async () => ({ id: 'must-not-run' })),
+        getDownloads: vi.fn(async () => []),
+      }
+      const orchestrator = createSlskdOrchestrator({
+        listPendingJobs: vi.fn(async () => [makeJob({ artistName, releaseTitle })]),
+        processPendingJobs: vi.fn(async () => {}),
+        createSlskdClient: vi.fn(() => slskdClient),
+        updateJobState: vi.fn(async () => makeJob()),
+      } as never)
 
-    await orchestrator.triggerSync()
+      await orchestrator.triggerSync()
 
-    expect(slskdClient.createSearch).toHaveBeenCalledWith(expectedQuery)
-  })
+      expect(slskdClient.createSearch).toHaveBeenCalledWith(expectedQuery)
+    },
+  )
 
   it('moves ambiguous matches to manual review instead of auto-queueing', async () => {
     const updateJobState = vi.fn(async () => makeJob())

--- a/tests/scripts/prepare-rollback-backup.test.ts
+++ b/tests/scripts/prepare-rollback-backup.test.ts
@@ -383,18 +383,17 @@ describe('rollback backup preparation', () => {
     expect(existsSync(outputPath)).toBe(false)
   })
 
-  it.each([
-    { args: [] },
-    { args: ['one.json'] },
-    { args: ['one.json', 'two.json', 'three.json'] },
-  ])('requires exactly input and output CLI arguments: $args', ({ args }) => {
-    const result = runCli(args)
+  it.each([{ args: [] }, { args: ['one.json'] }, { args: ['one.json', 'two.json', 'three.json'] }])(
+    'requires exactly input and output CLI arguments: $args',
+    ({ args }) => {
+      const result = runCli(args)
 
-    expect(result.error).toBeUndefined()
-    expect(result.status).toBe(1)
-    expect(result.stdout).toBe('')
-    expect(result.stderr.trim()).toBe('usage: prepare-rollback-backup <input> <output>')
-  })
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(1)
+      expect(result.stdout).toBe('')
+      expect(result.stderr.trim()).toBe('usage: prepare-rollback-backup <input> <output>')
+    },
+  )
 
   it('prints only the resolved output path after CLI success', () => {
     const inputPath = join(testDir, 'input.json')

--- a/tests/server/middleware/csrf.test.ts
+++ b/tests/server/middleware/csrf.test.ts
@@ -43,29 +43,29 @@ function unsafeRequest(headers: Record<string, string> = {}, path = '/api/v1/tes
 }
 
 describe('csrf middleware policy', () => {
-  it.each<AuthMethod>([
-    'session-bearer',
-    'legacy-bearer',
-  ])('allows verified %s auth without browser headers', async (authMethod) => {
-    const res = await createGuardApp(authMethod).request(unsafeRequest())
+  it.each<AuthMethod>(['session-bearer', 'legacy-bearer'])(
+    'allows verified %s auth without browser headers',
+    async (authMethod) => {
+      const res = await createGuardApp(authMethod).request(unsafeRequest())
 
-    expect(res.status).toBe(200)
-  })
+      expect(res.status).toBe(200)
+    },
+  )
 
-  it.each<AuthMethod>([
-    'session-cookie',
-    'proxy',
-  ])('allows %s auth with the CSRF header and exact same-origin evidence', async (authMethod) => {
-    const res = await createGuardApp(authMethod).request(
-      unsafeRequest({
-        'X-Digarr-CSRF': '1',
-        Origin: APP_ORIGIN,
-        'Sec-Fetch-Site': 'same-origin',
-      }),
-    )
+  it.each<AuthMethod>(['session-cookie', 'proxy'])(
+    'allows %s auth with the CSRF header and exact same-origin evidence',
+    async (authMethod) => {
+      const res = await createGuardApp(authMethod).request(
+        unsafeRequest({
+          'X-Digarr-CSRF': '1',
+          Origin: APP_ORIGIN,
+          'Sec-Fetch-Site': 'same-origin',
+        }),
+      )
 
-    expect(res.status).toBe(200)
-  })
+      expect(res.status).toBe(200)
+    },
+  )
 
   it.each([
     ['missing header', { Origin: APP_ORIGIN, 'Sec-Fetch-Site': 'same-origin' }],
@@ -127,20 +127,20 @@ describe('csrf middleware policy', () => {
     expect(res.status).toBe(200)
   })
 
-  it.each([
-    'not a URL',
-    'null',
-  ])('rejects an explicit %s Origin even when an exact Referer is supplied', async (origin) => {
-    const res = await createGuardApp('session-cookie').request(
-      unsafeRequest({
-        'X-Digarr-CSRF': '1',
-        Origin: origin,
-        Referer: `${APP_ORIGIN}/settings`,
-      }),
-    )
+  it.each(['not a URL', 'null'])(
+    'rejects an explicit %s Origin even when an exact Referer is supplied',
+    async (origin) => {
+      const res = await createGuardApp('session-cookie').request(
+        unsafeRequest({
+          'X-Digarr-CSRF': '1',
+          Origin: origin,
+          Referer: `${APP_ORIGIN}/settings`,
+        }),
+      )
 
-    expect(res.status).toBe(403)
-  })
+      expect(res.status).toBe(403)
+    },
+  )
 
   it('accepts an exact Origin without fetch metadata', async () => {
     const res = await createGuardApp('session-cookie').request(
@@ -208,20 +208,20 @@ describe('csrf middleware policy', () => {
     }
   })
 
-  it.each<AuthMethod>([
-    'session-query',
-    'legacy-query',
-  ])('rejects unsafe %s auth even with valid browser evidence', async (authMethod) => {
-    const res = await createGuardApp(authMethod).request(
-      unsafeRequest({
-        'X-Digarr-CSRF': '1',
-        Origin: APP_ORIGIN,
-        'Sec-Fetch-Site': 'same-origin',
-      }),
-    )
+  it.each<AuthMethod>(['session-query', 'legacy-query'])(
+    'rejects unsafe %s auth even with valid browser evidence',
+    async (authMethod) => {
+      const res = await createGuardApp(authMethod).request(
+        unsafeRequest({
+          'X-Digarr-CSRF': '1',
+          Origin: APP_ORIGIN,
+          'Sec-Fetch-Site': 'same-origin',
+        }),
+      )
 
-    expect(res.status).toBe(403)
-  })
+      expect(res.status).toBe(403)
+    },
+  )
 
   it('returns the canonical non-oracular RFC 9457 problem', async () => {
     const res = await createGuardApp('session-cookie').request(unsafeRequest())

--- a/tests/server/middleware/session-cookie.test.ts
+++ b/tests/server/middleware/session-cookie.test.ts
@@ -92,11 +92,14 @@ describe('sessionCookieOptions', () => {
     ['http://app.example.com', 'http://internal/test', false, true],
     ['http://app.example.com', 'http://internal/test', true, false],
     ['https://app.example.com', 'http://internal/test', true, true],
-  ] as const)('uses secure production defaults', async (allowedOrigin, requestUrl, allowInsecureCookies, secure) => {
-    process.env.NODE_ENV = 'production'
-    envConfig.allowInsecureCookies = allowInsecureCookies
-    await expect(optionsFor(allowedOrigin, requestUrl)).resolves.toMatchObject({ secure })
-  })
+  ] as const)(
+    'uses secure production defaults',
+    async (allowedOrigin, requestUrl, allowInsecureCookies, secure) => {
+      process.env.NODE_ENV = 'production'
+      envConfig.allowInsecureCookies = allowInsecureCookies
+      await expect(optionsFor(allowedOrigin, requestUrl)).resolves.toMatchObject({ secure })
+    },
+  )
 
   it('derives Secure from the public origin protocol outside production', async () => {
     process.env.NODE_ENV = 'development'
@@ -114,16 +117,14 @@ describe('sessionCookieOptions', () => {
     ).resolves.toMatchObject({ secure: false })
   })
 
-  it.each([
-    'not a URL',
-    'file:///tmp/app',
-    'data:text/plain,hello',
-    'mailto:user@example.com',
-  ])('rejects invalid or non-HTTP(S) configured origin %s', async (allowedOrigin) => {
-    await expect(optionsErrorFor(allowedOrigin, 'https://internal/test')).resolves.toBeInstanceOf(
-      TypeError,
-    )
-  })
+  it.each(['not a URL', 'file:///tmp/app', 'data:text/plain,hello', 'mailto:user@example.com'])(
+    'rejects invalid or non-HTTP(S) configured origin %s',
+    async (allowedOrigin) => {
+      await expect(optionsErrorFor(allowedOrigin, 'https://internal/test')).resolves.toBeInstanceOf(
+        TypeError,
+      )
+    },
+  )
 
   it('does not fall back to an HTTPS request URL when the configured origin is invalid', async () => {
     await expect(
@@ -166,47 +167,47 @@ describe('session auth helpers', () => {
     await expect(res.json()).resolves.toEqual({ token: 'new-session-token' })
   })
 
-  it.each([
-    'create',
-    'rotate',
-  ] as const)('validates cookie options before %s token generation or session mutation', async (mode) => {
-    envConfig.allowedOrigin = 'app.example.com'
-    let capturedError: unknown
-    const app = new Hono<HonoEnv>()
-    app.get('/test', async (c) => {
-      try {
-        if (mode === 'create') {
-          const cookie = prepareSessionCookie(c)
-          await issueSession(c, 7, {
-            kind: 'create',
-            cookie,
-            revokeTokens: ['old-token'],
-          })
-        } else {
-          const cookie = prepareSessionCookie(c)
-          await issueSession(c, 7, {
-            kind: 'rotate',
-            cookie,
-            requiredSourceToken: 'source-token',
-            revokeTokens: ['old-token'],
-          })
+  it.each(['create', 'rotate'] as const)(
+    'validates cookie options before %s token generation or session mutation',
+    async (mode) => {
+      envConfig.allowedOrigin = 'app.example.com'
+      let capturedError: unknown
+      const app = new Hono<HonoEnv>()
+      app.get('/test', async (c) => {
+        try {
+          if (mode === 'create') {
+            const cookie = prepareSessionCookie(c)
+            await issueSession(c, 7, {
+              kind: 'create',
+              cookie,
+              revokeTokens: ['old-token'],
+            })
+          } else {
+            const cookie = prepareSessionCookie(c)
+            await issueSession(c, 7, {
+              kind: 'rotate',
+              cookie,
+              requiredSourceToken: 'source-token',
+              revokeTokens: ['old-token'],
+            })
+          }
+        } catch (error) {
+          capturedError = error
         }
-      } catch (error) {
-        capturedError = error
-      }
-      return c.body(null, 204)
-    })
+        return c.body(null, 204)
+      })
 
-    const res = await app.request('https://internal/test')
+      const res = await app.request('https://internal/test')
 
-    expect(capturedError).toBeInstanceOf(TypeError)
-    expect(generateSessionToken).not.toHaveBeenCalled()
-    expect(deleteSession).not.toHaveBeenCalled()
-    expect(createSession).not.toHaveBeenCalled()
-    expect(replaceSession).not.toHaveBeenCalled()
-    expect(res.headers.get('set-cookie')).toBeNull()
-    expect(res.headers.get('cache-control')).toBe('no-store')
-  })
+      expect(capturedError).toBeInstanceOf(TypeError)
+      expect(generateSessionToken).not.toHaveBeenCalled()
+      expect(deleteSession).not.toHaveBeenCalled()
+      expect(createSession).not.toHaveBeenCalled()
+      expect(replaceSession).not.toHaveBeenCalled()
+      expect(res.headers.get('set-cookie')).toBeNull()
+      expect(res.headers.get('cache-control')).toBe('no-store')
+    },
+  )
 
   it('does not parse cookie configuration for cookie-free issuance', async () => {
     envConfig.allowedOrigin = 'app.example.com'

--- a/tests/server/routes/auth.test.ts
+++ b/tests/server/routes/auth.test.ts
@@ -800,28 +800,27 @@ describe('POST /api/v1/auth/session/migrate', () => {
     })
   })
 
-  it.each([
-    'session-cookie',
-    'session-query',
-    'proxy',
-  ] as const)('rejects verified %s auth because migration requires a bearer', async (authMethod) => {
-    const app = new Hono<HonoEnv>()
-    app.use('*', async (c, next) => {
-      c.set('userId', 1)
-      c.set('authMethod', authMethod)
-      await next()
-    })
-    app.route('/', authRoutes(makeDeps()))
+  it.each(['session-cookie', 'session-query', 'proxy'] as const)(
+    'rejects verified %s auth because migration requires a bearer',
+    async (authMethod) => {
+      const app = new Hono<HonoEnv>()
+      app.use('*', async (c, next) => {
+        c.set('userId', 1)
+        c.set('authMethod', authMethod)
+        await next()
+      })
+      app.route('/', authRoutes(makeDeps()))
 
-    const res = await app.request('/api/v1/auth/session/migrate', { method: 'POST' })
+      const res = await app.request('/api/v1/auth/session/migrate', { method: 'POST' })
 
-    expect(res.status).toBe(403)
-    expect(res.headers.get('set-cookie')).toBeNull()
-    await expect(res.json()).resolves.toMatchObject({
-      type: '/problems/auth-session-migration-requires-bearer',
-      status: 403,
-    })
-  })
+      expect(res.status).toBe(403)
+      expect(res.headers.get('set-cookie')).toBeNull()
+      await expect(res.json()).resolves.toMatchObject({
+        type: '/problems/auth-session-migration-requires-bearer',
+        status: 403,
+      })
+    },
+  )
 
   it('leaves an invalid bearer to the auth middleware', async () => {
     const app = createApp(makeDeps({ getUserCount: vi.fn(async () => 1) }))

--- a/tests/server/routes/settings.test.ts
+++ b/tests/server/routes/settings.test.ts
@@ -901,33 +901,36 @@ describe('POST /api/v1/settings/test/:service', () => {
     ['explicit', { libraryId: 'music-1' }, 'music-1'],
     ['empty', { libraryId: '' }, ''],
     ['omitted', {}, 'stored-music'],
-  ])('passes the %s Jellyfin library selection to the client', async (_case, selection, expected) => {
-    mockCreateJellyfinClient.mockClear()
-    mockGetUserConnections.mockResolvedValueOnce({
-      ...defaultUserConnections,
-      jellyfinLibraryId: 'stored-music',
-    })
-    const app = createApp(makeDeps())
+  ])(
+    'passes the %s Jellyfin library selection to the client',
+    async (_case, selection, expected) => {
+      mockCreateJellyfinClient.mockClear()
+      mockGetUserConnections.mockResolvedValueOnce({
+        ...defaultUserConnections,
+        jellyfinLibraryId: 'stored-music',
+      })
+      const app = createApp(makeDeps())
 
-    const res = await authedRequest(app, '/api/v1/settings/test/jellyfin', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        url: 'http://jellyfin:8096',
-        apiKey: 'jellyfin-key',
-        userId: 'user-1',
-        ...selection,
-      }),
-    })
+      const res = await authedRequest(app, '/api/v1/settings/test/jellyfin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          url: 'http://jellyfin:8096',
+          apiKey: 'jellyfin-key',
+          userId: 'user-1',
+          ...selection,
+        }),
+      })
 
-    expect(res.status).toBe(200)
-    expect(mockCreateJellyfinClient).toHaveBeenCalledWith(
-      'http://jellyfin:8096',
-      'jellyfin-key',
-      'user-1',
-      { skipTlsVerify: false, libraryId: expected },
-    )
-  })
+      expect(res.status).toBe(200)
+      expect(mockCreateJellyfinClient).toHaveBeenCalledWith(
+        'http://jellyfin:8096',
+        'jellyfin-key',
+        'user-1',
+        { skipTlsVerify: false, libraryId: expected },
+      )
+    },
+  )
 
   it.each([
     ['explicit', { libraryId: 'music-1' }, 'music-1'],


### PR DESCRIPTION
## What

Replaces the Dependabot **dev-tools** group bump (#511) whose `lint-typecheck-test`
job failed. Same dependency bumps, plus the formatter fixes 2.5.4 requires so CI
goes green.

Bumps:
- `@biomejs/biome` `^2.5.3` -> `^2.5.4`
- `vite` `^8.1.4` -> `^8.1.5`
- `@tailwindcss/vite` `^4.3.3` -> `^4.3.2`

**Supersedes #511** (Dependabot owns that branch; it will be closed manually — not
auto-closed here).

## Why CI failed

The failure was **formatter**, not lint-rule, behavior. biome 2.5.4 refined how
call arguments group when a chained call has a multiline array argument followed by
a trailing callback — the exact `it.each([...] as const)('desc', async (x) => {…})`
shape used across the test suite. 2.5.4 now prints the array inline and breaks at
the outer call instead, so `biome check` reported 7 files as needing reformat and
exited non-zero.

## How fixed

- Applied the **safe** autofix only (`biome check --write`, no `--unsafe`). All
  changes are pure whitespace/reflow — no code semantics touched.
- Synced `biome.json` `$schema` URL to `2.5.4` to match the installed version.

Files reformatted (formatter-only):
- `tests/core/ops/backup.test.ts`
- `tests/core/slskd/orchestrator.test.ts`
- `tests/scripts/prepare-rollback-backup.test.ts`
- `tests/server/middleware/csrf.test.ts`
- `tests/server/middleware/session-cookie.test.ts`
- `tests/server/routes/auth.test.ts`
- `tests/server/routes/settings.test.ts`

## Verification

- `bun run lint` -> clean (798 files checked, no fixes applied)
- `bun run typecheck` -> clean (tsc --noEmit, no output)
- `bun run test` -> **317 files passed / 4 skipped; 3098 tests passed / 32 skipped**
