### PR TITLE
fix(web): clear query cache when the session changes

### DIFF
--- a/src/web/components/auth-gate.tsx
+++ b/src/web/components/auth-gate.tsx
@@ -11,6 +11,7 @@ import {
   registerUser,
 } from '../lib/api'
 import { useI18n } from '../lib/i18n'
+import { clearQueryCache } from '../lib/query-client'
 import { LanguageSwitcher } from './language-switcher'
 import { Button } from './ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
@@ -179,6 +180,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   // Listen for 401s from fetchApi and return to login
   useEffect(() => {
     const handler = () => {
+      clearQueryCache()
       setNotice(null)
       setState(hasUsers ? 'login' : 'register')
     }
@@ -187,6 +189,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   }, [hasUsers])
 
   async function handleAuthenticated(fallback: 'login' | 'register') {
+    clearQueryCache()
     setNotice(null)
     clearLegacyMigrationState()
     try {

--- a/src/web/lib/query-client.ts
+++ b/src/web/lib/query-client.ts
@@ -9,3 +9,7 @@ export const queryClient = new QueryClient({
     },
   },
 })
+
+export function clearQueryCache() {
+  queryClient.clear()
+}

--- a/tests/web/components/auth-gate.test.tsx
+++ b/tests/web/components/auth-gate.test.tsx
@@ -5,6 +5,7 @@ import { StrictMode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthGate } from '@/web/components/auth-gate'
 import { I18nProvider } from '@/web/lib/i18n'
+import { queryClient } from '@/web/lib/query-client'
 
 vi.mock('@/web/lib/locale-storage', () => ({
   detectBrowserLocale: vi.fn(() => 'en'),
@@ -88,6 +89,7 @@ describe('AuthGate', () => {
     window.sessionStorage.clear()
     window.history.replaceState({}, '', '/')
     vi.clearAllMocks()
+    queryClient.clear()
     apiMocks.getAuthStatus.mockResolvedValue(unauthenticatedStatus)
     apiMocks.getLegacyStoredToken.mockReturnValue(null)
     apiMocks.loginUser.mockResolvedValue({
@@ -483,5 +485,32 @@ describe('AuthGate', () => {
 
     expect(await screen.findByRole('button', { name: 'Sign in' })).toBeInTheDocument()
     expect(screen.queryByText('secret area')).not.toBeInTheDocument()
+  })
+
+  it('drops cached account data when the session expires', async () => {
+    apiMocks.getAuthStatus.mockResolvedValue(authenticatedStatus)
+    renderGate()
+    await screen.findByText('secret area')
+
+    queryClient.setQueryData(['settings'], { userId: 1 })
+    act(() => window.dispatchEvent(new Event('digarr:auth-expired')))
+
+    await screen.findByRole('button', { name: 'Sign in' })
+    expect(queryClient.getQueryData(['settings'])).toBeUndefined()
+  })
+
+  it('drops cached account data before mounting a fresh login', async () => {
+    apiMocks.getAuthStatus
+      .mockResolvedValueOnce(unauthenticatedStatus)
+      .mockResolvedValueOnce(authenticatedStatus)
+    renderGate()
+    await screen.findByRole('button', { name: 'Sign in' })
+
+    queryClient.setQueryData(['settings'], { userId: 1 })
+
+    await submitLogin()
+
+    await screen.findByText('secret area')
+    expect(queryClient.getQueryData(['settings'])).toBeUndefined()
   })
 })


### PR DESCRIPTION
After logout, a different account saw the previous user's settings until a refresh. The query cache is a module-level singleton and never got cleared, so the new session read the old entries.

Clears it on logout/401 and after login, with a regression test for each.

Fixes #634