### PR TITLE
ci: bound compatibility jobs and retry transient image pulls

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -20,6 +20,7 @@ jobs:
   podman:
     name: Podman (rootless)
     runs-on: ubuntu-24.04
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
@@ -35,7 +36,9 @@ jobs:
       # The base compose sets DB_HOST + a secret, so the app must resolve postgres.
       - name: Start postgres stack (base compose + built image)
         working-directory: deploy/docker
-        run: podman-compose -f docker-compose.yml -f docker-compose.compat.yml up -d --build
+        run: |
+          "$GITHUB_WORKSPACE/scripts/ci/compose-up-retry.sh" \
+            podman-compose -f docker-compose.yml -f docker-compose.compat.yml
 
       - name: Assert postgres backend
         run: |
@@ -57,7 +60,9 @@ jobs:
       # pglite from DB_PATH set by the pglite compose.
       - name: Start pglite stack
         working-directory: deploy/docker
-        run: podman-compose -f docker-compose.pglite.yml -f docker-compose.compat.yml up -d --build
+        run: |
+          "$GITHUB_WORKSPACE/scripts/ci/compose-up-retry.sh" \
+            podman-compose -f docker-compose.pglite.yml -f docker-compose.compat.yml
 
       - name: Assert pglite backend + persistence across restart
         working-directory: deploy/docker
@@ -97,6 +102,7 @@ jobs:
   docker-macos:
     name: Docker via Colima (macOS Intel)
     runs-on: macos-15-intel
+    timeout-minutes: 45
     # Keep the macOS signal visible without blocking unrelated pull requests
     # while the hosted Intel path proves stable.
     continue-on-error: true
@@ -149,7 +155,9 @@ jobs:
       - name: Start postgres stack (base compose + built image)
         if: steps.docker.outputs.ready == 'true'
         working-directory: deploy/docker
-        run: docker compose -f docker-compose.yml -f docker-compose.compat.yml up -d --build
+        run: |
+          "$GITHUB_WORKSPACE/scripts/ci/compose-up-retry.sh" \
+            docker compose -f docker-compose.yml -f docker-compose.compat.yml
 
       - name: Assert postgres backend
         id: postgres_assert
@@ -176,7 +184,9 @@ jobs:
       - name: Start pglite stack
         if: steps.docker.outputs.ready == 'true'
         working-directory: deploy/docker
-        run: docker compose -f docker-compose.pglite.yml -f docker-compose.compat.yml up -d --build
+        run: |
+          "$GITHUB_WORKSPACE/scripts/ci/compose-up-retry.sh" \
+            docker compose -f docker-compose.pglite.yml -f docker-compose.compat.yml
 
       - name: Assert pglite backend + persistence across restart
         id: pglite_assert

--- a/scripts/ci/compose-up-retry.sh
+++ b/scripts/ci/compose-up-retry.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Bring a compose stack up, retrying past transient registry failures.
+#
+# The compatibility jobs run four `up -d --build` invocations per workflow, each
+# pulling base images. A single truncated layer ("short read: expected N bytes
+# but got M: unexpected EOF") otherwise kills the whole job, which says nothing
+# about the thing under test.
+#
+# Usage: compose-up-retry.sh <compose-command> [compose-args...]
+#   compose-up-retry.sh docker compose -f docker-compose.yml -f docker-compose.compat.yml
+#   compose-up-retry.sh podman-compose -f docker-compose.pglite.yml
+set -euo pipefail
+
+ATTEMPTS="${COMPOSE_UP_ATTEMPTS:-3}"
+DELAY="${COMPOSE_UP_RETRY_DELAY:-15}"
+
+if [[ "$#" -lt 1 ]]; then
+  printf 'usage: %s <compose-command> [compose-args...]\n' "$0" >&2
+  exit 2
+fi
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  if "$@" up -d --build; then
+    exit 0
+  fi
+
+  if [[ "$attempt" -eq "$ATTEMPTS" ]]; then
+    printf 'compose up failed after %s attempts\n' "$ATTEMPTS" >&2
+    exit 1
+  fi
+
+  # Tear down first: a partial stack from the failed attempt would otherwise
+  # leave the retry reusing half-created containers and volumes.
+  printf 'compose up failed (attempt %s/%s); tearing down and retrying in %ss\n' \
+    "$attempt" "$ATTEMPTS" "$DELAY" >&2
+  "$@" down -v || true
+  sleep "$DELAY"
+done


### PR DESCRIPTION
Closes #599.

Two unrelated defects surfaced by run [31961019722](https://github.com/iuliandita/digarr/actions/runs/31961019722), neither of them in the thing under test.

## 1. Nothing bounded the jobs

Neither job declared `timeout-minutes`, so GitHub's default of **360 minutes** applied. The only two in the file were step-level, on the macOS `brew install` and `colima start` steps.

The `Podman (rootless)` job hung on `Start postgres stack` and was still going at **2h 45m** when I cancelled it by hand. Successful runs of this workflow finish in 10-18 minutes, so it had roughly three more hours of runner time queued up.

Both jobs now declare their own bound: 25 minutes for Podman, 45 for the macOS path, which legitimately spends ~2.5 minutes on brew plus Colima boot before it does any real work.

## 2. Nothing retried the image pulls

The Colima job in the same run died on:

```
short read: expected 106284967 bytes but got 76728444: unexpected EOF
```

A truncated layer mid-pull. Between them the two jobs bring a stack up four times (postgres + pglite, per job), each pulling base images, with no retry -- so one bad layer anywhere killed the job.

All four now go through `scripts/ci/compose-up-retry.sh`. It takes the compose command as arguments, so one implementation covers both `docker compose` and `podman-compose`:

```yaml
run: |
  "$GITHUB_WORKSPACE/scripts/ci/compose-up-retry.sh" \
    podman-compose -f docker-compose.yml -f docker-compose.compat.yml
```

**It tears the stack down between attempts.** A retry that skipped that would inherit half-created containers and volumes from the failed attempt, which fails in a much more confusing way than the original pull error. Attempt count and delay are overridable via `COMPOSE_UP_ATTEMPTS` / `COMPOSE_UP_RETRY_DELAY` for local reproduction.

## Deliberately unchanged

- **The `deploy/docker/**` trigger.** It fires on `.env.example` edits, which looks disproportionate, but the jobs do `cp deploy/docker/.env.example deploy/docker/.env` and boot from it, so a malformed line there genuinely breaks compose. Earned coverage.
- **`continue-on-error: true` on `docker-macos`.** Working as its comment says: keeps the Intel signal visible without blocking unrelated PRs. Worth noting the label has a shelf life -- `macos-15-intel` is the last x86_64 image and GitHub retires it in Fall 2027 ([actions/runner-images#13045](https://github.com/actions/runner-images/issues/13045)).
- **The `Verify compatibility assertions ran` guard.** It is what turned "silently skipped every assertion" into a visible failure in that run, rather than a green tick over a job that tested nothing.

## Verification

- YAML parses; both jobs carry `timeout-minutes` and both retry steps resolve.
- `shellcheck` clean on the helper.
- Helper exercised locally on all three paths: success (`exit 0` on first attempt), retry-then-exhaust (`exit 1` after N attempts with teardown between), and the usage guard (`exit 2` on no arguments).
- This PR touches `.github/workflows/compatibility.yml`, which is itself in the trigger paths -- so the workflow runs against these changes here, which is the real end-to-end check.
