### PR TITLE
feat(notifications): encrypt and mask webhook URLs at rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Releases that have been promoted to the `:stable` Docker channel carry a `(stabl
 
 ## Unreleased
 
+### Security
+
+- **Webhook notification URLs are now encrypted at rest and masked in the settings API.** Discord and Slack webhook URLs carry their secret in the URL path, so they now get the same protection as the other channel secrets: field-encrypted in the database, and returned partially masked by the settings API (the host and path structure stay visible so you can recognize the destination, while the secret tail and any query-string values become `***`). Leaving the masked value untouched on save keeps the stored URL; entering a new URL replaces it. Existing webhook URLs are encrypted on their next save.
+
 ### Added
 
 - **Library reconciliation review is faster and clearer.** Unresolved artists and albums now explain whether no MusicBrainz match exists, multiple matches remain, or a lookup failed. Admins can select visible artists or the current album page and confirm one atomic "Ignore selected" action; transient lookup failures stay out of bulk selection, existing per-row MBID controls remain available, and the workflow is translated across all 15 shipped locales.

--- a/src/core/crypto.ts
+++ b/src/core/crypto.ts
@@ -162,22 +162,60 @@ export const SENSITIVE_PREFERENCES = ['fanartApiKey'] as const
 
 // Notification channels store secrets in array-nested, per-type fields that the
 // flat encrypt/decryptFields helpers cannot reach. These walkers apply
-// field-level crypto per channel type. webhook has no secret field.
+// field-level crypto per channel type. Two classes of field:
+//  - full secrets (CHANNEL_SECRET_FIELDS): encrypted at rest, masked to '***'.
+//  - url secrets (CHANNEL_URL_FIELDS): encrypted at rest, but only PARTIALLY
+//    masked (host + path kept, secret tail/query hidden) because the URL also
+//    identifies the destination and the operator needs to recognize it.
 const CHANNEL_SECRET_FIELDS: Record<string, readonly string[]> = {
   telegram: ['botToken'],
   ntfy: ['token'],
   apprise: ['urls'],
-  webhook: [],
 }
 
-function transformChannelSecrets(
+const CHANNEL_URL_FIELDS: Record<string, readonly string[]> = {
+  webhook: ['url'],
+}
+
+const MASK = '***'
+
+function encryptedFieldsFor(type: string): readonly string[] {
+  return [...(CHANNEL_SECRET_FIELDS[type] ?? []), ...(CHANNEL_URL_FIELDS[type] ?? [])]
+}
+
+/**
+ * Partially mask a webhook URL for API display: keep the scheme, host, and path
+ * structure so the operator can recognize the destination, but replace the last
+ * path segment (where Discord/Slack carry the token) and every query-param value
+ * with `***`. Unparseable input is fully masked.
+ */
+export function maskWebhookUrl(url: string): string {
+  try {
+    const u = new URL(url)
+    const segments = u.pathname.split('/')
+    for (let i = segments.length - 1; i >= 0; i--) {
+      if (segments[i]) {
+        segments[i] = MASK
+        break
+      }
+    }
+    u.pathname = segments.join('/')
+    for (const key of [...u.searchParams.keys()]) {
+      u.searchParams.set(key, MASK)
+    }
+    return u.toString()
+  } catch {
+    return MASK
+  }
+}
+
+function transformChannelFields(
   channels: NotificationChannel[],
   fn: (value: string) => string,
 ): NotificationChannel[] {
   return channels.map((channel) => {
-    const fields = CHANNEL_SECRET_FIELDS[channel.type] ?? []
     const copy = { ...channel } as Record<string, unknown>
-    for (const f of fields) {
+    for (const f of encryptedFieldsFor(channel.type)) {
       const val = copy[f]
       if (typeof val === 'string' && val) {
         copy[f] = fn(val)
@@ -190,46 +228,72 @@ function transformChannelSecrets(
 /** Encrypt per-type secret fields in notification channels. No-op if encryption disabled. */
 export function encryptChannelSecrets(channels: NotificationChannel[]): NotificationChannel[] {
   if (!isEncryptionEnabled()) return channels
-  return transformChannelSecrets(channels, (v) => encryptField(v) as string)
+  return transformChannelFields(channels, (v) => encryptField(v) as string)
 }
 
 /** Decrypt per-type secret fields in notification channels. No-op if encryption disabled. */
 export function decryptChannelSecrets(channels: NotificationChannel[]): NotificationChannel[] {
   if (!isEncryptionEnabled()) return channels
-  return transformChannelSecrets(channels, (v) => decryptField(v) as string)
-}
-
-/** Replace per-type secret fields with a masked placeholder. Always runs. */
-export function maskChannelSecrets(channels: NotificationChannel[]): NotificationChannel[] {
-  return transformChannelSecrets(channels, () => '***')
+  return transformChannelFields(channels, (v) => decryptField(v) as string)
 }
 
 /**
- * Restore masked ('***') channel secrets from a previously-stored channel of the
- * same id, so a save/test that echoes back masked placeholders keeps the stored
- * (encrypted) secret. If the previous channel is missing or has a different type
- * (id reused across a type change, or a genuinely new channel that still carries
- * a literal '***'), the field is dropped instead of persisting a broken secret.
- * Returns new objects; does not mutate the input.
+ * Mask channel secrets for API display. Full-secret fields become '***'; url
+ * fields are decrypted (server-side only) and partially masked so the host stays
+ * visible while the secret tail is hidden. Always runs.
+ */
+export function maskChannelSecrets(channels: NotificationChannel[]): NotificationChannel[] {
+  return channels.map((channel) => {
+    const copy = { ...channel } as Record<string, unknown>
+    for (const f of CHANNEL_SECRET_FIELDS[channel.type] ?? []) {
+      if (typeof copy[f] === 'string' && copy[f]) copy[f] = MASK
+    }
+    for (const f of CHANNEL_URL_FIELDS[channel.type] ?? []) {
+      const val = copy[f]
+      if (typeof val === 'string' && val) copy[f] = maskWebhookUrl(decryptField(val) as string)
+    }
+    return copy as NotificationChannel
+  })
+}
+
+/**
+ * Restore masked channel secrets from a previously-stored channel of the same id,
+ * so a save/test that echoes back masked placeholders keeps the stored (encrypted)
+ * value. Full secrets restore on the '***' sentinel (dropped if there is no prior
+ * channel of the same type, to avoid persisting a broken secret). Url fields
+ * restore when the submitted url still equals the mask of the stored url (i.e. the
+ * operator did not edit it). Returns new objects; does not mutate the input.
  */
 export function restoreMaskedChannelSecrets(
   incoming: NotificationChannel[],
   prevById: Map<string, NotificationChannel>,
 ): NotificationChannel[] {
   return incoming.map((channel) => {
-    const fields = CHANNEL_SECRET_FIELDS[channel.type] ?? []
     const copy = { ...channel } as Record<string, unknown>
-    if (fields.length === 0) return copy as NotificationChannel
+    const secretFields = CHANNEL_SECRET_FIELDS[channel.type] ?? []
+    const urlFields = CHANNEL_URL_FIELDS[channel.type] ?? []
+    if (secretFields.length === 0 && urlFields.length === 0) return copy as NotificationChannel
     const prev = prevById.get(channel.id)
     const prevFields =
       prev && prev.type === channel.type ? (prev as unknown as Record<string, unknown>) : undefined
-    for (const f of fields) {
-      if (copy[f] === '***') {
+    for (const f of secretFields) {
+      if (copy[f] === MASK) {
         if (prevFields && typeof prevFields[f] === 'string' && prevFields[f]) {
           copy[f] = prevFields[f]
         } else {
           delete copy[f]
         }
+      }
+    }
+    for (const f of urlFields) {
+      const prevVal = prevFields?.[f]
+      if (
+        typeof copy[f] === 'string' &&
+        typeof prevVal === 'string' &&
+        prevVal &&
+        copy[f] === maskWebhookUrl(decryptField(prevVal) as string)
+      ) {
+        copy[f] = prevVal
       }
     }
     return copy as NotificationChannel

--- a/tests/core/crypto.channels.test.ts
+++ b/tests/core/crypto.channels.test.ts
@@ -5,6 +5,7 @@ import {
   encryptChannelSecrets,
   initEncryption,
   maskChannelSecrets,
+  maskWebhookUrl,
   restoreMaskedChannelSecrets,
 } from '@/core/crypto'
 import type { NotificationChannel } from '@/core/notifications/types'
@@ -72,11 +73,24 @@ describe('channel secret walkers', () => {
     expect(dec).toEqual(channels)
   })
 
-  it('leaves webhook and non-secret fields untouched', () => {
+  it('encrypts the webhook url at rest and round-trips it', () => {
     const channels = sampleChannels()
     const enc = encryptChannelSecrets(channels)
 
-    expect(enc[0]).toEqual(channels[0]) // webhook has no secret field
+    const webhookEnc = enc[0] as Extract<NotificationChannel, { type: 'webhook' }>
+    expect(webhookEnc.url).not.toBe('https://x.test/hook')
+    expect(webhookEnc.url.startsWith('enc:v1:')).toBe(true)
+
+    const dec = decryptChannelSecrets(enc)
+    expect((dec[0] as Extract<NotificationChannel, { type: 'webhook' }>).url).toBe(
+      'https://x.test/hook',
+    )
+  })
+
+  it('leaves non-secret fields untouched', () => {
+    const channels = sampleChannels()
+    const enc = encryptChannelSecrets(channels)
+
     const telEnc = enc[1] as Extract<NotificationChannel, { type: 'telegram' }>
     expect(telEnc.chatId).toBe('999') // non-secret field preserved
     const ntfyEnc = enc[2] as Extract<NotificationChannel, { type: 'ntfy' }>
@@ -90,13 +104,14 @@ describe('channel secret walkers', () => {
     expect((channels[1] as { botToken: string }).botToken).toBe('bot-secret-123')
   })
 
-  it('mask replaces every secret with ***', () => {
+  it('mask replaces every full secret with *** and partial-masks the webhook url', () => {
     const masked = maskChannelSecrets(sampleChannels())
     expect((masked[1] as { botToken: string }).botToken).toBe('***')
     expect((masked[2] as { token?: string }).token).toBe('***')
     expect((masked[3] as { urls: string }).urls).toBe('***')
-    // webhook + non-secret fields survive
-    expect(masked[0]).toEqual(sampleChannels()[0])
+    // webhook url keeps its host but hides the secret tail
+    expect((masked[0] as { url: string }).url).toBe('https://x.test/***')
+    // non-secret fields survive
     expect((masked[1] as { chatId: string }).chatId).toBe('999')
   })
 
@@ -106,6 +121,30 @@ describe('channel secret walkers', () => {
     const enc = encryptChannelSecrets(channels)
     expect(enc).toBe(channels)
     expect((enc[1] as { botToken: string }).botToken).toBe('bot-secret-123')
+  })
+})
+
+describe('maskWebhookUrl', () => {
+  it('masks the token tail of a Discord webhook but keeps the id', () => {
+    expect(maskWebhookUrl('https://discord.com/api/webhooks/123456/tok-abc')).toBe(
+      'https://discord.com/api/webhooks/123456/***',
+    )
+  })
+
+  it('masks the last path segment of a Slack webhook', () => {
+    expect(maskWebhookUrl('https://hooks.slack.com/services/T00/B00/XXXXsecret')).toBe(
+      'https://hooks.slack.com/services/T00/B00/***',
+    )
+  })
+
+  it('redacts query-string secrets (and the path tail, conservatively)', () => {
+    expect(maskWebhookUrl('https://ex.test/hook?token=abc123')).toBe(
+      'https://ex.test/***?token=***',
+    )
+  })
+
+  it('fully masks an unparseable value', () => {
+    expect(maskWebhookUrl('not a url')).toBe('***')
   })
 })
 
@@ -158,5 +197,42 @@ describe('restoreMaskedChannelSecrets', () => {
     expect((out as { botToken: string }).botToken).toBe('fresh-plaintext')
     expect((input[0] as { botToken: string }).botToken).toBe('fresh-plaintext')
     expect(out).not.toBe(input[0])
+  })
+})
+
+describe('restoreMaskedChannelSecrets webhook url', () => {
+  beforeEach(() => {
+    initEncryption(TEST_KEY)
+  })
+  afterEach(() => {
+    initEncryption(undefined)
+  })
+
+  function webhook(url: string): NotificationChannel {
+    return { id: 'w', type: 'webhook', enabled: true, events: ['batch_complete'], url }
+  }
+
+  it('keeps the stored url when the submitted url is still masked', () => {
+    const storedPlain = 'https://discord.com/api/webhooks/123456/tok-abc'
+    const storedEnc = encryptChannelSecrets([webhook(storedPlain)])[0] as NotificationChannel
+    const prev = new Map<string, NotificationChannel>([['w', storedEnc]])
+
+    // the client echoes back exactly what the masked GET /settings returned
+    const [out] = restoreMaskedChannelSecrets([webhook(maskWebhookUrl(storedPlain))], prev)
+
+    expect((out as { url: string }).url).toBe((storedEnc as { url: string }).url)
+    expect((decryptChannelSecrets([out as NotificationChannel])[0] as { url: string }).url).toBe(
+      storedPlain,
+    )
+  })
+
+  it('replaces the url when the user submits a new one', () => {
+    const storedPlain = 'https://discord.com/api/webhooks/123456/tok-abc'
+    const storedEnc = encryptChannelSecrets([webhook(storedPlain)])[0] as NotificationChannel
+    const prev = new Map<string, NotificationChannel>([['w', storedEnc]])
+
+    const [out] = restoreMaskedChannelSecrets([webhook('https://new.test/hook')], prev)
+
+    expect((out as { url: string }).url).toBe('https://new.test/hook')
   })
 })


### PR DESCRIPTION
## What

Webhook channel URLs were the only channel field stored in cleartext and returned unmasked from `GET /settings`. Discord/Slack webhook URLs carry their secret in the path, so this brings them in line with the other channel secrets (Telegram token, ntfy token, Apprise URLs), which have been encrypted-at-rest + masked since #520.

Closes #543 (audit-sweep follow-up).

## How

- **Encrypt at rest**: webhook `url` joins the channel encrypt/decrypt walker via a new `CHANNEL_URL_FIELDS` map. Existing rows encrypt on their next save, guarded by the `enc:v1:` idempotency prefix (no forced migration — same lazy model as the other channel secrets).
- **Partial mask in the API**: new `maskWebhookUrl()` keeps scheme/host/path structure so the operator recognizes the destination, but replaces the last path segment (the Discord/Slack token) and every query-string value with `***`. Masking decrypts server-side; plaintext never leaves the process.
- **Restore on save**: compares the submitted url against the mask of the stored url. An untouched masked value keeps the stored (encrypted) url; a new url replaces it. This avoids sentinel-sniffing and needs **no frontend change** — the existing input round-trips the masked value.

Send paths (`pipeline/orchestrator.ts`, `settings.ts`, `index.ts`) already decrypt channel secrets before dispatch, and `url` is now in the decrypt set, so webhooks POST to the plaintext url.

## Design note

Masking is conservative and host-agnostic: it masks the last path segment for **any** webhook URL (not just known Discord/Slack hosts), since we can't reliably tell where a secret lives. A generic `https://host/notify?token=x` shows as `https://host/***?token=***` — the host still identifies it. UX matches the established masked-secret convention (leave to keep, retype to change).

## Tests (TDD)

New `maskWebhookUrl` unit cases (Discord tail, Slack tail, query redaction, unparseable → `***`), at-rest encrypt/decrypt round-trip for the url, and restore keep-vs-replace. Old assertions that encoded 'webhook has no secret field' updated to the new behavior.

## Verification

- `bun run typecheck` clean
- `bun run lint` clean
- `bun run test` — 3228 passed, 13 skipped (7 new)

## Docs

CHANGELOG Unreleased gains a Security entry. (AGENTS.md notification gotcha already reflects channel-secret encryption.)