### PR TITLE
fix(auth): name the fix when a Secure cookie blocks login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes are documented here.
 
 Releases that have been promoted to the `:stable` Docker channel carry a `(stable)` marker after the version heading. Promotion happens after a release has been live for at least seven days with no follow-up patch.
 
+## Unreleased
+
+### Fixed
+
+- **A failed login over plain HTTP now says which setting to change.** Signing in from another machine on a direct-HTTP install failed with "The browser did not accept the session cookie", which named the symptom but not the fix. The cause is that session cookies are `Secure` in production and browsers keep those only over HTTPS and on `http://localhost` -- so logging in works on the machine running Digarr and fails everywhere else. When the page is served over plain HTTP from a non-localhost address, the login screen now explains that and names both remedies (serve over HTTPS, or set `DIGARR_ALLOW_INSECURE_COOKIES=true` with a matching `ALLOWED_ORIGIN`). A production instance in that configuration also logs a warning at startup, before anyone reaches a login screen, and `docs/AUTHENTICATION.md` gained a troubleshooting entry under the error text. Translated across all 15 shipped locales.
+
 ## v1.15.0 - 2026-07-29
 
 ### Security

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -119,6 +119,27 @@ HTTPS public origin and leave the override at `false` whenever a proxy or
 terminator can provide TLS. Outside production the cookie is `Secure` only for
 an `https:` public origin.
 
+#### "The browser did not accept the session cookie"
+
+This is the `Secure`-only cookie being discarded by the browser. Browsers keep
+`Secure` cookies on `https://` origins and on `http://localhost`, which the
+platform treats as a secure context, but drop them on any other plain-HTTP
+address. The tell is that signing in works on the machine running Digarr and
+fails from every other device on the network.
+
+Either serve Digarr over HTTPS and set an `https://` `ALLOWED_ORIGIN`, or, for a
+deliberate plain-HTTP deployment, set both:
+
+```sh
+DIGARR_ALLOW_INSECURE_COOKIES=true
+ALLOWED_ORIGIN=http://<host-or-ip>:3000
+```
+
+`ALLOWED_ORIGIN` must match the URL typed into the address bar exactly, scheme
+and port included. On plain HTTP the session cookie travels unencrypted, so
+prefer TLS wherever a proxy can provide it. A production instance that would hit
+this logs a warning naming both remedies at startup.
+
 Registration is closed by default after the first user has been created. To
 open registration in a fresh install or internal deployment, set
 `DIGARR_DISABLE_REGISTRATION=false`.

--- a/src/core/i18n/messages/de.ts
+++ b/src/core/i18n/messages/de.ts
@@ -32,6 +32,8 @@ export const de = {
   'auth.registerDescription': 'Erstellen Sie das erste Konto, um loszulegen.',
   'auth.sessionCookieRejected':
     'Der Browser hat das Sitzungscookie nicht akzeptiert. Überprüfen Sie die öffentliche URL- und HTTPS-Konfiguration.',
+  'auth.sessionCookieInsecureOrigin':
+    'Der Browser hat das Sitzungscookie nicht akzeptiert. Diese Seite wird über einfaches HTTP von einer Adresse außerhalb von localhost ausgeliefert, und das Sitzungscookie ist als Secure markiert, daher verwirft der Browser es. Stelle Digarr über HTTPS bereit oder setze DIGARR_ALLOW_INSECURE_COOKIES=true und ALLOWED_ORIGIN auf genau diese URL und starte anschließend neu.',
   'auth.sessionMigrationFailed':
     'Ihre gespeicherte Browsersitzung konnte nicht aktualisiert werden. Melden Sie sich erneut an.',
   'auth.sessionVerificationFailed':

--- a/src/core/i18n/messages/en.ts
+++ b/src/core/i18n/messages/en.ts
@@ -32,6 +32,8 @@ export const en = {
   'auth.registerDescription': 'Create the first account to get started.',
   'auth.sessionCookieRejected':
     'The browser did not accept the session cookie. Check the public URL and HTTPS configuration.',
+  'auth.sessionCookieInsecureOrigin':
+    'The browser did not accept the session cookie. This page is served over plain HTTP from a non-localhost address, and the session cookie is marked Secure, so the browser discards it. Serve Digarr over HTTPS, or set DIGARR_ALLOW_INSECURE_COOKIES=true and ALLOWED_ORIGIN to this exact URL, then restart.',
   'auth.sessionMigrationFailed': 'Your saved browser session could not be upgraded. Sign in again.',
   'auth.sessionVerificationFailed':
     'The session could not be verified. Check your connection and try again.',

--- a/src/core/i18n/messages/es.ts
+++ b/src/core/i18n/messages/es.ts
@@ -32,6 +32,8 @@ export const es = {
   'auth.registerDescription': 'Crea la primera cuenta para empezar.',
   'auth.sessionCookieRejected':
     'El navegador no aceptó la cookie de sesión. Comprueba la configuración de la URL pública y HTTPS.',
+  'auth.sessionCookieInsecureOrigin':
+    'El navegador no aceptó la cookie de sesión. Esta página se sirve por HTTP sin cifrar desde una dirección que no es localhost y la cookie de sesión está marcada como Secure, así que el navegador la descarta. Sirve Digarr por HTTPS, o define DIGARR_ALLOW_INSECURE_COOKIES=true y ALLOWED_ORIGIN con esta URL exacta y reinicia.',
   'auth.sessionMigrationFailed':
     'Tu sesión guardada en el navegador no se pudo actualizar. Inicia sesión de nuevo.',
   'auth.sessionVerificationFailed':

--- a/src/core/i18n/messages/fr.ts
+++ b/src/core/i18n/messages/fr.ts
@@ -32,6 +32,8 @@ export const fr = {
   'auth.registerDescription': 'Créez le premier compte pour commencer.',
   'auth.sessionCookieRejected':
     "Le navigateur n'a pas accepté le cookie de session. Vérifiez la configuration de l'URL publique et de HTTPS.",
+  'auth.sessionCookieInsecureOrigin':
+    "Le navigateur n'a pas accepté le cookie de session. Cette page est servie en HTTP simple depuis une adresse autre que localhost, et le cookie de session porte l'attribut Secure : le navigateur le rejette donc. Servez Digarr en HTTPS, ou définissez DIGARR_ALLOW_INSECURE_COOKIES=true et ALLOWED_ORIGIN sur cette URL exacte, puis redémarrez.",
   'auth.sessionMigrationFailed':
     "Votre session enregistrée dans le navigateur n'a pas pu être mise à niveau. Reconnectez-vous.",
   'auth.sessionVerificationFailed':

--- a/src/core/i18n/messages/it.ts
+++ b/src/core/i18n/messages/it.ts
@@ -32,6 +32,8 @@ export const it = {
   'auth.registerDescription': 'Crea il primo account per iniziare.',
   'auth.sessionCookieRejected':
     "Il browser non ha accettato il cookie di sessione. Controlla la configurazione dell'URL pubblico e di HTTPS.",
+  'auth.sessionCookieInsecureOrigin':
+    'Il browser non ha accettato il cookie di sessione. Questa pagina viene servita tramite HTTP semplice da un indirizzo diverso da localhost e il cookie di sessione è contrassegnato come Secure, quindi il browser lo scarta. Servi Digarr tramite HTTPS oppure imposta DIGARR_ALLOW_INSECURE_COOKIES=true e ALLOWED_ORIGIN su questo URL esatto, poi riavvia.',
   'auth.sessionMigrationFailed':
     'La sessione salvata nel browser non ha potuto essere aggiornata. Accedi di nuovo.',
   'auth.sessionVerificationFailed':

--- a/src/core/i18n/messages/ja.ts
+++ b/src/core/i18n/messages/ja.ts
@@ -32,6 +32,8 @@ export const ja = {
   'auth.registerDescription': '開始するには、最初のアカウントを作成します。',
   'auth.sessionCookieRejected':
     'ブラウザーがセッション Cookie を受け入れませんでした。公開 URL と HTTPS の設定を確認してください。',
+  'auth.sessionCookieInsecureOrigin':
+    'ブラウザーがセッション Cookie を受け入れませんでした。このページは localhost 以外のアドレスから平文の HTTP で配信されており、セッション Cookie には Secure が付いているため、ブラウザーが破棄します。Digarr を HTTPS で配信するか、DIGARR_ALLOW_INSECURE_COOKIES=true と ALLOWED_ORIGIN にこの URL をそのまま設定して再起動してください。',
   'auth.sessionMigrationFailed':
     'ブラウザーに保存されたセッションを更新できませんでした。もう一度サインインしてください。',
   'auth.sessionVerificationFailed':

--- a/src/core/i18n/messages/ko.ts
+++ b/src/core/i18n/messages/ko.ts
@@ -32,6 +32,8 @@ export const ko = {
   'auth.registerDescription': '시작하려면 첫 번째 계정을 만드세요.',
   'auth.sessionCookieRejected':
     '브라우저가 세션 쿠키를 허용하지 않았습니다. 공개 URL 및 HTTPS 설정을 확인하세요.',
+  'auth.sessionCookieInsecureOrigin':
+    '브라우저가 세션 쿠키를 허용하지 않았습니다. 이 페이지는 localhost가 아닌 주소에서 일반 HTTP로 제공되고 세션 쿠키에는 Secure 표시가 있어 브라우저가 쿠키를 버립니다. Digarr를 HTTPS로 제공하거나, DIGARR_ALLOW_INSECURE_COOKIES=true와 ALLOWED_ORIGIN을 이 URL과 정확히 동일하게 설정한 뒤 다시 시작하세요.',
   'auth.sessionMigrationFailed':
     '브라우저에 저장된 세션을 업그레이드하지 못했습니다. 다시 로그인하세요.',
   'auth.sessionVerificationFailed': '세션을 확인하지 못했습니다. 연결을 확인하고 다시 시도하세요.',

--- a/src/core/i18n/messages/nl.ts
+++ b/src/core/i18n/messages/nl.ts
@@ -32,6 +32,8 @@ export const nl = {
   'auth.registerDescription': 'Maak het eerste account aan om aan de slag te gaan.',
   'auth.sessionCookieRejected':
     'De browser heeft de sessiecookie niet geaccepteerd. Controleer de configuratie van de openbare URL en HTTPS.',
+  'auth.sessionCookieInsecureOrigin':
+    'De browser heeft de sessiecookie niet geaccepteerd. Deze pagina wordt via gewone HTTP geserveerd vanaf een ander adres dan localhost en de sessiecookie is als Secure gemarkeerd, dus de browser gooit hem weg. Serveer Digarr via HTTPS, of stel DIGARR_ALLOW_INSECURE_COOKIES=true en ALLOWED_ORIGIN in op exact deze URL en start opnieuw.',
   'auth.sessionMigrationFailed':
     'Uw opgeslagen browsersessie kon niet worden bijgewerkt. Meld u opnieuw aan.',
   'auth.sessionVerificationFailed':

--- a/src/core/i18n/messages/pl.ts
+++ b/src/core/i18n/messages/pl.ts
@@ -32,6 +32,8 @@ export const pl = {
   'auth.registerDescription': 'Aby rozpocząć, utwórz pierwsze konto.',
   'auth.sessionCookieRejected':
     'Przeglądarka nie zaakceptowała pliku cookie sesji. Sprawdź konfigurację publicznego adresu URL i HTTPS.',
+  'auth.sessionCookieInsecureOrigin':
+    'Przeglądarka nie zaakceptowała pliku cookie sesji. Ta strona jest serwowana przez zwykłe HTTP z adresu innego niż localhost, a plik cookie sesji ma atrybut Secure, więc przeglądarka go odrzuca. Udostępnij Digarr przez HTTPS albo ustaw DIGARR_ALLOW_INSECURE_COOKIES=true oraz ALLOWED_ORIGIN na dokładnie ten adres URL i uruchom ponownie.',
   'auth.sessionMigrationFailed':
     'Nie udało się uaktualnić zapisanej sesji przeglądarki. Zaloguj się ponownie.',
   'auth.sessionVerificationFailed':

--- a/src/core/i18n/messages/pt-BR.ts
+++ b/src/core/i18n/messages/pt-BR.ts
@@ -32,6 +32,8 @@ export const ptBR = {
   'auth.registerDescription': 'Crie a primeira conta para começar.',
   'auth.sessionCookieRejected':
     'O navegador não aceitou o cookie de sessão. Verifique a configuração da URL pública e do HTTPS.',
+  'auth.sessionCookieInsecureOrigin':
+    'O navegador não aceitou o cookie de sessão. Esta página é servida por HTTP simples a partir de um endereço diferente de localhost e o cookie de sessão está marcado como Secure, então o navegador o descarta. Sirva o Digarr por HTTPS ou defina DIGARR_ALLOW_INSECURE_COOKIES=true e ALLOWED_ORIGIN com exatamente esta URL e reinicie.',
   'auth.sessionMigrationFailed':
     'Não foi possível atualizar sua sessão salva no navegador. Entre novamente.',
   'auth.sessionVerificationFailed':

--- a/src/core/i18n/messages/ro.ts
+++ b/src/core/i18n/messages/ro.ts
@@ -32,6 +32,8 @@ export const ro = {
   'auth.registerDescription': 'Creați primul cont pentru a începe.',
   'auth.sessionCookieRejected':
     'Browserul nu a acceptat cookie-ul de sesiune. Verificați configurația URL-ului public și HTTPS.',
+  'auth.sessionCookieInsecureOrigin':
+    'Browserul nu a acceptat cookie-ul de sesiune. Această pagină este servită prin HTTP simplu de la o adresă diferită de localhost, iar cookie-ul de sesiune este marcat Secure, așa că browserul îl aruncă. Servește Digarr prin HTTPS sau setează DIGARR_ALLOW_INSECURE_COOKIES=true și ALLOWED_ORIGIN exact la acest URL, apoi repornește.',
   'auth.sessionMigrationFailed':
     'Sesiunea salvată în browser nu a putut fi actualizată. Conectați-vă din nou.',
   'auth.sessionVerificationFailed':

--- a/src/core/i18n/messages/ru.ts
+++ b/src/core/i18n/messages/ru.ts
@@ -32,6 +32,8 @@ export const ru = {
   'auth.registerDescription': 'Создайте первую учетную запись, чтобы начать.',
   'auth.sessionCookieRejected':
     'Браузер не принял файл cookie сеанса. Проверьте настройки публичного URL и HTTPS.',
+  'auth.sessionCookieInsecureOrigin':
+    'Браузер не принял файл cookie сеанса. Эта страница отдается по обычному HTTP с адреса, отличного от localhost, а файл cookie сеанса помечен как Secure, поэтому браузер его отбрасывает. Раздавайте Digarr по HTTPS либо задайте DIGARR_ALLOW_INSECURE_COOKIES=true и ALLOWED_ORIGIN точно с этим URL, затем перезапустите.',
   'auth.sessionMigrationFailed': 'Не удалось обновить сохраненный сеанс браузера. Войдите снова.',
   'auth.sessionVerificationFailed':
     'Не удалось проверить сеанс. Проверьте подключение и повторите попытку.',

--- a/src/core/i18n/messages/tr.ts
+++ b/src/core/i18n/messages/tr.ts
@@ -32,6 +32,8 @@ export const tr = {
   'auth.registerDescription': 'Başlamak için ilk hesabı oluşturun.',
   'auth.sessionCookieRejected':
     'Tarayıcı oturum çerezini kabul etmedi. Genel URL ve HTTPS yapılandırmasını kontrol edin.',
+  'auth.sessionCookieInsecureOrigin':
+    "Tarayıcı oturum çerezini kabul etmedi. Bu sayfa localhost dışındaki bir adresten düz HTTP ile sunuluyor ve oturum çerezi Secure olarak işaretli olduğundan tarayıcı çerezi atıyor. Digarr'ı HTTPS üzerinden sunun ya da DIGARR_ALLOW_INSECURE_COOKIES=true ve ALLOWED_ORIGIN değerini tam olarak bu URL yapıp yeniden başlatın.",
   'auth.sessionMigrationFailed': 'Kayıtlı tarayıcı oturumunuz yükseltilemedi. Yeniden oturum açın.',
   'auth.sessionVerificationFailed':
     'Oturum doğrulanamadı. Bağlantınızı kontrol edip tekrar deneyin.',

--- a/src/core/i18n/messages/uk.ts
+++ b/src/core/i18n/messages/uk.ts
@@ -32,6 +32,8 @@ export const uk = {
   'auth.registerDescription': 'Щоб почати, створіть перший обліковий запис.',
   'auth.sessionCookieRejected':
     'Браузер не прийняв файл cookie сеансу. Перевірте налаштування загальнодоступної URL-адреси та HTTPS.',
+  'auth.sessionCookieInsecureOrigin':
+    'Браузер не прийняв файл cookie сеансу. Ця сторінка віддається звичайним HTTP з адреси, відмінної від localhost, а файл cookie сеансу позначено як Secure, тому браузер його відкидає. Роздавайте Digarr через HTTPS або задайте DIGARR_ALLOW_INSECURE_COOKIES=true та ALLOWED_ORIGIN точно з цією URL-адресою, потім перезапустіть.',
   'auth.sessionMigrationFailed': 'Не вдалося оновити збережений сеанс браузера. Увійдіть знову.',
   'auth.sessionVerificationFailed':
     'Не вдалося перевірити сеанс. Перевірте з’єднання та повторіть спробу.',

--- a/src/core/i18n/messages/zh-CN.ts
+++ b/src/core/i18n/messages/zh-CN.ts
@@ -30,6 +30,8 @@ export const zhCN = {
   'auth.passwordMinError': '密码必须至少为 12 个字符',
   'auth.registerDescription': '创建第一个帐户以开始。',
   'auth.sessionCookieRejected': '浏览器未接受会话 Cookie。请检查公共 URL 和 HTTPS 配置。',
+  'auth.sessionCookieInsecureOrigin':
+    '浏览器未接受会话 Cookie。此页面通过普通 HTTP 从非 localhost 地址提供，而会话 Cookie 带有 Secure 标记，因此浏览器将其丢弃。请通过 HTTPS 提供 Digarr，或将 DIGARR_ALLOW_INSECURE_COOKIES=true 与 ALLOWED_ORIGIN 设置为完全相同的此 URL，然后重启。',
   'auth.sessionMigrationFailed': '无法升级浏览器中保存的会话。请重新登录。',
   'auth.sessionVerificationFailed': '无法验证会话。请检查网络连接后重试。',
   'auth.signIn': '登录',

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -113,6 +113,20 @@ export function createApp(deps: AppDependencies) {
       'DIGARR_ALLOW_INSECURE_COOKIES=true permits plaintext browser session cookies for HTTP origins.',
     )
   }
+  // A Secure-only cookie still works on http://localhost (a secure context), so
+  // this misconfiguration looks fine on the host and blocks every other client.
+  if (process.env.NODE_ENV === 'production' && !envConfig.allowInsecureCookies) {
+    const httpOrigin = envConfig.allowedOrigin?.startsWith('http://')
+    if (httpOrigin || !envConfig.allowedOrigin) {
+      console.warn(
+        `Session cookies are Secure-only${
+          httpOrigin
+            ? ` but ALLOWED_ORIGIN is ${envConfig.allowedOrigin}`
+            : ' and ALLOWED_ORIGIN is unset'
+        }. Browsers accept them over HTTPS and on http://localhost only, so logins from other machines over plain HTTP will fail with "the browser did not accept the session cookie". Serve Digarr over HTTPS, or set DIGARR_ALLOW_INSECURE_COOKIES=true with a matching http:// ALLOWED_ORIGIN.`,
+      )
+    }
+  }
   app.use(
     '*',
     cors({

--- a/src/web/components/auth-gate.tsx
+++ b/src/web/components/auth-gate.tsx
@@ -22,6 +22,28 @@ type MigrationRetryState = 'fresh' | 'retry' | 'unavailable'
 
 const MIGRATION_RETRY_KEY = 'digarr-session-migration-retry'
 
+/**
+ * Browsers treat http://localhost as a secure context and keep Secure cookies
+ * there, so a Secure-only session works on the host but silently fails from any
+ * other address. Detect that case to name the actual fix instead of the symptom.
+ */
+export function isInsecureRemoteOrigin(location: { protocol: string; hostname: string }): boolean {
+  if (location.protocol !== 'http:') return false
+  const host = location.hostname.toLowerCase().replace(/^\[|\]$/g, '')
+  return !(
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host === '127.0.0.1' ||
+    host === '::1'
+  )
+}
+
+function sessionCookieRejectedKey(): MessageKey {
+  return isInsecureRemoteOrigin(window.location)
+    ? 'auth.sessionCookieInsecureOrigin'
+    : 'auth.sessionCookieRejected'
+}
+
 function getMigrationRetryState(): MigrationRetryState {
   try {
     return window.sessionStorage.getItem(MIGRATION_RETRY_KEY) === null ? 'fresh' : 'retry'
@@ -176,7 +198,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
       } else if (status.authenticated) {
         setState('authenticated')
       } else {
-        setNotice('auth.sessionCookieRejected')
+        setNotice(sessionCookieRejectedKey())
         setState(status.hasUsers ? 'login' : 'register')
       }
     } catch {

--- a/tests/server/routes/auth.test.ts
+++ b/tests/server/routes/auth.test.ts
@@ -237,18 +237,28 @@ afterEach(async () => {
 })
 
 describe('createApp insecure-cookie warning', () => {
-  const INSECURE_WARNING = expect.stringContaining('DIGARR_ALLOW_INSECURE_COOKIES=true')
+  // Matches the opt-in-enabled warning specifically. The Secure-only warning
+  // also names DIGARR_ALLOW_INSECURE_COOKIES, as the remedy.
+  const INSECURE_WARNING = expect.stringContaining('permits plaintext browser session cookies')
+  const SECURE_ONLY_WARNING = expect.stringContaining('Session cookies are Secure-only')
   let previousNodeEnv: string | undefined
+  let previousOrigin: string | undefined
   let warnSpy: ReturnType<typeof vi.spyOn>
+
+  function setOrigin(origin: string | undefined) {
+    ;(envConfig as { allowedOrigin: string | undefined }).allowedOrigin = origin
+  }
 
   beforeEach(() => {
     previousNodeEnv = process.env.NODE_ENV
+    previousOrigin = envConfig.allowedOrigin
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
   afterEach(() => {
     warnSpy.mockRestore()
     ;(envConfig as { allowInsecureCookies: boolean }).allowInsecureCookies = false
+    setOrigin(previousOrigin)
     if (previousNodeEnv === undefined) delete process.env.NODE_ENV
     else process.env.NODE_ENV = previousNodeEnv
   })
@@ -272,6 +282,47 @@ describe('createApp insecure-cookie warning', () => {
     ;(envConfig as { allowInsecureCookies: boolean }).allowInsecureCookies = true
     createApp(makeDeps())
     expect(warnSpy).not.toHaveBeenCalledWith(INSECURE_WARNING)
+  })
+
+  it('warns that Secure-only cookies will block remote logins on an http origin', () => {
+    process.env.NODE_ENV = 'production'
+    ;(envConfig as { allowInsecureCookies: boolean }).allowInsecureCookies = false
+    setOrigin('http://192.168.1.50:3000')
+    createApp(makeDeps())
+    expect(warnSpy).toHaveBeenCalledWith(SECURE_ONLY_WARNING)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('http://192.168.1.50:3000'))
+  })
+
+  it('warns about Secure-only cookies when ALLOWED_ORIGIN is unset in production', () => {
+    process.env.NODE_ENV = 'production'
+    ;(envConfig as { allowInsecureCookies: boolean }).allowInsecureCookies = false
+    setOrigin(undefined)
+    createApp(makeDeps())
+    expect(warnSpy).toHaveBeenCalledWith(SECURE_ONLY_WARNING)
+  })
+
+  it('stays quiet when production serves an https origin', () => {
+    process.env.NODE_ENV = 'production'
+    ;(envConfig as { allowInsecureCookies: boolean }).allowInsecureCookies = false
+    setOrigin('https://digarr.example.com')
+    createApp(makeDeps())
+    expect(warnSpy).not.toHaveBeenCalledWith(SECURE_ONLY_WARNING)
+  })
+
+  it('stays quiet about Secure-only cookies when the http opt-in is set', () => {
+    process.env.NODE_ENV = 'production'
+    ;(envConfig as { allowInsecureCookies: boolean }).allowInsecureCookies = true
+    setOrigin('http://192.168.1.50:3000')
+    createApp(makeDeps())
+    expect(warnSpy).not.toHaveBeenCalledWith(SECURE_ONLY_WARNING)
+  })
+
+  it('stays quiet about Secure-only cookies outside production', () => {
+    process.env.NODE_ENV = 'test'
+    ;(envConfig as { allowInsecureCookies: boolean }).allowInsecureCookies = false
+    setOrigin('http://192.168.1.50:3000')
+    createApp(makeDeps())
+    expect(warnSpy).not.toHaveBeenCalledWith(SECURE_ONLY_WARNING)
   })
 })
 

--- a/tests/web/components/auth-gate-insecure-origin.test.tsx
+++ b/tests/web/components/auth-gate-insecure-origin.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+import { isInsecureRemoteOrigin } from '@/web/components/auth-gate'
+
+describe('isInsecureRemoteOrigin', () => {
+  it.each([
+    ['http:', '192.168.1.50'],
+    ['http:', '10.0.0.4'],
+    ['http:', 'nas.lan'],
+    ['http:', 'digarr.example.com'],
+    ['http:', '[fd00::1]'],
+  ])('flags plain HTTP served from %s//%s', (protocol, hostname) => {
+    expect(isInsecureRemoteOrigin({ protocol, hostname })).toBe(true)
+  })
+
+  it.each([
+    ['http:', 'localhost'],
+    ['http:', 'LOCALHOST'],
+    ['http:', 'app.localhost'],
+    ['http:', '127.0.0.1'],
+    ['http:', '[::1]'],
+  ])('treats %s//%s as a secure context', (protocol, hostname) => {
+    expect(isInsecureRemoteOrigin({ protocol, hostname })).toBe(false)
+  })
+
+  it.each([
+    ['https:', 'digarr.example.com'],
+    ['https:', '192.168.1.50'],
+    ['https:', 'localhost'],
+  ])('never flags %s//%s', (protocol, hostname) => {
+    expect(isInsecureRemoteOrigin({ protocol, hostname })).toBe(false)
+  })
+})


### PR DESCRIPTION
Reported in [discussion #568](https://github.com/iuliandita/digarr/discussions/568): a user could not log in from any machine other than the one running Digarr, getting only "The browser did not accept the session cookie. Check the public URL and HTTPS configuration."

## Cause

`browserCookieSecure` (`src/server/middleware/session-cookie.ts:27`) marks session cookies `Secure` in production unless `DIGARR_ALLOW_INSECURE_COOKIES=true` **and** the public origin is `http:`. Browsers keep `Secure` cookies over HTTPS and on `http://localhost`, which is a secure context, but discard them on any other plain-HTTP address.

So a direct-HTTP install works perfectly on the host and fails from every other device -- and the error named the symptom without naming the setting to change. This is the footgun already recorded in the audit backlog as "a misconfig footgun -- candidate for a boot-time warning".

## Change

**Login screen.** The browser knows its own origin, so no server-side config is exposed to unauthenticated callers. `isInsecureRemoteOrigin()` detects a plain-HTTP non-localhost page and swaps in a message that states the cause and both remedies. Everything else still gets the original generic text.

**Startup warning.** Production + Secure-only cookies + an `http://` (or unset) `ALLOWED_ORIGIN` now logs a warning naming both remedies, so an operator sees it before anyone reaches a login screen. The existing warning covered only the opposite case (opt-in *enabled*).

**Docs.** `docs/AUTHENTICATION.md` gains a troubleshooting entry titled with the exact error text, so searching the message finds the fix.

## Test change worth a look

`tests/server/routes/auth.test.ts` asserted that no warning contains `DIGARR_ALLOW_INSECURE_COOKIES=true` when cookies stay secure. The new warning names that variable as the remedy, so the matcher was too broad for its own intent. It now matches the opt-in warning's distinctive wording (`permits plaintext browser session cookies`), and six new cases cover the Secure-only warning across http/https/unset origin, opt-in set, and non-production.

## Verification

- `bun run test` -- 3319 passed, 13 skipped, 0 failed (18 new)
- `bun run lint`, `bun run typecheck`, `bun run i18n:check` -- clean