### PR TITLE
fix(ci): unbreak the podman compatibility job

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -24,18 +24,44 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
+      # Pinned so the next silent podman-compose release is distinguishable from
+      # a real regression.
       - name: Install podman-compose
-        run: pip install podman-compose
+        run: pip install podman-compose==1.6.0
+
+      # The runner image roll is the only input that changed when #601 started,
+      # so record what this job actually runs against.
+      - name: Report container tooling
+        run: |
+          podman --version
+          podman-compose --version
+          podman info --format 'runtime: {{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Version}}'
+          podman info --format 'network: {{.Host.NetworkBackend}}'
+          systemctl --user is-system-running || true
+          loginctl show-user "$(id -un)" --property=Linger || true
 
       - name: Prepare env
         run: |
           cp deploy/docker/.env.example deploy/docker/.env
           printf '%s\n' 'testpass123' > deploy/docker/secrets/postgres_password
 
+      # podman-compose resolves the app's `condition: service_healthy` on
+      # postgres with an unbounded wait, so bringing the stack up in one shot
+      # hangs the whole job when the healthcheck never reports. Start the
+      # dependency alone and gate on it here, where the wait is bounded and
+      # failure prints the health state (#601).
+      - name: Start postgres and wait for health
+        working-directory: deploy/docker
+        timeout-minutes: 10
+        run: |
+          podman-compose -f docker-compose.yml -f docker-compose.compat.yml up -d postgres
+          "$GITHUB_WORKSPACE/scripts/ci/wait-for-compose-health.sh" postgres
+
       # Existing Postgres install + freshly-built image (upgrade-safety test).
       # The base compose sets DB_HOST + a secret, so the app must resolve postgres.
       - name: Start postgres stack (base compose + built image)
         working-directory: deploy/docker
+        timeout-minutes: 10
         run: |
           "$GITHUB_WORKSPACE/scripts/ci/compose-up-retry.sh" \
             podman-compose -f docker-compose.yml -f docker-compose.compat.yml
@@ -60,6 +86,7 @@ jobs:
       # pglite from DB_PATH set by the pglite compose.
       - name: Start pglite stack
         working-directory: deploy/docker
+        timeout-minutes: 10
         run: |
           "$GITHUB_WORKSPACE/scripts/ci/compose-up-retry.sh" \
             podman-compose -f docker-compose.pglite.yml -f docker-compose.compat.yml
@@ -89,6 +116,10 @@ jobs:
         if: failure()
         working-directory: deploy/docker
         run: |
+          podman ps -a || true
+          podman ps -aq | while IFS= read -r container; do
+            podman inspect --format '{{.Name}} {{json .State}}' "$container" || true
+          done
           podman-compose -f docker-compose.yml -f docker-compose.compat.yml logs || true
           podman-compose -f docker-compose.pglite.yml -f docker-compose.compat.yml logs || true
 

--- a/scripts/ci/wait-for-compose-health.sh
+++ b/scripts/ci/wait-for-compose-health.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Wait for a podman-compose service container to report healthy.
+#
+# podman-compose resolves `depends_on: condition: service_healthy` with an
+# unbounded `while True` around `podman wait --condition=healthy`, so a service
+# whose healthcheck never reports hangs `up` instead of failing it -- the whole
+# job then dies at its own timeout with no logs, because a job-level timeout
+# skips the `if: failure()` diagnostics. Gating on health here bounds the wait
+# and prints the state needed to tell "the healthcheck never ran" apart from
+# "postgres is broken" (issue #601).
+#
+# Usage: wait-for-compose-health.sh <service> [timeout-seconds]
+set -euo pipefail
+
+SERVICE="${1:?usage: wait-for-compose-health.sh <service> [timeout-seconds]}"
+TIMEOUT="${2:-120}"
+
+container=""
+for _ in $(seq 1 10); do
+  container=$(podman ps -aq --filter "label=io.podman.compose.service=$SERVICE" | head -1)
+  if [[ -n "$container" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ -z "$container" ]]; then
+  printf 'no container found for compose service %s\n' "$SERVICE" >&2
+  podman ps -a >&2
+  exit 1
+fi
+
+deadline=$((SECONDS + TIMEOUT))
+status=unknown
+while ((SECONDS < deadline)); do
+  status=$(podman inspect --format '{{.State.Health.Status}}' "$container" 2>/dev/null || echo unknown)
+  case "$status" in
+    healthy)
+      printf '%s reported healthy after %ss\n' "$SERVICE" "$SECONDS"
+      exit 0
+      ;;
+    unhealthy)
+      break
+      ;;
+  esac
+  sleep 2
+done
+
+printf '%s never reported healthy within %ss (last status: %s)\n' "$SERVICE" "$TIMEOUT" "$status" >&2
+printf '=== health state ===\n' >&2
+podman inspect --format '{{json .State.Health}}' "$container" >&2 || true
+printf '\n=== container state ===\n' >&2
+podman inspect --format '{{json .State}}' "$container" >&2 || true
+printf '\n=== container logs ===\n' >&2
+podman logs --tail 100 "$container" >&2 || true
+exit 1

--- a/scripts/ci/wait-for-compose-health.sh
+++ b/scripts/ci/wait-for-compose-health.sh
@@ -5,9 +5,14 @@
 # unbounded `while True` around `podman wait --condition=healthy`, so a service
 # whose healthcheck never reports hangs `up` instead of failing it -- the whole
 # job then dies at its own timeout with no logs, because a job-level timeout
-# skips the `if: failure()` diagnostics. Gating on health here bounds the wait
-# and prints the state needed to tell "the healthcheck never ran" apart from
-# "postgres is broken" (issue #601).
+# skips the `if: failure()` diagnostics.
+#
+# Under podman 5.8.4 on the hosted runner the scheduled healthcheck never fires
+# at all: postgres logs "ready to accept connections" a second after start, yet
+# health sits at {"Status":"starting","FailingStreak":0,"Log":null} indefinitely.
+# Only the timer is broken -- running the probe by hand records a result and
+# flips the container healthy, which is also what releases podman-compose's
+# wait. So drive the probe here rather than waiting on the scheduler (#601).
 #
 # Usage: wait-for-compose-health.sh <service> [timeout-seconds]
 set -euo pipefail
@@ -32,6 +37,7 @@ fi
 
 deadline=$((SECONDS + TIMEOUT))
 status=unknown
+probe_output=""
 while ((SECONDS < deadline)); do
   status=$(podman inspect --format '{{.State.Health.Status}}' "$container" 2>/dev/null || echo unknown)
   case "$status" in
@@ -43,10 +49,14 @@ while ((SECONDS < deadline)); do
       break
       ;;
   esac
+  # Records a result even when the scheduled check never fires. A container
+  # without a healthcheck errors here, which the next inspect reports anyway.
+  probe_output=$(podman healthcheck run "$container" 2>&1) || true
   sleep 2
 done
 
 printf '%s never reported healthy within %ss (last status: %s)\n' "$SERVICE" "$TIMEOUT" "$status" >&2
+printf '=== last manual probe ===\n%s\n' "$probe_output" >&2
 printf '=== health state ===\n' >&2
 podman inspect --format '{{json .State.Health}}' "$container" >&2 || true
 printf '\n=== container state ===\n' >&2


### PR DESCRIPTION
## Root cause

Postgres was never broken. From the CI diagnostics:

```
2026-08-17 15:41:31.826 UTC [1] LOG:  database system is ready to accept connections
```

Ready one second after start -- then it sat ready for the full 120s bound while podman reported:

```json
{"Status":"starting","FailingStreak":0,"Log":null}
```

`Log: null` is the whole story: not a probe that failed, a probe that **never ran**. podman 5.8.4 on the current runner image does not fire the scheduled healthcheck at all.

podman-compose then resolves `depends_on: condition: service_healthy` with an unbounded loop (`podman_compose.py:3521`):

```python
if deps_cd:
    # podman wait will return always with a rc -1.
    while True:
        try:
            await compose.podman.output([], "wait", [f"--condition={condition.value}"] + deps_cd)
```

No timeout, no attempt cap. The `--wait-timeout` flag podman-compose exposes is wired to a different function (the `up --wait` feature at line 3730) and cannot reach this one. So the job hung instead of failing, and the job-level timeout that eventually killed it also skipped the `if: failure()` log dump -- which is why #601 had no evidence to work from.

What changed underneath: the runner image rolled `20260720.247.2` -> `20260810.271.1` between the last green run and the first hang. podman-compose was 1.6.0 in both, so the version-drift theory in #601 is ruled out. The user systemd session is healthy on the runner (`is-system-running: running`, `Linger=yes`), so the "no session" variant is ruled out too -- it is the scheduler itself.

| | Local | Runner |
| --- | --- | --- |
| podman | 6.1.0 | **5.8.4** |
| podman-compose | 1.6.0 | 1.6.0 |
| `systemctl --user` | running | running |

## Fix

Two defects, addressed separately:

| Defect | Fix |
| --- | --- |
| The unbounded wait swallowed the job and its diagnostics | Bounded health gate before the stack comes up, plus step-level `timeout-minutes` so `if: failure()` actually runs |
| The scheduler never fires the probe | Drive it with `podman healthcheck run`, which records a result, flips the container healthy, and is also what releases podman-compose's wait |

Supporting changes: pin `podman-compose==1.6.0`, report podman / OCI runtime / network backend / systemd session state, and include `podman ps -a` and per-container `.State` in the failure dump.

## Verification

CI run [32043814920](https://github.com/iuliandita/digarr/actions/runs/32043814920) on `b464b388`: **both jobs green**, Podman in **1m56s** on the same podman 5.8.4 that was hanging.

```
Report container tooling            podman version 5.8.4
Start postgres and wait for health  postgres reported healthy after 4s
Assert postgres backend             App is healthy after 2s
Assert pglite backend + restart     App is healthy after 4s
                                    App is healthy after restart (2s)
```

Recovery arc: 2m03s green (Aug 10) -> 2h45m hang -> 25min timeout kill -> 2m21s fast red with diagnostics -> 1m56s green.

Also verified locally against a real rootless podman install, using `--health-interval 0` to reproduce the runner's exact `starting`/`Log: null` state:

| Case | Before | After |
| --- | --- | --- |
| Timer disabled, service healthy | hangs forever | healthy in 4s |
| Timer disabled, probe genuinely fails | hangs forever | unhealthy, exits 1 |
| Normal stack, timer working | healthy in 6s | healthy in 6s |
| Full stack up after the gate | -- | postgres container reused, not recreated (same ID), so the unbounded wait returns immediately |
| Missing service | -- | exits 1 with `podman ps -a` |

The second row is the one that matters: this defeats the broken scheduler without weakening the assertion. A genuinely failing probe still goes unhealthy and still fails the job. `shellcheck` clean.

## Notes for review

- **The pin is now load-bearing.** `podman-compose==1.6.0` was defensive when added; the fix depends on `podman healthcheck run` mutating state the way 1.6.0's wait reads it. Worth re-checking on the next bump.
- **This is a workaround.** When the runner ships a podman whose scheduler works, the manual probe becomes redundant. Harmless there (the normal path still reports healthy in 6s, verified), so no urgency -- but it should not quietly become permanent.

Closes #601
