### PR TITLE
fix(lidarr): map the "new" monitor option to Lidarr's "future"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes are documented here.
 
 Releases that have been promoted to the `:stable` Docker channel carry a `(stable)` marker after the version heading. Promotion happens after a release has been live for at least seven days with no follow-up patch.
 
+## Unreleased
+
+### Fixed
+
+- **Approving an artist with the "New releases" monitor option now works instead of always failing.** Digarr sent its own name for the option, `new`, straight through to Lidarr, whose monitor list has no such value -- so Lidarr rejected the request outright and the recommendation landed in `add_failed` with nothing in the interface explaining why. Every other monitor option happened to be translated somewhere along the way; this one was not. It now maps to Lidarr's equivalent, `future`. The same setting is available for auto-approval, where the failure was quieter and larger: an instance configured to auto-approve with "New releases" failed on every artist it tried to add, on every scan, with no click involved. Reported in [#611](https://github.com/iuliandita/digarr/issues/611).
+
 ## v1.15.1 - 2026-08-17
 
 ### Security

--- a/src/core/clients/lidarr.ts
+++ b/src/core/clients/lidarr.ts
@@ -69,6 +69,16 @@ export type AddArtistOptions = {
   monitorOption?: 'all' | 'new' | 'none'
 }
 
+// digarr's monitor vocabulary is not Lidarr's. MonitorTypes has no `new`
+// member, so forwarding it verbatim fails JSON deserialization with a 400
+// before validation even runs (#611). Keep every digarr value mapped here --
+// the `satisfies` makes a new one a compile error rather than a runtime 400.
+export const LIDARR_MONITOR_TYPES = {
+  all: 'all',
+  new: 'future',
+  none: 'none',
+} as const satisfies Record<NonNullable<AddArtistOptions['monitorOption']>, string>
+
 // Lidarr's /api/v1/artist has no pagination, so a large library arrives as one
 // oversized response (7100 artists is ~54MB / ~83s). The 10s client default
 // cannot cover that; this is the budget for that one call.
@@ -214,7 +224,7 @@ export function createLidarrClient(
       throw new Error(`Root folder with id ${rootFolderId} not found`)
     }
 
-    const monitor = options?.monitorOption ?? 'none'
+    const monitorOption = options?.monitorOption ?? 'none'
 
     return http.post<LidarrArtist>('/api/v1/artist', {
       foreignArtistId,
@@ -224,8 +234,10 @@ export function createLidarrClient(
       rootFolderPath: folder.path,
       monitored: true,
       addOptions: {
-        monitor,
-        searchForMissingAlbums: monitor === 'all',
+        monitor: LIDARR_MONITOR_TYPES[monitorOption],
+        // Derived from digarr's value, not the mapped one, so a future value
+        // that maps onto `all` does not silently inherit the search.
+        searchForMissingAlbums: monitorOption === 'all',
       },
     })
   }

--- a/tests/core/clients/lidarr.test.ts
+++ b/tests/core/clients/lidarr.test.ts
@@ -8,7 +8,8 @@ import type {
   QualityProfile,
   RootFolder,
 } from '@/core/clients/lidarr'
-import { createLidarrClient } from '@/core/clients/lidarr'
+import { createLidarrClient, LIDARR_MONITOR_TYPES } from '@/core/clients/lidarr'
+import { monitorOptionSchema } from '@/server/schemas/recommendations'
 
 // Mock the HTTP client module so we never hit a real server.
 const mockGet = vi.fn()
@@ -289,7 +290,9 @@ describe('createLidarrClient', () => {
       )
     })
 
-    it('uses monitorOption:"new" and sets searchForMissingAlbums:false', async () => {
+    // Lidarr's MonitorTypes enum has no `new`; the equivalent is `future`.
+    // Sending `new` fails deserialization with a 400 (#611).
+    it('maps monitorOption:"new" to Lidarr "future" and sets searchForMissingAlbums:false', async () => {
       mockLidarrGets()
       mockPost.mockResolvedValueOnce({ ...mockArtists[0], id: 13 })
 
@@ -300,7 +303,7 @@ describe('createLidarrClient', () => {
       expect(mockPost).toHaveBeenCalledWith(
         '/api/v1/artist',
         expect.objectContaining({
-          addOptions: { monitor: 'new', searchForMissingAlbums: false },
+          addOptions: { monitor: 'future', searchForMissingAlbums: false },
         }),
       )
     })
@@ -693,5 +696,41 @@ describe('createLidarrClient', () => {
       expect(result).toHaveProperty('success')
       expect(result).toHaveProperty('message')
     })
+  })
+})
+
+// digarr's monitor vocabulary and Lidarr's MonitorTypes enum drifted apart once
+// already (#611): `new` was forwarded verbatim and rejected with a 400. Mocks
+// cannot catch that -- they accept any string -- so pin both ends here.
+describe('monitor vocabulary', () => {
+  // NzbDrone.Core.Music.MonitorTypes, lowercased as the API serializes it.
+  // Source: src/NzbDrone.Core/Music/Model/MonitorTypes.cs
+  const LIDARR_MONITOR_TYPE_MEMBERS = [
+    'all',
+    'future',
+    'missing',
+    'existing',
+    'latest',
+    'first',
+    'none',
+    'unknown',
+  ]
+
+  it('maps every digarr monitor option onto a real Lidarr MonitorTypes member', () => {
+    for (const target of Object.values(LIDARR_MONITOR_TYPES)) {
+      expect(LIDARR_MONITOR_TYPE_MEMBERS).toContain(target)
+    }
+  })
+
+  it('handles every monitorOptionSchema value somewhere in the chain', () => {
+    // `selected` collapses to `none` in the Lidarr target and `popular` becomes
+    // `selected` in the approve route, so neither reaches the client. Every
+    // other value must have a mapping here.
+    const TRANSLATED_UPSTREAM = ['selected', 'popular']
+    const handled = [...Object.keys(LIDARR_MONITOR_TYPES), ...TRANSLATED_UPSTREAM]
+
+    for (const option of monitorOptionSchema.options) {
+      expect(handled).toContain(option)
+    }
   })
 })


### PR DESCRIPTION
Approving an artist with the **New releases** monitor option always failed with HTTP 400. The artist was never created, the recommendation landed in `add_failed`, and nothing in the UI explained why.

`monitorOptionSchema` allows `all, new, none, selected, popular`. Lidarr's enum is a different vocabulary that happens to overlap on two members:

```csharp
public enum MonitorTypes
{ All, Future, Missing, Existing, Latest, First, None, Unknown }
```

No `New`. Lidarr rejected the value in its JSON deserializer, before validation ran:

```
"$.addOptions.monitor": ["The JSON value could not be converted to
 NzbDrone.Core.Music.MonitorTypes."]
```

## Why it survived this long

Four of the five schema values were already translated -- but at three different layers:

| Value | Translated | Where |
|---|---|---|
| `popular` | -> `selected` | `routes/recommendations.ts:488` |
| `selected` | -> `none` | `targets/lidarr.ts:56` |
| `all`, `none` | valid as-is | -- |
| `new` | **never** | reached `clients/lidarr.ts:227` verbatim |

No single layer owned the boundary, so the one value needing translation had nowhere to be translated. TypeScript could not help: `monitorOption?: 'all' | 'new' | 'none'` sits on the function that speaks Lidarr's protocol but is typed in digarr's vocabulary, so both sides type-checked fine.

And `tests/core/clients/lidarr.test.ts:292` asserted `monitor: 'new'` -- the mock accepts any string, so the test pinned the defect in place rather than catching it.

## Two reach paths

The report covers manual approve (`approve-dialog.tsx:99`). The quieter one is auto-approval: `autoApproveMonitorOption` (`schemas/settings.ts:72`) also accepts `new`, and feeds `orchestrator.ts:562`. An instance set to auto-approve with "New releases" fails on **every artist, every scan**, with no one clicking anything.

## Fix

Map at the client, where both target paths converge:

```ts
export const LIDARR_MONITOR_TYPES = {
  all: 'all',
  new: 'future',
  none: 'none',
} as const satisfies Record<NonNullable<AddArtistOptions['monitorOption']>, string>
```

The `satisfies` is the real guard -- a sixth schema value becomes a compile error instead of a runtime 400. `searchForMissingAlbums` stays derived from digarr's value rather than the mapped one, so a future value mapping onto `all` cannot silently inherit the search.

## Tests

- The test that asserted the bug now expects `future`.
- Every `LIDARR_MONITOR_TYPES` target must be a real `MonitorTypes` member (list sourced from `MonitorTypes.cs`).
- Every `monitorOptionSchema` value must be handled -- mapped here, or documented as translated upstream.

Both guards were verified to fail when the bug is reintroduced (`new: 'new'` -> 2 failures), so they are not vacuous.

## Verification

- `bun run lint` clean, `bun run typecheck` clean
- `bun run test` -- 3359 passed, 13 skipped
- Enum confirmed against upstream `Lidarr/Lidarr@develop`, not taken from the report

## Note

Not reproduced against a live Lidarr -- no instance in this environment. The enum is confirmed from source and the reporter verified `future` against Lidarr 2.14.x.

Closes #611
