### PR TITLE
ci(security): run dependency audit on develop PRs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,9 +3,9 @@ on:
   schedule:
     - cron: "0 6 * * 1"
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read
@@ -70,8 +70,11 @@ jobs:
   trivy-image:
     name: Trivy container scan
     runs-on: ubuntu-24.04
-    # skip when DOCKERHUB secrets unavailable (fork PRs, dependabot)
-    if: github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]')
+    # Heavy (builds the image): main-only + weekly schedule, so develop PRs stay
+    # cheap. Also skip when DOCKERHUB secrets are unavailable (fork PRs, dependabot).
+    if: >-
+      (github.event_name == 'schedule' || github.ref == 'refs/heads/main' || github.base_ref == 'main') &&
+      (github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]'))
     permissions:
       security-events: write
     steps:
@@ -108,6 +111,8 @@ jobs:
 
   codeql:
     runs-on: ubuntu-24.04
+    # Heavy (full analysis): main-only + weekly schedule, so develop PRs stay cheap.
+    if: github.event_name == 'schedule' || github.ref == 'refs/heads/main' || github.base_ref == 'main'
     permissions:
       security-events: write
     steps:


### PR DESCRIPTION
## What

Extend the Security workflow to also trigger on `develop` push/PR (previously `main` + weekly cron only).

## Why

Features and dependabot bumps land on `develop`, where `bun audit` never ran. A high/critical advisory could ride `:nightly` and only surface at the release PR. This closes that coverage gap without adding release friction.

## How

- `develop` added to the workflow's push/PR branch triggers.
- `bun audit` + `trivy-fs` now run on develop PRs (cheap; catch high/critical early).
- Heavy jobs stay lean: `trivy-image` (builds the image) and `codeql` (full analysis) are gated to main-only + the weekly `schedule`, so develop PRs don't pay for them.
- Gate covers all three event shapes: `github.ref == refs/heads/main` (push), `github.base_ref == main` (PR merge ref), and `github.event_name == schedule` (cron runs on the default branch `develop`, so it must be allowed explicitly or weekly deep-scan coverage would drop).
- Audit stays **non-required** on main protection by design: a fixless upstream advisory should not hard-block a release, and the job already fails its own run on high/critical.

Verified: `yaml.safe_load` + `actionlint` clean.

Closes #540