### PR TITLE
chore(cleanup): consolidate MBID validation and clear audit nits

### DIFF
--- a/docs/guides/unraid.md
+++ b/docs/guides/unraid.md
@@ -81,7 +81,11 @@ The template exposes these fields (matching
 | Encryption Key | `DIGARR_ENCRYPTION_KEY` | No | 32+ char key for encrypting API keys, tokens, and connection passwords. If blank, those fields are stored unencrypted and the app logs a production warning; generate and persist a key before entering secrets |
 | Disable Registration | `DIGARR_DISABLE_REGISTRATION` | No | Defaults to `true`; set `false` to allow new sign-ups |
 | Skip TLS Verify | `SKIP_TLS_VERIFY` | No | Skip TLS checks for Lidarr/Jellyfin/etc. connections |
-| Webhook URL | `WEBHOOK_URL` | No | Discord HTTPS webhook (embed payload) or a public HTTPS endpoint that accepts Digarr's raw JSON payload |
+| Webhook URL | `WEBHOOK_URL` | No | Optional bootstrap for a single webhook channel: a Discord HTTPS webhook (embed payload) or a public HTTPS endpoint that accepts Digarr's raw JSON payload. Auto-migrates into the channel list on first start |
+
+`WEBHOOK_URL` seeds one webhook channel for convenience. Notifications are
+multi-channel -- add webhook, ntfy, Telegram, or Apprise channels (each with its
+own event subscriptions) under **Settings -> Notifications** in the web UI.
 
 Use HTTPS for webhook delivery. Plain HTTP is accepted for compatibility but
 exposes notification data and any credential embedded in the URL while in transit.

--- a/src/core/library/album-reconciler.ts
+++ b/src/core/library/album-reconciler.ts
@@ -1,11 +1,10 @@
 import { type createMusicBrainzClient, parseYear } from '@/core/clients/musicbrainz'
+import { isValidMbid } from '@/core/validation'
 import { normalizeAlbumTitle } from './normalize'
 import type { LibraryAlbum } from './sources/types'
 import type { UnreconciledReason } from './types'
 
 type MBClient = Pick<ReturnType<typeof createMusicBrainzClient>, 'getReleaseGroups'>
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export type ReconciledAlbum = {
   sourceAlbumId: string
@@ -90,10 +89,9 @@ export async function reconcileAlbumsForArtist(
       )
     }
 
-    const direct =
-      typeof album.mbid === 'string' && UUID_RE.test(album.mbid)
-        ? releaseGroups.find((rg) => rg.id === album.mbid)
-        : undefined
+    const direct = isValidMbid(album.mbid)
+      ? releaseGroups.find((rg) => rg.id === album.mbid)
+      : undefined
 
     if (direct) {
       return makeRow(
@@ -143,11 +141,13 @@ export async function reconcileAlbumsForArtist(
       const yearMatches = candidates.filter(
         (candidate) => parseYear(candidate.firstReleaseDate) === album.releaseYear,
       )
-      const allOtherCandidatesHaveKnownDifferentYears = candidates.every((candidate) => {
-        const candidateYear = parseYear(candidate.firstReleaseDate)
-        return candidateYear === album.releaseYear || candidateYear !== undefined
-      })
-      if (yearMatches.length === 1 && yearMatches[0] && allOtherCandidatesHaveKnownDifferentYears) {
+      // Only a confident year match when every candidate has a known year: an
+      // unknown-year candidate could share album.releaseYear, which would make
+      // the single match ambiguous rather than unique.
+      const allCandidatesHaveKnownYears = candidates.every(
+        (candidate) => parseYear(candidate.firstReleaseDate) !== undefined,
+      )
+      if (yearMatches.length === 1 && yearMatches[0] && allCandidatesHaveKnownYears) {
         return makeRow(
           album,
           titleNormalized,

--- a/src/core/library/reconciler.ts
+++ b/src/core/library/reconciler.ts
@@ -1,4 +1,5 @@
 import type { createMusicBrainzClient } from '@/core/clients/musicbrainz'
+import { isValidMbid } from '@/core/validation'
 import type { LibrarySyncCounts } from '@/db/schema'
 import { normalizeArtistName } from './normalize'
 import type { LibraryArtist } from './sources/types'
@@ -8,8 +9,6 @@ type MBClient = Pick<
   ReturnType<typeof createMusicBrainzClient>,
   'searchArtist' | 'getReleaseGroups'
 >
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 function mbErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
@@ -52,10 +51,6 @@ export type ReconcilerContext = {
   ) => Promise<Array<{ mbid: string; name: string; source: string }>>
   /** Mutable accumulator updated as the run progresses; surfaced to UI */
   counts: LibrarySyncCounts
-}
-
-function isValidUuid(value: string | undefined): value is string {
-  return typeof value === 'string' && UUID_RE.test(value)
 }
 
 function matchedRow(
@@ -123,7 +118,7 @@ export async function reconcileArtist(
   }
 
   // Step 1: source-provided MBID
-  if (isValidUuid(artist.mbid)) {
+  if (isValidMbid(artist.mbid)) {
     ctx.counts.matchedMbid += 1
     return matchedRow(artist, nameNormalized, artist.mbid, 'mbid', 1.0)
   }

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -6,7 +6,7 @@ export function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
-const MBID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+export const MBID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export function isValidMbid(value: unknown): value is string {
   return typeof value === 'string' && MBID_RE.test(value)

--- a/src/server/routes/album-blocks.ts
+++ b/src/server/routes/album-blocks.ts
@@ -1,10 +1,9 @@
 import { Hono } from 'hono'
+import { isValidMbid } from '@/core/validation'
 import type { BlockedAlbumRow } from '@/db/queries/album-blocks'
 import { problem } from '@/server/helpers/problem'
 import { requireUser } from '@/server/helpers/require-user'
 import type { HonoEnv } from '@/server/types'
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export type AlbumBlocksRouteDeps = {
   listAlbumBlocks: (userId: number) => Promise<BlockedAlbumRow[]>
@@ -29,7 +28,7 @@ export function albumBlocksRoutes(deps: AlbumBlocksRouteDeps) {
     if (!auth.ok) return auth.response
     const { userId } = auth
     const releaseGroupMbid = c.req.param('releaseGroupMbid')
-    if (!UUID_RE.test(releaseGroupMbid)) {
+    if (!isValidMbid(releaseGroupMbid)) {
       return problem(
         c,
         'invalid-id',

--- a/src/server/routes/artists.ts
+++ b/src/server/routes/artists.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 import { createDeezerClient } from '@/core/clients/deezer'
 import { createMusicBrainzClient } from '@/core/clients/musicbrainz'
 import { createWikidataClient } from '@/core/clients/wikidata'
+import { isValidMbid } from '@/core/validation'
 import type { TopTrack, TopTracksCache } from '@/db/schema'
 import { artists } from '@/db/schema'
 import type { AppDependencies } from '@/server'
@@ -187,7 +188,7 @@ export function artistRoutes(deps: AppDependencies) {
 
   router.get('/api/v1/albums/:mbid', async (c) => {
     const mbid = c.req.param('mbid')
-    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(mbid)) {
+    if (!isValidMbid(mbid)) {
       return c.json({ error: 'Invalid MBID format' }, 400)
     }
     const releaseGroups = await mb.getReleaseGroups(mbid)

--- a/src/server/routes/library.ts
+++ b/src/server/routes/library.ts
@@ -5,7 +5,7 @@ import type { SkyHookWarmer } from '@/core/library/skyhook-warmer'
 import type { LibrarySyncStore } from '@/core/library/store'
 import { SOURCE_NOT_CONFIGURED_ERROR, type SyncOrchestrator } from '@/core/library/sync'
 import type { HealthCheckId, UnreconciledReason } from '@/core/library/types'
-import { errMsg, logAndSanitize } from '@/core/validation'
+import { errMsg, isValidMbid, logAndSanitize } from '@/core/validation'
 import { requireAdmin, requireSessionUser } from '@/server/helpers/require-user'
 import { rateLimiter } from '@/server/middleware/rate-limit'
 import {
@@ -28,7 +28,6 @@ const VALID_CHECK_IDS: Set<string> = new Set([
   'image-gaps',
   'missing-wikidata',
 ])
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 type PublicUnreconciledReason = Exclude<UnreconciledReason, 'override_skip'> | null
 
 type LibraryRouteDeps = {
@@ -181,7 +180,7 @@ export function libraryRoutes(deps: LibraryRouteDeps) {
     const auth = requireSessionUser(c)
     if (!auth.ok) return auth.response
     const artistMbid = c.req.param('artistMbid')
-    if (!UUID_RE.test(artistMbid)) {
+    if (!isValidMbid(artistMbid)) {
       return c.json({ error: 'artistMbid must be a valid UUID' }, 400)
     }
     const coverage = await deps.albumCoverage.getCoverageForArtist(auth.userId, artistMbid)

--- a/src/server/schemas/library.ts
+++ b/src/server/schemas/library.ts
@@ -1,7 +1,6 @@
 import * as z from 'zod'
 import { LIBRARY_BULK_IGNORE_LIMIT } from '@/core/library/types'
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+import { MBID_RE } from '@/core/validation'
 
 // Keep the batch cap in lockstep with the runtime slice in library.ts.
 export const libraryWarmSchema = z
@@ -79,7 +78,7 @@ export const libraryOverrideSchema = z
       .union([
         z.literal(''),
         z.null(),
-        z.string().regex(UUID_RE, 'correctMbid must be a valid UUID'),
+        z.string().regex(MBID_RE, 'correctMbid must be a valid UUID'),
       ])
       .optional(),
     note: z.string().optional(),
@@ -94,7 +93,7 @@ export const libraryAlbumOverrideSchema = z
       .union([
         z.literal(''),
         z.null(),
-        z.string().regex(UUID_RE, 'correctAlbumMbid must be a valid UUID'),
+        z.string().regex(MBID_RE, 'correctAlbumMbid must be a valid UUID'),
       ])
       .optional(),
     note: z.string().optional(),

--- a/src/web/components/library-unreconciled-album-row.tsx
+++ b/src/web/components/library-unreconciled-album-row.tsx
@@ -22,6 +22,8 @@ export function LibraryUnreconciledAlbumRowComponent({
   const typeLabel = row.primaryType ?? t('libraryReconciliation.unknownType')
   const yearLabel = row.releaseYear ?? t('libraryReconciliation.unknownYear')
 
+  // selectionLabel uses a function replacer: user titles may contain
+  // $-sequences that a string replacement would expand ($&, $1, ...).
   return (
     <LibraryUnreconciledReviewRow
       title={row.title}

--- a/src/web/components/library-unreconciled-review-row.tsx
+++ b/src/web/components/library-unreconciled-review-row.tsx
@@ -1,10 +1,9 @@
 import { type ReactNode, useId, useState } from 'react'
+import { isValidMbid } from '@/core/validation'
 import type { LibraryUnreconciledReason } from '../lib/api'
 import { rerunLibraryReconciler } from '../lib/api'
 import { useI18n } from '../lib/i18n'
 import { isBulkIgnoreEligible, LibraryReconciliationReason } from './library-reconciliation-reason'
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 type Props = {
   title: string
@@ -59,7 +58,7 @@ export function LibraryUnreconciledReviewRow({
   async function pinMbid() {
     const mbid = mbidInput.trim()
     setError(null)
-    if (!UUID_RE.test(mbid)) {
+    if (!isValidMbid(mbid)) {
       setError(t('libraryReconciliation.invalidMbid'))
       return
     }

--- a/src/web/components/library-unreconciled-row.tsx
+++ b/src/web/components/library-unreconciled-row.tsx
@@ -25,6 +25,8 @@ export function LibraryUnreconciledRowComponent({
       metadata={
         <>
           {row.source} -{' '}
+          {/* function replacer: user names may contain $-sequences that a string
+              replacement would expand ($&, $1, ...) */}
           {t('libraryReconciliation.normalizedName').replace('{0}', () => row.nameNormalized)}
         </>
       }

--- a/src/web/pages/settings.tsx
+++ b/src/web/pages/settings.tsx
@@ -351,11 +351,11 @@ const CHANNEL_TYPE_LABEL: Record<ChannelType, MessageKey> = {
 }
 
 function makeChannel(type: ChannelType): NotificationChannel {
-  const id =
-    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-      ? crypto.randomUUID()
-      : `ch_${Date.now()}_${Math.random().toString(36).slice(2)}`
-  const base = { id, enabled: true, events: ['batch_complete', 'digest'] as NotificationEvent[] }
+  const base = {
+    id: crypto.randomUUID(),
+    enabled: true,
+    events: ['batch_complete', 'digest'] as NotificationEvent[],
+  }
   switch (type) {
     case 'webhook':
       return { ...base, type, url: '' }


### PR DESCRIPTION
## What

Low-severity cleanups from a four-lens audit sweep (code-review, anti-slop, security, docs) of everything merged since the 2026-07-06 sweep.

**Sweep verdict: the batch is clean** — code-review found 0 findings at/above threshold, security 0 P0/P1/P2, docs healthy. These are the P3 tidy-ups only.

## Changes

- **MBID regex dedup**: the strict `/^[0-9a-f]{8}-...$/i` was copy-pasted in 7 files. Consolidated onto the existing `MBID_RE` / `isValidMbid` in `src/core/validation.ts` (web already imports from there). The Jellyfin optional-dash and ListenBrainz RFC-4122 variants are intentionally different and left alone.
- **Dead code**: simplified a redundant disjunct + misleading name in the album-reconciler year-disambiguation guard (`allOtherCandidatesHaveKnownDifferentYears` → `allCandidatesHaveKnownYears`; behavior identical given the surrounding `yearMatches.length === 1` guard). Removed a dead `crypto.randomUUID` feature-detection fallback in settings (browser secure-context app).
- **Clarity**: one-line comments on the safe `.replace('{0}', () => userValue)` function-replacer form (guards $-sequences in user names).
- **Docs**: Unraid guide now notes multi-channel notifications instead of presenting `WEBHOOK_URL` as the only path.

## Verification

- `bun run typecheck` clean
- `bun run lint` clean
- `bun run test` — 3221 passed, 13 skipped

Behavior-preserving refactor; all MBID regex copies were byte-identical to the canonical form.

Follow-ups filed separately: #543 (webhook URL secret-at-rest), #544 (makeRow object-param).

Closes #542