### PR TITLE
refactor(core): centralize the connected-token predicate

### DIFF
--- a/src/core/provider-auth.ts
+++ b/src/core/provider-auth.ts
@@ -47,6 +47,16 @@ export function providerLabel(provider: OAuthProvider): string {
 }
 
 /**
+ * Whether a stored token represents a live connection. The legacy `pending:`
+ * marker is no longer written (migration 0047); the guard covers a downgrade.
+ */
+export function isConnectedToken(
+  row: { accessToken: string } | undefined | null,
+): row is { accessToken: string } {
+  return row != null && !row.accessToken.startsWith('pending:')
+}
+
+/**
  * Resolve a usable access token for a provider connection.
  * Refreshes when the provider supports it and stored credentials allow it,
  * otherwise returns the stored token.
@@ -58,7 +68,7 @@ export async function resolveProviderToken(
 ): Promise<string> {
   const spec = PROVIDER_AUTH[provider]
   const row = await getOAuthToken(db, userId, provider)
-  if (!row || row.accessToken.startsWith('pending:')) {
+  if (!isConnectedToken(row)) {
     throw new ProviderAuthError(
       provider,
       'not_connected',

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ import { createDiscogsSource } from './core/plugins/discogs'
 import { createLastFmSource } from './core/plugins/lastfm'
 import { createListenBrainzSource } from './core/plugins/listenbrainz'
 import { SourceRegistry } from './core/plugins/registry'
-import { resolveProviderToken } from './core/provider-auth'
+import { isConnectedToken, resolveProviderToken } from './core/provider-auth'
 import { createDefaultRegistry } from './core/providers/registry'
 import { buildSearchSourceCatalog } from './core/search/catalog'
 import { enrichSearchResultsWithImages } from './core/search/enrich'
@@ -267,14 +267,12 @@ async function getDiscoveryConnectionSnapshot(userId: number) {
     hasListenBrainz: Boolean(
       userConnections?.listenbrainzUsername && userConnections.listenbrainzToken,
     ),
-    hasSpotify: Boolean(
-      spotifyToken?.accessToken && !spotifyToken.accessToken.startsWith('pending:'),
-    ),
+    hasSpotify: isConnectedToken(spotifyToken),
     spotifyScopes: spotifyToken?.scopes?.split(' ').filter(Boolean) ?? [],
     hasLastfm: Boolean(userConnections?.lastfmUsername && userConnections.lastfmApiKey),
     hasDiscogs: Boolean(userConnections?.discogsUsername && userConnections.discogsToken),
-    hasDeezer: Boolean(deezerToken?.accessToken && !deezerToken.accessToken.startsWith('pending:')),
-    hasTidal: Boolean(tidalToken?.accessToken && !tidalToken.accessToken.startsWith('pending:')),
+    hasDeezer: isConnectedToken(deezerToken),
+    hasTidal: isConnectedToken(tidalToken),
     hasLibrarySync,
     hasSubsonic: Boolean(
       userConnections?.subsonicUrl &&
@@ -904,7 +902,7 @@ async function executeSubscription(subscriptionId: number): Promise<void> {
     // Deezer adapter - only if the user has a stored OAuth token
     if (userId !== null && userId !== undefined) {
       const deezerOAuthRow = await getOAuthToken(db, userId, 'deezer')
-      if (deezerOAuthRow && !deezerOAuthRow.accessToken.startsWith('pending:')) {
+      if (isConnectedToken(deezerOAuthRow)) {
         const getToken = () => resolveProviderToken(db, userId, 'deezer')
         adapterRegistry.register(createDeezerAdapter({ getToken }))
       }

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -12,6 +12,7 @@ import {
 } from '@/core/crypto'
 import { dispatch } from '@/core/notifications'
 import type { NotificationChannel, NotificationEvent } from '@/core/notifications/types'
+import { isConnectedToken } from '@/core/provider-auth'
 import { redactSecrets } from '@/core/providers/retry'
 import { validateAiBaseUrl } from '@/core/url-safety'
 import { getUserConnections, updateUserConnections } from '@/db/queries/users'
@@ -636,7 +637,7 @@ export function settingsRoutes(deps: AppDependencies) {
         if (!spotifyUserId) return missingInput('Login required')
         const { getOAuthToken } = await import('@/db/queries/oauth-tokens')
         const oauthToken = await getOAuthToken(deps.db, spotifyUserId, 'spotify')
-        if (!oauthToken || oauthToken.accessToken.startsWith('pending:')) {
+        if (!isConnectedToken(oauthToken)) {
           return missingInput('Spotify not connected')
         }
         const { createSpotifyClient } = await import('@/core/clients/spotify')

--- a/src/server/routes/subscriptions.ts
+++ b/src/server/routes/subscriptions.ts
@@ -6,7 +6,7 @@ import {
   evaluateDiscoveryModeAvailability,
 } from '@/core/discovery-modes/availability'
 import type { DiscoveryModeRegistry } from '@/core/discovery-modes/registry'
-import { resolveProviderToken } from '@/core/provider-auth'
+import { isConnectedToken, resolveProviderToken } from '@/core/provider-auth'
 import { DISCOVERY_MODE_SUBSCRIPTION_TYPE } from '@/core/subscriptions/registry'
 import { errMsg } from '@/core/validation'
 import { getOAuthToken } from '@/db/queries/oauth-tokens'
@@ -352,7 +352,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
     }
 
     const spotifyToken = await getOAuthToken(deps.db, userId, 'spotify')
-    if (!spotifyToken || spotifyToken.accessToken.startsWith('pending:')) {
+    if (!isConnectedToken(spotifyToken)) {
       return c.json({ error: messages['subscriptions.spotifyNotConnected'] }, 400)
     }
 
@@ -454,7 +454,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
       const { playlistId: rawId } = c.req.valid('json')
 
       const spotifyToken = await getOAuthToken(deps.db, userId, 'spotify')
-      if (!spotifyToken || spotifyToken.accessToken.startsWith('pending:')) {
+      if (!isConnectedToken(spotifyToken)) {
         return c.json({ error: 'Spotify is not connected' }, 400)
       }
 
@@ -505,7 +505,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
     }
 
     const deezerToken = await getOAuthToken(deps.db, userId, 'deezer')
-    if (!deezerToken || deezerToken.accessToken.startsWith('pending:')) {
+    if (!isConnectedToken(deezerToken)) {
       return c.json({ error: 'Deezer is not connected' }, 400)
     }
 
@@ -552,7 +552,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
     }
 
     const deezerToken = await getOAuthToken(deps.db, userId, 'deezer')
-    if (!deezerToken || deezerToken.accessToken.startsWith('pending:')) {
+    if (!isConnectedToken(deezerToken)) {
       return c.json({ error: 'Deezer is not connected' }, 400)
     }
 
@@ -620,7 +620,7 @@ export function subscriptionRoutes(deps: AppDependencies) {
       }
 
       const deezerToken = await getOAuthToken(deps.db, userId, 'deezer')
-      if (!deezerToken || deezerToken.accessToken.startsWith('pending:')) {
+      if (!isConnectedToken(deezerToken)) {
         return c.json({ error: 'Deezer is not connected' }, 400)
       }
 

--- a/tests/core/provider-auth.test.ts
+++ b/tests/core/provider-auth.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/core/oauth', () => ({ getValidToken: vi.fn() }))
 
 const { getOAuthToken } = await import('@/db/queries/oauth-tokens')
 const { getValidToken } = await import('@/core/oauth')
-const { ProviderAuthError, providerLabel, resolveProviderToken } = await import(
+const { ProviderAuthError, isConnectedToken, providerLabel, resolveProviderToken } = await import(
   '@/core/provider-auth'
 )
 
@@ -43,6 +43,20 @@ describe('providerLabel', () => {
     ['tidal', 'TIDAL'],
   ] as const)('names %s as %s', (provider, label) => {
     expect(providerLabel(provider)).toBe(label)
+  })
+})
+
+describe('isConnectedToken', () => {
+  it('treats a stored token as connected', () => {
+    expect(isConnectedToken({ accessToken: 'valid-token' })).toBe(true)
+  })
+
+  it('treats a legacy pending marker as disconnected', () => {
+    expect(isConnectedToken({ accessToken: 'pending:1:abc' })).toBe(false)
+  })
+
+  it.each([undefined, null])('treats %s as disconnected', (value) => {
+    expect(isConnectedToken(value)).toBe(false)
   })
 })
 

--- a/tests/server/routes/subscriptions.test.ts
+++ b/tests/server/routes/subscriptions.test.ts
@@ -453,6 +453,18 @@ describe('POST /api/v1/subscriptions/import/spotify-liked-songs', () => {
     expect(mockSubQueries.createSubscription).not.toHaveBeenCalled()
   })
 
+  it('returns 400 when the stored Spotify token is a legacy pending marker', async () => {
+    mockGetOAuthToken.mockResolvedValueOnce({ accessToken: 'pending:1:abc' })
+    const app = createTestApp(makeDeps(), USER_ID)
+
+    const res = await app.request('/api/v1/subscriptions/import/spotify-liked-songs', {
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(400)
+    expect(mockSubQueries.createSubscription).not.toHaveBeenCalled()
+  })
+
   it('localizes spotify import errors', async () => {
     mockGetOAuthToken.mockResolvedValueOnce(null)
     const app = createTestApp(makeDeps(), USER_ID)


### PR DESCRIPTION
Closes #603.

The "is this provider connected" check was duplicated at ten sites as `!row || row.accessToken.startsWith('pending:')` (or its inverted form). It now lives in one `isConnectedToken` helper beside `PROVIDER_AUTH`, so retiring the legacy `pending:` marker is a one-file change.

No behavior change at any call site, including the `hasSpotify`/`hasDeezer`/`hasTidal` booleans -- the helper returns a boolean. Added unit tests for the predicate and a subscription test for the pending-marker path that had no direct coverage before.