### PR TITLE
fix(deps): override postcss and nanoid to clear dev-tree advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,8 +52,10 @@
   },
   "overrides": {
     "esbuild": "^0.28.0",
+    "nanoid": "^3.3.18",
     "picomatch": "^4.0.4",
     "playwright-core": "^1.62.0",
+    "postcss": "^8.5.26",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
@@ -716,8 +718,6 @@
 
     "vitest/vite/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
-    "vitest/vite/postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
-
     "vitest/vite/rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
 
     "vitest/vite/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -741,8 +741,6 @@
     "vitest/vite/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "vitest/vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
-
-    "vitest/vite/postcss/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
     "vitest/vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
   },
   "overrides": {
     "esbuild": "^0.28.0",
+    "nanoid": "^3.3.18",
     "picomatch": "^4.0.4",
-    "playwright-core": "^1.62.0"
+    "playwright-core": "^1.62.0",
+    "postcss": "^8.5.26"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",


### PR DESCRIPTION
Closes #596.

`bun audit` reported four findings that no dependency update could clear, because the vulnerable copies were not reachable from the top level.

## Why bumps didn't help

`vite@8.2.1` already resolves clean transitives -- `postcss@8.5.26` (advisory range `<=8.5.22`) and `nanoid@3.3.18` (range `<3.3.16`). But `vitest` pins its own `vite` range, and that subtree resolved its own copies:

```
vitest/vite                -> vite@8.1.3
vitest/vite/postcss        -> postcss@8.5.16   GHSA-r28c-9q8g-f849, GHSA-fxqj-rqcc-2cmp
vitest/vite/postcss/nanoid -> nanoid@3.3.15    GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8
```

Raising `vite` in `package.json` cannot move them. The findings survived the whole dependabot fold in #595.

## Change

Two entries added to the existing `overrides` block, alongside the `esbuild` / `picomatch` / `playwright-core` entries already there:

```json
"nanoid": "^3.3.18",
"postcss": "^8.5.26"
```

The nested `vitest/vite/postcss` and `vitest/vite/postcss/nanoid` entries collapse onto the hoisted clean versions. Net lockfile change is 6 lines.

## Risk

The override forces a postcss minor across a range `vitest` chose, so the test toolchain is the thing that has to prove it -- a resolution the lockfile accepts could still break at test time. Full suite is the gate, and it passes unchanged. The Vite build also exercises postcss through the Tailwind CSS pipeline, and is clean.

Exposure was dev-only regardless: `vitest` is a devDependency, and `deploy/docker/Dockerfile` installs production dependencies only.

## Verification

- `bun audit` -- **no vulnerabilities found** (was 4: 3 high, 1 moderate)
- `bun run test` -- 3344 passed, 13 skipped (338 files), identical to pre-change
- `bun run lint` clean
- `bun run typecheck` clean
- `bun run build` clean
